### PR TITLE
fix(group-buy):  allow unauthenticated access to public endpoint (#10)

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyQueryController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyQueryController.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -41,9 +42,17 @@ public class GroupBuyQueryController {
     /// 공구 게시글 상세 조회 V2 update - wish SUCCESS
     @GetMapping("/{postId}")
     public ResponseEntity<WrapperResponse<DetailResponse>> getGroupBuyDetailInfo(
-        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @AuthenticationPrincipal Optional<CustomUserDetails> userDetails,
         @PathVariable Long postId) {
-        DetailResponse detail = groupBuyService.getGroupBuyDetailInfo(userDetails.getUser().getId(), postId);
+
+        Long userId;
+        if (userDetails == null || userDetails.isEmpty()) {
+            userId = null;
+        } else {
+            userId = userDetails.get().getUser().getId();
+        }
+
+        DetailResponse detail = groupBuyService.getGroupBuyDetailInfo(userId, postId);
         return ResponseEntity.ok(
                 WrapperResponse.<DetailResponse>builder()
                         .message("공구 게시글 상세 정보를 성공적으로 조회했습니다.")
@@ -55,7 +64,7 @@ public class GroupBuyQueryController {
     /// 공구 리스트 조회  V2 update - wish SUCCESS
     @GetMapping
     public ResponseEntity<WrapperResponse<PagedResponse<BasicListResponse>>> getGroupBuyListByCursor(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal Optional<CustomUserDetails> userDetails,
             @RequestParam(value = "category", required = false) Long categoryId,
             @RequestParam(value = "sort", defaultValue = "created") String sort,
             @RequestParam(value = "cursorId", required = false) Long cursorId,
@@ -66,8 +75,15 @@ public class GroupBuyQueryController {
             @RequestParam(value = "cursorPrice", required = false) Integer cursorPrice,
             @RequestParam(value = "limit", defaultValue = "10") Integer limit
     ) {
+        Long userId;
+        if (userDetails == null || userDetails.isEmpty()) {
+            userId = null;
+        } else {
+            userId = userDetails.get().getUser().getId();
+        }
+
         PagedResponse<BasicListResponse> pagedResponse =
-                groupBuyService.getGroupBuyListByCursor(userDetails.getUser(), categoryId, sort, cursorId, cursorCreatedAt,
+                groupBuyService.getGroupBuyListByCursor(userId, categoryId, sort, cursorId, cursorCreatedAt,
                         cursorPrice, limit);
         return ResponseEntity.ok(
                 WrapperResponse.<PagedResponse<BasicListResponse>>builder()

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService.java
@@ -79,7 +79,7 @@ public class GroupBuyQueryService {
 
     /// 공구 리스트 조회
     public PagedResponse<BasicListResponse> getGroupBuyListByCursor(
-            User currentUser,
+            Long userId,
             Long categoryId,
             String sort,
             Long cursorId,
@@ -163,7 +163,7 @@ public class GroupBuyQueryService {
         }
 
         // DTO 매핑
-        Map<Long, Boolean> wishMap = fetchWishMap(currentUser.getId(), entities);
+        Map<Long, Boolean> wishMap = fetchWishMap(userId, entities);
 
         // 4) DTO 매핑
         List<BasicListResponse> posts = entities.stream()

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.moogsan.moongsan_backend.global.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -35,7 +36,11 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/users", "/api/users/token", "/api/users/check-nickname",
-                                "/api/group-buys", "/api/group-buys/{postId}", "/uploads/**", "/api/group-buys/generation/description").permitAll() // 해당 위치 외에는 토큰 적용
+                                "/uploads/**", "/api/group-buys/generation/description").permitAll() // 해당 위치 외에는 토큰 적용
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/group-buys",         // 메인
+                                "/api/group-buys/*"        // 상세(한 단계 하위)
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, userDetailsService), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/moogsan/moongsan_backend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/security/jwt/JwtAuthenticationFilter.java
@@ -27,6 +27,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
+        String path   = request.getRequestURI();
+        String method = request.getMethod();
+
+        // 공개 엔드포인트이면 토큰 검사 없이 바로 통과
+        if ("GET".equals(method) &&
+                (path.equals("/api/group-buys") || path.startsWith("/api/group-buys/"))) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String token = resolveToken(request);
 
         if (token != null && jwtUtil.validateToken(token)) {


### PR DESCRIPTION
## 🔎 작업 개요
Wish 추가 후 메인 리스트 조회, 공동구매 게시글 상세 조회 시 403 에러 발생하여 원인 코드 분석 후 수정

## 🛠️ 주요 변경 사항
- 메인 리스트, 상세조회 controller 수정
  - Wish로 인해 추가된 CustomUserDetails에 Optional 적용
  - User가 아닌 Long으로 파라미터 전달. primitive 타입 적용하여 null 허용 강화
- SecurityConfig 수정
  - 메인과 상세 조회의 경우 GET requestMatchers로 변경
- JwtAuthenticationFilter 수정
  - 공개 엔드포인트이면 토큰 검사 없이 통과하도록 수정

## ✅ 검증 방법
- 빌드 및 빌드 파일로 실행 확인
- Postman 응답 확인 및 교차 검증 완료

## 🔍 머지 전 확인사항  
- 

## ➕ 이슈 링크
- [#10 공동구매 상품 관리 기능 개선 및 확장](https://github.com/100-hours-a-week/14-YG-BE/issues/32)