### PR TITLE
feat(group-buy): isWish 조회 메서드, 컬럼 mapper 추가, JsonProperty 위치 수정

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyCommandController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyCommandController.java
@@ -118,7 +118,7 @@ public class GroupBuyCommandController {
     }
 
 
-    // 공구 참여 취소
+    /// 공구 참여 취소 SUCCESS
     @DeleteMapping("/{postId}/participants")
     public ResponseEntity<WrapperResponse<EmptyResponse>> leaveGroupBuy(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyCommandController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyCommandController.java
@@ -132,12 +132,6 @@ public class GroupBuyCommandController {
         );
     }
 
-    // 관심 공구 추가
-    //  TODO V2
-
-    // 관심 공구 취소
-    //  TODO V2
-
     // 공구 게시글 공구 종료
     @PatchMapping("/{postId}/end")
     public ResponseEntity<WrapperResponse<EmptyResponse>> endGroupBuy(

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyQueryController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyQueryController.java
@@ -76,7 +76,7 @@ public class GroupBuyQueryController {
         );
     }
 
-    /*
+
     // 관심 공구 리스트 조회
     @GetMapping("/user/wishes")
     public ResponseEntity<WrapperResponse<PagedResponse<WishListResponse>>> getGroupBuyWishList(
@@ -93,8 +93,6 @@ public class GroupBuyQueryController {
                         .build()
         );
     }
-
-     */
 
     // 주최 공구 리스트 조회 V2 update - wish
     @GetMapping("/user/hosts")

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyQueryController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyQueryController.java
@@ -38,7 +38,7 @@ public class GroupBuyQueryController {
         );
     }
 
-    // 공구 게시글 상세 조회 V2 update - wish
+    /// 공구 게시글 상세 조회 V2 update - wish SUCCESS
     @GetMapping("/{postId}")
     public ResponseEntity<WrapperResponse<DetailResponse>> getGroupBuyDetailInfo(
         @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -52,9 +52,10 @@ public class GroupBuyQueryController {
         );
     }
 
