### PR TITLE
feat(group-buy) add AI proxy api, AiClient, WebClient and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# secrets
+/config/application-secrets.yml
+

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // or jjwt-gson
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/client/AiClient.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/client/AiClient.java
@@ -1,0 +1,55 @@
+// 1) AiClient.java
+package com.moogsan.moongsan_backend.domain.groupbuy.client;
+
+import com.moogsan.moongsan_backend.domain.WrapperResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.DescriptionGenerationRequest;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.response.ApiResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.response.DescriptionDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class AiClient {
+
+    private final WebClient webClient;
+
+    @Value("${ai.service.base-url}")
+    private String aiBaseUrl;
+
+    /**
+     * 외부 AI API 호출 → ApiResponse<DescriptionDto> 로 파싱 → DescriptionDto 추출
+     */
+    public Mono<DescriptionDto> generateDescription(String url) {
+        DescriptionGenerationRequest req = DescriptionGenerationRequest.builder()
+                .url(url)
+                .build();
+
+        return webClient.post()
+                .uri(aiBaseUrl + "/generation/description")
+                .bodyValue(req)
+                .retrieve()
+                // 4xx 클라이언트 에러면 Bad Request로 매핑
+                .onStatus(HttpStatusCode::is4xxClientError,
+                        resp -> Mono.error(new IllegalArgumentException("유효하지 않은 URL 형식입니다.")))
+                // 5xx 서버 에러면 Internal Server Error로 매핑
+                .onStatus(HttpStatusCode::is5xxServerError,
+                        resp -> Mono.error(new IllegalStateException("AI 서비스 호출 중 서버 오류가 발생했습니다.")))
+                // 외부 AI의 공통 래퍼(ApiResponse<T>) 형태로 역직렬화
+                .bodyToMono(new ParameterizedTypeReference<ApiResponse<DescriptionDto>>() {})
+                // wrapper 안에서 data만 꺼내거나, 없으면 에러 처리
+                .flatMap(apiRes -> {
+                    DescriptionDto data = apiRes.getData();
+                    if (data != null) {
+                        return Mono.just(data);
+                    } else {
+                        return Mono.error(new IllegalStateException("AI 서비스가 데이터를 반환하지 않았습니다."));
+                    }
+                });
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
@@ -8,8 +8,7 @@ import org.hibernate.validator.constraints.URL;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Getter
-@Setter
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/DescriptionGenerationRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/DescriptionGenerationRequest.java
@@ -1,0 +1,18 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import org.hibernate.validator.constraints.URL;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DescriptionGenerationRequest {
+
+    @NotBlank(message = "URL은 필수 입력 항목입니다.")
+    @Size(min = 1, max = 2000, message = "URL은 1자 이상, 2000자 이하로 입력해주세요.")
+    @URL(message = "URL 형식이 올바르지 않습니다.")
+    private String url;
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
@@ -9,8 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Getter
-@Setter
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/response/ApiResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/response/ApiResponse.java
@@ -1,0 +1,10 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.command.response;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+    private String message;
+    private T data;
+}
+

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/response/DescriptionDto.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/response/DescriptionDto.java
@@ -1,0 +1,3 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.dto.command.response;
+
+public record DescriptionDto(String description) {}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService.java
@@ -1,7 +1,9 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.service;
 
+import com.moogsan.moongsan_backend.domain.groupbuy.client.AiClient;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.CreateGroupBuyRequest;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.UpdateGroupBuyRequest;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.response.DescriptionDto;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
@@ -17,6 +19,7 @@ import com.moogsan.moongsan_backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,6 +33,7 @@ public class GroupBuyCommandService {
     private final ImageMapper imageMapper;
     private final GroupBuyCommandMapper groupBuyCommandMapper;
     private final OrderRepository orderRepository;
+    private final AiClient aiClient;
 
     /// 공구 게시글 작성
     public Long createGroupBuy(User currentUser, CreateGroupBuyRequest createGroupBuyRequest) {
@@ -50,6 +54,11 @@ public class GroupBuyCommandService {
         groupBuyRepository.save(gb);
 
         return gb.getId();
+    }
+
+    /// 공구 게시글 상세 설명 생성
+    public Mono<DescriptionDto> generate(String url) {
+        return aiClient.generateDescription(url);
     }
 
     /// 공구 게시글 수정

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/WebClientConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package com.moogsan.moongsan_backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 spring.application.name=moongsan-backend
 
+spring.config.import: optional:file:./config/application-secrets.yml
+
 jwt.secret=your-very-secure-secret-key-must-be-long-enough
 jwt.access-token-expire-ms=3600000
 jwt.refresh-token-expire-ms=1209600000


### PR DESCRIPTION
## 🔎 작업 개요
외부 AI 서비스 엔드포인트 설정을 안전하게 관리하기 위해, 운영·스테이징·로컬 환경별 설정 분리 방안 도입

## 🛠️ 주요 변경 사항
- **프로퍼티 구조 변경**  
  - `src/main/resources/application.properties` 에는 공개 설정만 유지
- **외부 설정 파일**  
  - 프로젝트 루트 `config/application-secrets.yml` 에 AI 서비스 기본 URL 플레이스홀더 정의  
  - `.gitignore` 에 `config/` 폴더 전체 추가
- **디펜던시 및 빈 등록**  
  - `spring-boot-starter-webflux` 의존성 추가  
  - `WebClientConfig` 클래스로 `WebClient` 빈 등록

## ✅ 검증 방법
- `./gradlew clean build --refresh-dependencies` 로 빌드 및 테스트 통과 확인  

## 🔍 머지 전 확인사항 
- 로컬 개발 가이드에 외부 설정 파일 생성 방법 문서화
- API 명세서 추가 확인(GROUPBUY:: AI 상품 상세 설명 생성 프록시 v1)

## ➕ 이슈 링크
- [[Sprint #3] BE - 공동구매 상품 관리 기능 개발](https://github.com/100-hours-a-week/14-YG-BE/issues/9)  