### PR TITLE
feat(group-buy): allow detail view without permission

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
@@ -28,7 +28,9 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/users", "/api/users/token", "/api/users/check-nickname", "/api/group-buys").permitAll() // 해당 위치 외에는 토큰 적용
+                        .requestMatchers(
+                                "/api/users", "/api/users/token", "/api/users/check-nickname",
+                                "/api/group-buys", "/api/group-buys/{postId}").permitAll() // 해당 위치 외에는 토큰 적용
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, userDetailsService), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 🔎 작업 개요
공동구매 상세 조회 API에 대한 인증 권한을 수정했습니다.

## 🛠️ 주요 변경 사항
- **Controller 권한 설정 변경**  
  - `/api/group-buys/{postId}` 엔드포인트에 인증 없이 접근 가능하도록 허용  

## ✅ 검증 방법
1. 인증 없이 `GET /api/group-buys/{postId}` 호출 시 정상적으로 상세 정보 반환 확인  
2. `./gradlew clean build` 및 기존 테스트 모두 통과 확인

## 🔍 머지 전 확인사항
- API 명세서 및 보안 정책 문서에 권한 변경 사항 반영 여부  

## ➕ 이슈 링크
- [[Sprint #3] BE - 공동구매 상품 관리 기능 개발](https://github.com/100-hours-a-week/14-YG-BE/issues/9