-    // 공구 리스트 조회  V2 update - wish
+    /// 공구 리스트 조회  V2 update - wish SUCCESS
     @GetMapping
     public ResponseEntity<WrapperResponse<PagedResponse<BasicListResponse>>> getGroupBuyListByCursor(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(value = "category", required = false) Long categoryId,
             @RequestParam(value = "sort", defaultValue = "created") String sort,
             @RequestParam(value = "cursorId", required = false) Long cursorId,
@@ -66,7 +67,7 @@ public class GroupBuyQueryController {
             @RequestParam(value = "limit", defaultValue = "10") Integer limit
     ) {
         PagedResponse<BasicListResponse> pagedResponse =
-                groupBuyService.getGroupBuyListByCursor(categoryId, sort, cursorId, cursorCreatedAt,
+                groupBuyService.getGroupBuyListByCursor(userDetails.getUser(), categoryId, sort, cursorId, cursorCreatedAt,
                         cursorPrice, limit);
         return ResponseEntity.ok(
                 WrapperResponse.<PagedResponse<BasicListResponse>>builder()
@@ -77,7 +78,7 @@ public class GroupBuyQueryController {
     }
 
 
-    // 관심 공구 리스트 조회
+    /// 관심 공구 리스트 조회 SUCCESS
     @GetMapping("/user/wishes")
     public ResponseEntity<WrapperResponse<PagedResponse<WishListResponse>>> getGroupBuyWishList(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -94,7 +95,7 @@ public class GroupBuyQueryController {
         );
     }
 
-    // 주최 공구 리스트 조회 V2 update - wish
+    // 주최 공구 리스트 조회 V2 update - wish, 커서 적용 필요
     @GetMapping("/user/hosts")
     public ResponseEntity<WrapperResponse<PagedResponse<HostedListResponse>>> getGroupBuyHostedList(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -111,7 +112,7 @@ public class GroupBuyQueryController {
         );
     }
 
-    // 참여 공구 리스트 조회 SUCCESS V2 update - wish
+    /// 참여 공구 리스트 조회 SUCCESS V2 update - wish SUCCESS, 커서 적용 필요
     @GetMapping("/user/participants")
     public ResponseEntity<WrapperResponse<PagedResponse<ParticipatedListResponse>>> getGroupBuyParticipatedList(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/DetailResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/DetailResponse.java
@@ -34,11 +34,7 @@ public class DetailResponse {
 
     // 상태/플래그
     private boolean dueSoon;                // 마감 임박 여부
-
-    @JsonProperty("isWish")
     private boolean isWish;                 // 관심 여부
-
-    @JsonProperty("isParticipant")
     private boolean isParticipant;          // 참여 여부
 
     // 날짜
@@ -48,4 +44,14 @@ public class DetailResponse {
 
     // 연관 객체
     private UserProfileResponse userProfileResponse;    // 주최자 정보
+
+    @JsonProperty("isWish")
+    public boolean isWish() {
+        return isWish;
+    }
+
+    @JsonProperty("isParticipant")
+    public boolean isParticipant() {
+        return isParticipant;
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/DetailResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/DetailResponse.java
@@ -1,5 +1,6 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyDetail;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.ImageResponse;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,7 +34,11 @@ public class DetailResponse {
 
     // 상태/플래그
     private boolean dueSoon;                // 마감 임박 여부
+
+    @JsonProperty("isWish")
     private boolean isWish;                 // 관심 여부
+
+    @JsonProperty("isParticipant")
     private boolean isParticipant;          // 참여 여부
 
     // 날짜

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/BasicList/BasicListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/BasicList/BasicListResponse.java
@@ -31,11 +31,14 @@ public class BasicListResponse {
 
     // 상태/플래그
     private boolean dueSoon;         // 마감 임박 여부
-
-    @JsonProperty("isWish")
     private boolean isWish;          // 관심 여부
 
     // 날짜
     private LocalDateTime createdAt; // 생성 일시
+
+    @JsonProperty("isWish")
+    public boolean isWish() {
+        return isWish;
+    }
 
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/BasicList/BasicListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/BasicList/BasicListResponse.java
@@ -1,5 +1,6 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.BasicList;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.ImageResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import lombok.Builder;
@@ -30,14 +31,11 @@ public class BasicListResponse {
 
     // 상태/플래그
     private boolean dueSoon;         // 마감 임박 여부
+
+    @JsonProperty("isWish")
     private boolean isWish;          // 관심 여부
 
     // 날짜
     private LocalDateTime createdAt; // 생성 일시
-
-    public BasicListResponse of(GroupBuy groupBuy) {
-        return BasicListResponse.builder()
-                .build();
-    }
 
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/HostedList/HostedListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/HostedList/HostedListResponse.java
@@ -29,8 +29,10 @@ public class HostedListResponse {
 
     // 상태/플래그
     private boolean dueSoon;       // 마감 임박 여부
-
-    @JsonProperty("isWish")
     private boolean isWish;        // 관심 여부
 
+    @JsonProperty("isWish")
+    public boolean isWish() {
+        return isWish;
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/HostedList/HostedListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/HostedList/HostedListResponse.java
@@ -1,5 +1,6 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.HostedList;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -28,6 +29,8 @@ public class HostedListResponse {
 
     // 상태/플래그
     private boolean dueSoon;       // 마감 임박 여부
+
+    @JsonProperty("isWish")
     private boolean isWish;        // 관심 여부
 
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipatedList/ParticipatedListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipatedList/ParticipatedListResponse.java
@@ -1,5 +1,6 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipatedList;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -26,6 +27,8 @@ public class ParticipatedListResponse {
     // 상태/플래그
     private String orderStatus;    // 주문 상태: PENDING(입금 전), PAID(입금 됨, 입금 확인 전), CONFIRMED(입금 확인), CANCELED(취소)
     private boolean dueSoon;       // 마감 임박 여부
+
+    @JsonProperty("isWish")
     private boolean isWish;        // 관심 여부
 
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipatedList/ParticipatedListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipatedList/ParticipatedListResponse.java
@@ -27,8 +27,10 @@ public class ParticipatedListResponse {
     // 상태/플래그
     private String orderStatus;    // 주문 상태: PENDING(입금 전), PAID(입금 됨, 입금 확인 전), CONFIRMED(입금 확인), CANCELED(취소)
     private boolean dueSoon;       // 마감 임박 여부
-
-    @JsonProperty("isWish")
     private boolean isWish;        // 관심 여부
 
+    @JsonProperty("isWish")
+    public boolean isWish() {
+        return isWish;
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/wishList/WishListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/wishList/WishListResponse.java
@@ -25,8 +25,10 @@ public class WishListResponse {
 
     // 상태/플래그
     private boolean dueSoon;       // 마감 임박 여부
-
-    @JsonProperty("isWish")
     private boolean isWish;        // 관심 여부
 
+    @JsonProperty("isWish")
+    public boolean isWish() {
+        return isWish;
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/wishList/WishListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/wishList/WishListResponse.java
@@ -1,5 +1,6 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.WishList;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -24,6 +25,8 @@ public class WishListResponse {
 
     // 상태/플래그
     private boolean dueSoon;       // 마감 임박 여부
+
+    @JsonProperty("isWish")
     private boolean isWish;        // 관심 여부
 
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
@@ -48,8 +48,8 @@ public class GroupBuyQueryMapper {
     }
 
     // 공구 리스트 조회용 DTO 변환
-    public BasicListResponse toBasicListResponse(GroupBuy g) {
-        List<ImageResponse> imgs = g.getImages().stream()
+    public BasicListResponse toBasicListResponse(GroupBuy g, Boolean isWish) {
+        List<ImageResponse> imageKeys = g.getImages().stream()
                 .map(img -> ImageResponse.builder()
                         .imageKey(img.getImageKey())
                         .imageSeqNo(img.getImageSeqNo())
@@ -62,19 +62,20 @@ public class GroupBuyQueryMapper {
                 .title(g.getTitle())
                 .name(g.getName())
                 .postStatus(g.getPostStatus())
-                .imageKeys(imgs)
+                .imageKeys(imageKeys)
                 .unitPrice(g.getUnitPrice())
                 .unitAmount(g.getUnitAmount())
                 .soldAmount(g.getTotalAmount() - g.getLeftAmount())
                 .totalAmount(g.getTotalAmount())
                 .participantCount(g.getParticipantCount())
                 .dueSoon(g.isDueSoon())
+                .isWish(isWish)
                 .createdAt(g.getCreatedAt())
                 .build();
     }
 
     // 상세 페이지 조회용 DTO
-    public DetailResponse toDetailResponse(GroupBuy gb, Boolean isParticipant) {
+    public DetailResponse toDetailResponse(GroupBuy gb, Boolean isParticipant, Boolean isWish) {
         List<ImageResponse> imageUrls = gb.getImages().stream()
                 .map(img -> ImageResponse.builder()
                         .imageKey(img.getImageKey())
@@ -101,6 +102,7 @@ public class GroupBuyQueryMapper {
                 .pickupDate(gb.getPickupDate())
                 .location(gb.getLocation())
                 .isParticipant(isParticipant)
+                .isWish(isWish)
                 .createdAt(gb.getCreatedAt())
                 .userProfileResponse(toUserProfile(gb.getUser()))
                 .build();
@@ -138,12 +140,13 @@ public class GroupBuyQueryMapper {
                 .soldAmount(gb.getTotalAmount() - gb.getLeftAmount())
                 .totalAmount(gb.getTotalAmount())
                 .participantCount(gb.getParticipantCount())
+                .isWish(true)
                 .dueSoon(dueSoon)
                 .build();
     }
 
     // 주최 공구 리스트 조회
-    public HostedListResponse toHostedListResponse(GroupBuy gb) {
+    public HostedListResponse toHostedListResponse(GroupBuy gb, Boolean isWish) {
         String img = gb.getImages().stream()
                 .findFirst()
                 .map(Image::getImageKey)
@@ -164,13 +167,14 @@ public class GroupBuyQueryMapper {
                 .soldAmount(gb.getTotalAmount() - gb.getLeftAmount())
                 .totalAmount(gb.getTotalAmount())
                 .participantCount(gb.getParticipantCount())
+                .isWish(isWish)
                 .dueSoon(dueSoon)
                 .build();
     }
 
 
     // 참여 공구 리스트 조회
-    public ParticipatedListResponse toParticipatedListResponse(Order o) {
+    public ParticipatedListResponse toParticipatedListResponse(Order o, boolean isWish) {
         GroupBuy post = o.getGroupBuy();
 
         String img = post.getImages().stream()
@@ -194,6 +198,7 @@ public class GroupBuyQueryMapper {
                 .soldAmount(post.getTotalAmount() - post.getLeftAmount())
                 .totalAmount(post.getTotalAmount())
                 .participantCount(post.getParticipantCount())
+                .isWish(isWish)
                 .dueSoon(dueSoon)
                 .build();
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService.java
@@ -161,49 +161,6 @@ public class GroupBuyCommandService {
 
     }
 
-    /// 관심 공구 추가
-    // TODO V2
-    public Long wishPost(User currentUser, Long postId) {
-
-        // 해당 공구가 존재하는지 조회 -> 없으면 404
-        GroupBuy groupBuy = groupBuyRepository.findById(postId)
-                .orElseThrow(GroupBuyNotFoundException::new);
-
-        // 해당 공구가 OPEN인지 조회, dueDate가 현재 이후인지 조회 -> 아니면 409
-        if (!groupBuy.getPostStatus().equals("OPEN")
-                || groupBuy.getDueDate().isBefore(LocalDateTime.now())) {
-            throw new GroupBuyInvalidStateException("관심 공구 등록은 공구가 열려있는 상태에서만 가능합니다.");
-        }
-
-        ///  TODO: 관심 공구 등록 여부 조회 -> 등록했으면 409
-
-
-        ///  TODO: 관심 공구 등록
-
-
-        ///  TODO: 저장
-
-        return postId;
-    }
-
-    /// 관심 공구 취소
-    // TODO V2
-    public void unwishPost(User currentUser, Long postId) {
-
-        // 해당 공구가 존재하는지 조회 -> 없으면 404
-        GroupBuy groupBuy = groupBuyRepository.findById(postId)
-                .orElseThrow(GroupBuyNotFoundException::new);
-
-        ///  TODO: 관심 공구 등록 여부 조회 -> 등록하지 않았으면 409
-
-
-        ///  TODO: 관심 공구 취소
-
-
-        ///  TODO: 저장
-
-    }
-
     ///  공구 마감
     public void closePastDueGroupBuys(LocalDateTime now) {
         List<GroupBuy> expired = groupBuyRepository

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService.java
@@ -269,7 +269,7 @@ public class GroupBuyQueryService {
 
         String status = postStatus.toUpperCase();
 
-        Pageable page = PageRequest.of(0, limit, Sort.by("groupBuy.id").descending());
+        Pageable page = PageRequest.of(0, limit, Sort.by("id").descending());
 
         // cursorId가 없으면 cursor 조건 제외
         List<GroupBuy> groupBuys;

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService.java
@@ -7,6 +7,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyL
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipantList.ParticipantListResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipantList.ParticipantResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipatedList.ParticipatedListResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.WishList.WishListResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyUpdate.GroupBuyForUpdateResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
@@ -15,6 +16,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepositor
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
+import com.moogsan.moongsan_backend.domain.user.repository.WishRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -34,6 +36,7 @@ public class GroupBuyQueryService {
     private final GroupBuyRepository groupBuyRepository;
     private final OrderRepository orderRepository;
     private final GroupBuyQueryMapper groupBuyQueryMapper;
+    private final WishRepository wishRepository;
 
     /// 공구 게시글 수정 전 정보 조회
     /// TODO V2
@@ -193,31 +196,32 @@ public class GroupBuyQueryService {
 
     /// 관심 공구 리스트 조회
     /// TODO V2
-    /*
     public PagedResponse<WishListResponse> getGroupBuyWishList(
             User currentUser,
-            String sort,
+            String postStatus,
             Long cursorId,
             Integer limit) {
-        String status = sort.toUpperCase();
+        String status = postStatus.toUpperCase();
 
         Pageable page = PageRequest.of(0, limit, Sort.by("groupBuy.id").descending());
 
         // cursorId가 없으면 cursor 조건 제외
         List<GroupBuy> groupBuys;
         if (cursorId == null) {
-            groupBuys = wishRepository.findByUserIdAndGroupBuyPostStatus(
-                    currentUser.getId(),
-                    status,
-                    page
-            );
+            groupBuys = wishRepository
+                    .findGroupBuysByUserAndStatus (
+                            currentUser.getId(),
+                            status,
+                            page
+                    );
         } else {
-            groupBuys = wishRepository.findByUserIdAndGroupBuyPostStatusAndGroupBuyIdLessThan(
-                    currentUser.getId(),
-                    status,
-                    cursorId,
-                    page
-            );
+            groupBuys = wishRepository
+                    .findGroupBuysByUserAndStatusBeforeId(
+                            currentUser.getId(),
+                            status,
+                            cursorId,
+                            page
+                    );
         }
 
         // 매핑
@@ -239,17 +243,15 @@ public class GroupBuyQueryService {
                 .build();
     }
 
-     */
-
 
     /// 주최 공구 리스트 조회
     public PagedResponse<HostedListResponse> getGroupBuyHostedList(
             User currentUser,
-            String sort,
+            String postStatus,
             Long cursorId,
             Integer limit) {
 
-        String status = sort.toUpperCase();
+        String status = postStatus.toUpperCase();
 
         Pageable page = PageRequest.of(0, limit, Sort.by("groupBuy.id").descending());
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/repository/WishRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/repository/WishRepository.java
@@ -1,14 +1,47 @@
 package com.moogsan.moongsan_backend.domain.user.repository;
 
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.user.entity.Wish;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface WishRepository extends JpaRepository<Wish, Long> {
 
+    Optional<Wish> findByUserIdAndGroupBuyId(Long userId, Long groupBuyId);
+
     boolean existsByUserIdAndGroupBuyId(Long userId, Long groupBuyId);
 
-    Optional<Wish> findByUserIdAndGroupBuyId(Long userId, Long groupBuyId);
+    @Query("""
+       select w.groupBuy
+         from Wish w
+        where w.user.id = :userId
+          and w.groupBuy.postStatus = :postStatus
+     order by w.groupBuy.id desc
+    """)
+    List<GroupBuy> findGroupBuysByUserAndStatus(
+            @Param("userId") Long userId,
+            @Param("postStatus") String postStatus,
+            Pageable pageable
+    );
+
+    @Query("""
+       select w.groupBuy
+         from Wish w
+        where w.user.id = :userId
+          and w.groupBuy.postStatus = :postStatus
+          and w.groupBuy.id < :cursorId
+     order by w.groupBuy.id desc
+    """)
+    List<GroupBuy> findGroupBuysByUserAndStatusBeforeId(
+            @Param("userId") Long userId,
+            @Param("postStatus") String postStatus,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable
+    );
 
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/repository/WishRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/repository/WishRepository.java
@@ -16,6 +16,12 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
 
     boolean existsByUserIdAndGroupBuyId(Long userId, Long groupBuyId);
 
+    // 공구 리스트 목록에 속한 공구가 관심 공구인지 확인
+    @Query("select w.groupBuy.id from Wish w where w.user.id = :userId and w.groupBuy.id in :ids")
+    List<Long> findWishedGroupBuyIds(@Param("userId") Long userId,
+                                     @Param("ids") List<Long> groupBuyIds);
+
+    // 관심 공구 리스트 첫 조회
     @Query("""
        select w.groupBuy
          from Wish w
@@ -29,6 +35,7 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
             Pageable pageable
     );
 
+    // 관심 공구 리스트 이어서 조회
     @Query("""
        select w.groupBuy
          from Wish w


### PR DESCRIPTION
## 🔎 작업 개요
전체 공구/관심 공구/주최 공구/참여 공구 리스트 및 게시글 상세 조회에 isWish , isParticipant추가

## 🛠️ 주요 변경 사항
- 전체 공구/관심 공구/주최 공구/참여 공구 리스트에 isWish mapper 추가
- 게시글 상세 조회에 isWish mapper 추가
- cursor 사용 시 10개씩 조회되는 게시글(최대 10개)에 대한 관심 등록 여부를 조회하는 메서드 추가하여 오버헤드 줄임
- isWish, isParticipant 필드가 아닌 게터에 @JsonProperty 사용

## ✅ 검증 방법
- 빌드 및 빌드 파일로 실행 확인
- Postman 응답 확인 및 교차 검증 완료

## 🔍 머지 전 확인사항  
- (예정) 주최 공구, 참여 공구에 적절한 커서 사용

## ➕ 이슈 링크
- [#10 공동구매 상품 관리 기능 개선 및 확장](https://github.com/100-hours-a-week/14-YG-BE/issues/32)