### PR TITLE
feat/fix(user): 토큰 쿠키로 전달, 토큰 재발행

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/controller/UserController.java
@@ -11,8 +11,11 @@ import com.moogsan.moongsan_backend.domain.user.service.LogoutService;
 import com.moogsan.moongsan_backend.domain.user.service.SignUpService;
 import com.moogsan.moongsan_backend.domain.user.service.UserProfileService;
 import com.moogsan.moongsan_backend.domain.user.service.WithdrawService;
+import com.moogsan.moongsan_backend.domain.user.service.TokenRefreshService;
 import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
 import com.moogsan.moongsan_backend.domain.WrapperResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,25 +34,28 @@ public class UserController {
     private final CheckNicknameService nicknameService;
     private final LogoutService logoutService;
     private final WithdrawService withdrawService;
+    private final TokenRefreshService tokenRefreshService;
 
     @PostMapping("/users")
-    public ResponseEntity<WrapperResponse<LoginResponse>> signUp(@Valid @RequestBody SignUpRequest request) {
-        LoginResponse response = signUpService.signUp(request);
+    public ResponseEntity<WrapperResponse<LoginResponse>> signUp(@Valid @RequestBody SignUpRequest request,
+                                                                 HttpServletResponse response) {
+        LoginResponse loginResponse = signUpService.signUp(request, response);
         return ResponseEntity.ok(
             WrapperResponse.<LoginResponse>builder()
                 .message("회원가입이 완료되었습니다.")
-                .data(response)
+                .data(loginResponse)
                 .build()
         );
     }
 
     @PostMapping("/users/token")
-    public ResponseEntity<WrapperResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest loginRequest) {
-        LoginResponse response = loginService.login(loginRequest);
+    public ResponseEntity<WrapperResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest loginRequest,
+                                                                jakarta.servlet.http.HttpServletResponse response) {
+        LoginResponse loginResponse = loginService.login(loginRequest, response);
         return ResponseEntity.ok(
             WrapperResponse.<LoginResponse>builder()
                 .message("로그인이 완료되었습니다.")
-                .data(response)
+                .data(loginResponse)
                 .build()
         );
     }
@@ -104,6 +110,17 @@ public class UserController {
         return ResponseEntity.ok(
                 WrapperResponse.<Void>builder()
                         .message("회원탈퇴가 완료되었습니다.")
+                        .data(null)
+                        .build()
+        );
+    }
+
+    @PostMapping("/users/token/refresh")
+    public ResponseEntity<WrapperResponse<Void>> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        tokenRefreshService.refreshAccessToken(request, response);
+        return ResponseEntity.ok(
+                WrapperResponse.<Void>builder()
+                        .message("Access Token이 재발급되었습니다.")
                         .data(null)
                         .build()
         );

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/response/LoginResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/response/LoginResponse.java
@@ -8,8 +8,5 @@ import lombok.Getter;
 public class LoginResponse {
     private Long userId;
     private String nickname;
-    private String accessToken;
-    private String refreshToken;
-    private Long accessTokenExpireAt;
-    private String redirectUrl;
+    private String imageUrl;
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/entity/Token.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/entity/Token.java
@@ -23,4 +23,9 @@ public class Token {
     private String token;
 
     private LocalDateTime expires;
+
+    public String getRefreshToken() {
+        return token;
+    }
+
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/entity/User.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/entity/User.java
@@ -96,4 +96,7 @@ public class User implements UserDetails {
     public boolean isEnabled() {
         return this.deletedAt == null && !"DELETED".equalsIgnoreCase(this.status);
     }
+    public void setLastLoginAt() {
+        this.logoutAt = java.time.LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/exception/UnauthorizedException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.moogsan.moongsan_backend.domain.user.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED) // 401
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/repository/TokenRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/repository/TokenRepository.java
@@ -3,6 +3,10 @@ package com.moogsan.moongsan_backend.domain.user.repository;
 import com.moogsan.moongsan_backend.domain.user.entity.Token;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TokenRepository extends JpaRepository<Token, Long> {
     void deleteByUserId(Long userId);
+
+    Optional<Token> findByUserId(Long userId);
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/LoginService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/LoginService.java
@@ -7,6 +7,8 @@ import com.moogsan.moongsan_backend.domain.user.entity.User;
 import com.moogsan.moongsan_backend.domain.user.repository.TokenRepository;
 import com.moogsan.moongsan_backend.domain.user.repository.UserRepository;
 import com.moogsan.moongsan_backend.global.security.jwt.JwtUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -24,47 +26,62 @@ public class LoginService {
     private final TokenRepository refreshTokenRepository;
 
     @Transactional
-    public LoginResponse login(LoginRequest request) {
+    public LoginResponse login(LoginRequest request, HttpServletResponse response) {
         // 1. 이메일로 사용자 조회
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new IllegalArgumentException("해당 이메일을 가진 사용자가 존재하지 않습니다."));
 
-        // 2. 비밀번호 검증
+        // 비밀번호 검증
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        // 추가. 탈퇴 복구 처리
+        // 탈퇴 복구 및 마지막 로그인 시간 기록
         if (user.getDeletedAt() != null) {
             user.setDeletedAt(null);
         }
+        user.setLastLoginAt(); // 마지막 로그인 시간 갱신
 
         // 3. JWT 토큰 발급
         String accessToken = jwtUtil.generateAccessToken(user);
         String refreshToken = jwtUtil.generateRefreshToken(user);
-        Long accessTokenExpireAt = jwtUtil.getAccessTokenExpireAt(); // 만료 시간 (millis)
-        Long refreshTokenExpireMillis = jwtUtil.getRefreshTokenExpireMillis(); // 리프레시 토큰 만료 기간 (millis)
+        Long accessTokenExpireAt = jwtUtil.getAccessTokenExpireAt();
+        Long refreshTokenExpireMillis = jwtUtil.getRefreshTokenExpireMillis();
 
-        // 4. 기존 리프레시 토큰 제거 (동일 유저 기준)
+        // 4. 기존 리프레시 토큰 제거
         refreshTokenRepository.deleteByUserId(user.getId());
 
         // 5. 새로운 리프레시 토큰 저장
         Token newToken = new Token(
-                null, // ID는 auto increment
+                null,
                 user.getId(),
                 refreshToken,
                 LocalDateTime.now().plusSeconds(refreshTokenExpireMillis / 1000)
         );
         refreshTokenRepository.save(newToken);
 
-        // 6. 응답 반환
+        // 쿠키 설정
+        Cookie accessTokenCookie = new Cookie("AccessToken", accessToken);
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge((int) (accessTokenExpireAt / 1000));
+        response.addCookie(accessTokenCookie);
+        response.addHeader("Set-Cookie", "AccessToken=" + accessToken + "; HttpOnly; Secure; Path=/; SameSite=None");
+
+        Cookie refreshTokenCookie = new Cookie("RefreshToken", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge((int) (refreshTokenExpireMillis / 1000));
+        response.addCookie(refreshTokenCookie);
+        response.addHeader("Set-Cookie", "RefreshToken=" + refreshToken + "; HttpOnly; Secure; Path=/; SameSite=None");
+
+        // 7. 최소 응답 정보 반환
         return new LoginResponse(
                 user.getId(),
                 user.getNickname(),
-                accessToken,
-                refreshToken,
-                accessTokenExpireAt,
-                "https://example.com/home" // 홈페이지로 redirect
+                user.getImageUrl()
         );
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/TokenRefreshService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/TokenRefreshService.java
@@ -1,0 +1,67 @@
+package com.moogsan.moongsan_backend.domain.user.service;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import com.moogsan.moongsan_backend.domain.user.entity.Token;
+import com.moogsan.moongsan_backend.domain.user.repository.TokenRepository;
+import com.moogsan.moongsan_backend.domain.user.repository.UserRepository;
+import com.moogsan.moongsan_backend.domain.user.exception.UnauthorizedException;
+import com.moogsan.moongsan_backend.global.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenRefreshService {
+
+    private final JwtUtil jwtUtil;
+    private final TokenRepository tokenRepository;
+    private final UserRepository userRepository;
+
+    public void refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        // 1. 쿠키에서 RefreshToken 추출
+        String refreshToken = extractRefreshTokenFromCookie(request);
+        if (refreshToken == null || !jwtUtil.validateToken(refreshToken)) {
+            throw new UnauthorizedException("Refresh Token이 유효하지 않습니다.");
+        }
+
+        // 2. userId 추출
+        Long userId = jwtUtil.getUserIdFromToken(refreshToken);
+
+        // 3. DB의 refreshToken과 일치하는지 확인
+        Token storedToken = tokenRepository.findByUserId(userId)
+                .orElseThrow(() -> new UnauthorizedException("저장된 Refresh Token이 없습니다."));
+
+        if (!storedToken.getRefreshToken().equals(refreshToken)) {
+            throw new UnauthorizedException("Refresh Token이 일치하지 않습니다.");
+        }
+
+        // 4. AccessToken 재발급
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UnauthorizedException("유저 정보를 찾을 수 없습니다."));
+
+        String newAccessToken = jwtUtil.generateAccessToken(user);
+        long accessTokenExpireAt = jwtUtil.getAccessTokenExpireAt();
+
+        // 5. 쿠키에 새 AccessToken 설정
+        Cookie accessTokenCookie = new Cookie("AccessToken", newAccessToken);
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge((int) (accessTokenExpireAt / 1000));
+        response.addCookie(accessTokenCookie);
+        response.addHeader("Set-Cookie", "AccessToken=" + newAccessToken + "; HttpOnly; Secure; Path=/; SameSite=None");
+    }
+
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if ("RefreshToken".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/security/jwt/JwtAuthenticationFilter.java
@@ -47,7 +47,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest request) {
+        // 1. Authorization 헤더 우선 확인
         String bearer = request.getHeader("Authorization");
-        return (bearer != null && bearer.startsWith("Bearer ")) ? bearer.substring(7) : null;
+        if (bearer != null && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+
+        // 2. 쿠키에서 AccessToken 확인
+        if (request.getCookies() != null) {
+            for (jakarta.servlet.http.Cookie cookie : request.getCookies()) {
+                if ("AccessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
+        return null;
+    }
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+        // Exclude POST /api/users from filtering
+        return path.equals("/api/users") && method.equalsIgnoreCase("POST");
     }
 }


### PR DESCRIPTION
## feat/fix(user): 토큰 쿠키로 전달, 토큰 재발행

## 🔎 작업 개요
액세스/리프레시 토큰 쿠키를 통해 전달/재발급

## 🛠️ 주요 변경 사항
- 로그인 시, 액세스/리프레시 토큰은 쿠키를 통해 전달
- 로그인 시, 닉네임/실명/프로필이미지url은 바디를 통해 전달
- 액세스 토큰 재발행 api 생성 (/api/users/token/refresh)
- 테스트 확인 완료

## ✅ 검증 방법

## 🔍 머지 전 확인사항  

## ➕ 이슈 링크
