### PR TITLE
feat(group-buy): add request/response DTOs for product management (#9)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
-group = 'com.moogsan'
+group = 'com.moongsan'
 version = '0.0.1-SNAPSHOT'
 
 java {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
@@ -1,0 +1,66 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateGroupBuyRequest {
+
+    @NotBlank(message="제목은 필수 입력 항목입니다.")
+    @Size(min = 1, max = 30, message = "제목은 1자 이상, 30자 이하로 입력해주세요.")
+    private String title;
+
+    @NotBlank(message="상품명은 필수 입력 항목입니다.")
+    @Size(min = 1, max = 30, message = "상품명은 1자 이상, 30자 이하로 입력해주세요.")
+    private String name;
+
+    @Size(min = 1, max = 2000, message = "URL은 1자 이상, 2000자 이하로 입력해주세요.")
+    @URL(message="URL 형식이 올바르지 않습니다.")
+    private String url;
+
+    @NotBlank(message="상품 가격은 필수 입력 항목입니다.")
+    @Size(min = 1, message = "상품 가격은 1 이상이어야 합니다.")
+    private int price;
+
+    @NotBlank(message="상품 전체 수량은 필수 입력 항목입니다.")
+    @Size(min = 1, message = "상품 전체 수량은 1 이상이어야 합니다.")
+    private int totalAmount;
+
+    @NotBlank(message="상품 주문 단위는 필수 입력 항목입니다.")
+    @Size(min = 1, message = "상품 주문 단위는 1 이상이어야 합니다.")
+    private int unitAmount;
+
+    @NotBlank(message="상품 상세 설명은 필수 입력 항목입니다.")
+    @Size(min = 2, max = 2000, message = "상품 설명은 2자 이상, 1000자 이하로 입력해주세요.")
+    private String description;
+
+    @NotBlank(message="마감 일자는 필수 입력 항목입니다.")
+    @Future(message="마감일자는 현재 시간 이후여야 합니다.")
+    @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm")
+    private String dueDate;
+
+    @NotBlank(message="거래 장소는 필수 입력 항목입니다.")
+    private String location;
+
+    @NotBlank(message="픽업 일자는 필수 입력 항목입니다.")
+    @Future(message="픽업 일자는 현재 시간 이후여야 합니다.")
+    @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm")
+    private String pickupDate;
+
+    @NotEmpty(message="상품 이미지는 최소 1개 이상 등록해야 합니다.")
+    private List<String> imageUrls;
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
@@ -1,0 +1,46 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateGroupBuyRequest {
+
+    @Size(min = 1, max = 30, message = "제목은 1자 이상, 30자 이하로 입력해주세요.")
+    private String title;
+
+    @Size(min = 1, max = 30, message = "상품명은 1자 이상, 30자 이하로 입력해주세요.")
+    private String name;
+
+    @Size(min = 1, max = 2000, message = "URL은 1자 이상, 2000자 이하로 입력해주세요.")
+    @URL(message="URL 형식이 올바르지 않습니다.")
+    private String url;
+
+    @Size(min = 2, max = 2000, message = "상품 설명은 2자 이상, 1000자 이하로 입력해주세요.")
+    private String description;
+
+    @Future(message="마감일자는 현재 시간 이후여야 합니다.")
+    @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm")
+    private String dueDate;
+
+    @Future(message="픽업 일자는 현재 시간 이후여야 합니다.")
+    @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm")
+    private String pickupDate;
+
+    @Size(min = 2, max = 85, message = "픽업 일자 변경 사유는 2자 이상, 85자 이하로 입력해주세요.")
+    private String dateModificationReason;
+
+    private List<String> imageUrls;
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/request/SearchGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/request/SearchGroupBuyRequest.java
@@ -1,0 +1,18 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SearchGroupBuyRequest {
+    @NotBlank(message="검색 키워드는 필수 입력 항목입니다.")
+    @Size(min = 1, max = 30, message = "검색 키워드는 1자 이상, 30자 이하로 입력해주세요.")
+    private String keyword;
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/ImageResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/ImageResponse.java
@@ -1,0 +1,21 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ImageResponse {
+
+    // 식별/메타
+    private int imageSeqNo;     // 이미지 순서
+
+    // 본문
+    private String imageUrl;    // 이미지 URL(리사이즈된 버전 URL)
+
+    // 상태/플래그
+    private boolean thumbnail;  // 썸네일 여부
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/DetailResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/DetailResponse.java
@@ -1,0 +1,42 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyDetail;
+
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.ImageResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class DetailResponse {
+
+    // 식별/메타
+    private String postId;                  // 공구 게시글 아이디
+    private String title;                   // 공구 게시글 제목
+    private String name;                    // 공구 상품명
+    private String postStatus;              // 공구 진행 상태
+
+    // 본문
+    private String description;             // 상품 상세 설명
+    private String url;                     // 상품 URL
+    private List<ImageResponse> imageUrls;  // 상품 이미지 목록
+
+    // 숫자 데이터
+    private int unitPrice;                  // 상품 단위 당 가격
+    private int unitAmount;                 // 상품 주문 단위
+    private int soldAmount;                 // 판매 수량
+    private int totalAmount;                // 전체 수량
+    private int participantCount;           // 참여 인원 수
+
+    // 상태/플래그
+    private boolean dueSoon;                // 마감 임박 여부
+    private boolean isWish;                 // 관심 여부
+    private boolean isParticipant;          // 참여 여부
+
+    // 날짜
+    private LocalDateTime createdAt;       // 공구글 생성 시각
+
+    // 연관 객체
+    private UserProfileResponse userProfileResponse;    // 주최자 정보
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/UserProfileResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/UserProfileResponse.java
@@ -1,0 +1,18 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyDetail;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserProfileResponse {
+
+    // 식별/메타
+    private String authorId;       // 작성자 아이디
+    private String nickName;       // 닉네임
+
+    // 본문
+    private String accountNumber;  // 계좌 번호
+    private String imageUrl;       // 프로필 이미지
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/BasicList/BasicListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/BasicList/BasicListResponse.java
@@ -1,0 +1,37 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.BasicList;
+
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.ImageResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class BasicListResponse {
+
+    // 식별/메타
+    private String postId;           // 공구 게시글 아이디
+    private String title;            // 공구 게시글 제목
+    private String name;             // 상품명
+    private String postStatus;       // 공구 진행 상태(OPEN, CLOSED, ENDED)
+
+    // 본문
+    private List<ImageResponse> imageUrls;  // 상품 이미지 목록
+
+    // 숫자 데이터
+    private int unitPrice;           // 주문 단위 가격
+    private int unitAmount;          // 주문 단위 수량
+    private int soldAmount;          // 판매 수량(totalAmount - leftAmount)
+    private int totalAmount;         // 전체 상품 수량
+    private int participantCount;    // 참여 인원 수
+
+    // 상태/플래그
+    private boolean dueSoon;         // 마감 임박 여부
+    private boolean isWish;          // 관심 여부
+
+    // 날짜
+    private LocalDateTime createdAt; // 생성 일시
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/HostedList/HostedListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/HostedList/HostedListResponse.java
@@ -1,0 +1,33 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.HostedList;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class HostedListResponse {
+
+    // 식별/메타
+    private String postId;         // 공구 게시글 아이디
+    private String title;          // 공구 게시글 제목
+    private String postStatus;     // 공구 진행 상태(OPEN, CLOSED, ENDED)
+
+    // 본문
+    private String location;       // 거래 장소
+    private String imageUrl;       // thumbnail 이미지
+
+    // 숫자 데이터
+    private int price;             // 총 상품 가격
+    private int orderQuantity;     // 주문 개수(주최자)
+    private int soldAmount;        // 판매 수량(totalAmount - leftAmount)
+    private int totalAmount;       // 상품 전체 수량
+    private int participantCount;  // 참여 인원 수
+
+    // 상태/플래그
+    private boolean dueSoon;       // 마감 임박 여부
+    private boolean isWish;        // 관심 여부
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/PagedResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/PagedResponse.java
@@ -1,0 +1,18 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PagedResponse<T> {
+
+    private long totalCount;     // 공구 게시글 개수
+    private List<T> posts;       // 공구 게시글 리스트
+
+    private Integer nextCursor;  // 현재 응답의 마지막 postId. null 여부를 표현하기 위해 Integer 사용
+    private boolean hasNext;     // 다음 페이지 존재 여부
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipantList/ParticipantListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipantList/ParticipantListResponse.java
@@ -1,0 +1,14 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipantList;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ParticipantListResponse {
+
+    private List<ParticipantResponse> participants; // 참여자 리스트
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipantList/ParticipantResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipantList/ParticipantResponse.java
@@ -1,0 +1,26 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipantList;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ParticipantResponse {
+
+    // 식별/메타
+    private String participantId;  // 참여자 아이디
+    private String nickname;       // 참여자 닉네임
+    private String orderName;      // 입금자명
+
+    // 본문
+    private String phoneNumber;    // 전화번호
+    private String imageUrl;       // 프로필 이미지
+
+
+    // 숫자 데이터
+    private int orderQuantity;     // 주문 개수
+
+    // 상태/플래그
+    private String orderStatus;    // 주문 상태(PAID, CONFIRMED)
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipatedList/ParticipatedListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipatedList/ParticipatedListResponse.java
@@ -1,0 +1,31 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipatedList;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ParticipatedListResponse {
+
+    // 식별/메타
+    private String postId;         // 공구 게시글 아이디
+    private String title;          // 공구 게시글 제목
+    private String postStatus;     // 공구 진행 상태(OPEN, CLOSED, ENDED)
+
+    // 본문
+    private String location;       // 거래 장소
+    private String imageUrl;       // thumbnail 이미지
+
+    // 숫자 데이터
+    private int price;             // 총 상품 가격
+    private int orderQuantity;     // 주문 개수(참여자)
+    private int soldAmount;        // 판매 수량(totalAmount - leftAmount)
+    private int totalAmount;       // 상품 전체 수량
+    private int participantCount;  // 참여 인원 수
+
+    // 상태/플래그
+    private String orderStatus;    // 주문 상태: PENDING(입금 전), PAID(입금 됨, 입금 확인 전), CONFIRMED(입금 확인), CANCELED(취소)
+    private boolean dueSoon;       // 마감 임박 여부
+    private boolean isWish;        // 관심 여부
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/wishList/WishListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/wishList/WishListResponse.java
@@ -1,0 +1,29 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.wishList;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WishListResponse {
+
+    // 식별/메타
+    private String postId;         // 공구 게시글 아이디
+    private String title;          // 공구 게시글 제목
+    private String postStatus;     // 공구 진행 상태
+
+    // 본문
+    private String location;       // 거래 장소
+    private String imageUrl;       // thumbnail 이미지
+
+    // 숫자 데이터
+    private int price;             // 총 상품 가격
+    private int soldAmount;        // 판매 수량
+    private int totalAmount;       // 상품 주문 수량: totalAmount - leftAmount
+    private int participantCount;  // 참여 인원 수
+
+    // 상태/플래그
+    private boolean dueSoon;       // 마감 임박 여부
+    private boolean isWish;        // 관심 여부
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyUpdate/GroupBuyForUpdateResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyUpdate/GroupBuyForUpdateResponse.java
@@ -1,0 +1,30 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyUpdate;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+import java.util.List;
+
+@Getter
+@Builder
+public class GroupBuyForUpdateResponse {
+
+    // 식별/메타
+    private String title;           // 공구 게시글 제목
+    private String name;            // 상품명
+
+    // 본문
+    private String description;     // 공구 상세 설명
+    private String url;             // 상품 URL
+    private List<String> imageUrls; // 이미지 URL 리스트
+    private String dueDate;         // 마감 일자
+    private String location;        // 거래 장소
+    private String pickupDate;      // 픽업 예정 일자
+
+    // 숫자 데이터
+    private int price;              // 상품 총 가격
+    private int unitAmount;         // 상품 주문 단위 수량
+    private int totalAmount;        // 전체 상품 수량
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/main/GroupBuySummaryResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/main/GroupBuySummaryResponse.java
@@ -1,0 +1,27 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.main;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GroupBuySummaryResponse {
+
+    // 식별/메타
+    private Long postId;        // 공구 게시글 아이디
+    private String title;       // 제목
+    private String postStatus;  // 공구 진행 상태
+
+    // 본문
+    private String imageUrl;    // thumbnail 이미지
+
+    // 숫자 데이터
+    private int unitPrice;      // 단위 당 가격
+    private int unitAmount;     // 상품 주문 단위
+    private int soldAmount;     // 판매 수량: totalAmount - leftAmount
+    private int totalAmount;    // 상품 전체 수량
+
+    // 상태/플래그
+    private boolean isWish;     // 관심 여부
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/main/MainPageResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/main/MainPageResponse.java
@@ -1,0 +1,14 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.main;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MainPageResponse {
+
+    private List<SectionResponse> boards;
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/main/SectionResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/main/SectionResponse.java
@@ -1,0 +1,16 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.main;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SectionResponse {
+
+    private String code;        // endSoon, latest, moongsanPick
+    private String category;    // 마감 임박!!, 전체, 뭉산 PICK 핫 공구
+
+    private List<GroupBuySummaryResponse> posts;
+}

--- a/src/main/java/com/moogsan/moongsan_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,4 @@
+package com.moogsan.moongsan_backend.global.exception;
+
+public class GlobalExceptionHandler {
+}


### PR DESCRIPTION
## 🔎 작업 개요
CQRS 기반의 DTO 영역 분리, 각 Request, Response Dto 작성

## 🛠️ 주요 변경 사항
- domain/groupbuy/dto 하위 command, query 디렉토리 생성, 각각 request, response 하위 디렉토리 생성
- 공통 PagedResponse 분리, 제네릭 자료형으로 재사용
- 공통 ImageResponse 분리, BasicList, DetailResponse에서 재사용
- ERD 컬럼명, 코멘트 기반 주석 추가
- build.gradle에서 group명 moogsan에서 moongsan으로 변경

## ✅ 검증 방법
-

## 🔍 머지 전 확인사항  
-

## ➕ 이슈 링크
- [[Sprint #3] BE - 공동구매 상품 관리 기능 개발](https://github.com/100-hours-a-week/14-YG-BE/issues/9)
