### PR TITLE
fix(schema): build.gradle 수정, ORM 기준 init schema 및 더미 데이터 정비, dueSoon 정책 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,19 @@
+buildscript {
+	repositories {
+		mavenCentral()
+	}
+	dependencies {
+		classpath "mysql:mysql-connector-java:8.0.33"
+	}
+}
+
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+	id 'org.flywaydb.flyway' version '10.20.1'
 }
 
 group = 'com.moogsan'
@@ -34,7 +45,17 @@ dependencyManagement {
 	}
 }
 
+flyway {
+	url = 'jdbc:mysql://localhost:3306/moongsan_local_db'
+	user = 'root'
+	password = 'pass'
+	schemas = ['moongsan_local_db']
+	locations = ['filesystem:src/main/resources/db/migration']
+	driver = 'com.mysql.cj.jdbc.Driver'
+}
+
 dependencies {
+	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/entity/GroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/entity/GroupBuy.java
@@ -109,7 +109,7 @@ public class GroupBuy extends BaseEntity {
     }
 
     @Transient
-    public boolean isDueSoon() {
+    public boolean isAlmostSoldOut() {
         return getSoldRatio() >= 0.8;
     }
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
@@ -68,7 +68,7 @@ public class GroupBuyQueryMapper {
                 .soldAmount(g.getTotalAmount() - g.getLeftAmount())
                 .totalAmount(g.getTotalAmount())
                 .participantCount(g.getParticipantCount())
-                .dueSoon(g.isDueSoon())
+                .dueSoon(g.isAlmostSoldOut())
                 .isWish(isWish)
                 .createdAt(g.getCreatedAt())
                 .build();
@@ -99,7 +99,7 @@ public class GroupBuyQueryMapper {
                 .leftAmount(gb.getLeftAmount())
                 .participantCount(gb.getParticipantCount())
                 .dueDate(gb.getDueDate())
-                .dueSoon(gb.isDueSoon())
+                .dueSoon(gb.isAlmostSoldOut())
                 .pickupDate(gb.getPickupDate())
                 .location(gb.getLocation())
                 .isParticipant(isParticipant)

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/repository/GroupBuyRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/repository/GroupBuyRepository.java
@@ -32,6 +32,20 @@ public interface GroupBuyRepository extends JpaRepository<GroupBuy, Long> {
             Long cursorId,
             Pageable pageable);
 
+    /** 마감 임박 */
+    @Query("""
+    SELECT g
+    FROM GroupBuy g
+    WHERE g.postStatus = 'OPEN'
+      AND g.dueSoon = true
+    ORDER BY ((g.totalAmount - g.leftAmount) * 100.0 / g.totalAmount) DESC,
+             g.createdAt DESC,
+             g.id DESC
+    """)
+    List<GroupBuy> findDueSoonOnly(Pageable pageable);
+
+
+
     // 게시글 조회 - 공구 게시글 수정 전 정보, 공구 게시글 상세
     @EntityGraph(attributePaths = "images")
     Optional<GroupBuy> findWithImagesById(Long id);
@@ -71,8 +85,6 @@ public interface GroupBuyRepository extends JpaRepository<GroupBuy, Long> {
               id DESC
     """, nativeQuery = true)
     List<GroupBuy> findEndingSoon(Pageable pageable);
-
-
 
 
     /** 0-2-a) + 카테고리 필터 */

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService.java
@@ -82,7 +82,7 @@ public class GroupBuyQueryService {
     public PagedResponse<BasicListResponse> getGroupBuyListByCursor(
             Long userId,
             Long categoryId,
-            String orderBy,        // e.g. "latest", "ending_soon", "price_asc"
+            String orderBy,        // e.g. "latest", "ending_soon", "price_asc", "due_soon_only"
             Long cursorId,
             LocalDateTime cursorCreatedAt,
             Integer cursorPrice,
@@ -94,6 +94,11 @@ public class GroupBuyQueryService {
         // 각 정렬에 따라 cursor 유무 분기
         List<GroupBuy> entities;
         switch (orderBy) {
+            case "due_soon_only":
+                entities = groupBuyRepository.findDueSoonOnly(page);
+
+                break;
+
             case "price_asc":
                 int lastPrice = (cursorPrice != null) ? cursorPrice : 0;
                 LocalDateTime lastCreatedForPrice = (cursorCreatedAt != null)

--- a/src/main/resources/db/migration/V2__insert_dummy_data.sql
+++ b/src/main/resources/db/migration/V2__insert_dummy_data.sql
@@ -8,20 +8,20 @@ INSERT INTO users (
     type, status, joined_at, modified_at, logout_at, deleted_at
 ) VALUES (
       1,
-      'admin@moongsan.com',      -- 관리자용 이메일
-      'admin1234!',              -- 관리자용 비밀번호 (개발용 평문)
-      'adminmaster',             -- 닉네임
-      '관리자 계정',                -- 실명
-      '01099998888',             -- 전화번호
-      '카카오뱅크',                 -- 관리자 계좌 은행
-      '110123456789',            -- 계좌 번호
-      NULL,                      -- 프로필 이미지 없음
-      'ADMIN',                   -- 사용자 유형
-      'ACTIVE',                  -- 상태
-      '2025-05-01 09:00:00',     -- 가입 시각
-      '2025-05-01 09:00:00',     -- 수정 시각
-      NULL,                      -- 로그아웃 시각 없음
-      NULL                       -- 삭제 시각 없음
+      'admin@moongsan.com',
+      'admin1234!',
+      'adminmaster',
+      '관리자 계정',
+      '01099998888',
+      '카카오뱅크',
+      '110123456789',
+      NULL,
+      'ADMIN',
+      'ACTIVE',
+      '2025-05-01 09:00:00',
+      '2025-05-01 09:00:00',
+      NULL,
+      NULL
 );
 
 -- 2) category
@@ -47,7 +47,7 @@ INSERT INTO group_buy (
    '당류 0g, 칼로리 부담 없이 즐기는 탄산음료의 끝판왕! 다이어터, 건강 챙기는 분들 모두를 위한 선택! 250ml 소용량이라 휴대도 간편하고, 30개 대용량이라 나눠 마시기에도 최고!',
    'https://www.coupang.com/vp/products/2358334844?itemId=20262964509&vendorItemId=72077082095&q=부르르+제로+30&itemsCount=36&searchId=fe6fd7ae2113875&rank=6&searchRank=6&isAddedCart=',
    11700, 390, 30, 10, 20, 10,
-   TRUE, NULL, '2025-05-13 10:00:00','카카오테크 교육장','2025-05-22 17:00:00',
+   FALSE, NULL, '2025-05-13 10:00:00','카카오테크 교육장','2025-05-22 17:00:00',
    0,0,0,'OPEN', NULL, 1,'2025-05-11 10:00:00','2025-05-11 10:00:00'),
 
   (3, '🍜 짜라짜라짜짜짜 짜파게티 정품 🍜', '짜파게티 140g, 40개',
@@ -74,18 +74,9 @@ INSERT INTO image (
   ( 4, 'images/cbdd55d5-507b-4d16-93ba-f4cb924fd4ae', NULL, 0, TRUE,  3),
   ( 5, 'images/42119b97-e59f-491b-8572-c16d673076f6', NULL, 0, TRUE,  4);
 
--- 5) group_buy_category (1만 moongsanPick)
-INSERT INTO group_buy_category (
-    id, group_buy_id, category_id
-) VALUES
-  ( 1,  1, 1);
+-- 5) group_buy_category
+INSERT INTO group_buy_category (id, group_buy_id, category_id) VALUES
+  (1, 1, 1);
 
--- 6) orders
-INSERT INTO orders (
-    id, user_id, post_id, status, price, quantity, name, deleted_count, created_at, modified_at, deleted_at
-) VALUES (
-    1, 1, 40, 'PAID', 2000, 8, '박지은', 0, '2025-05-04 13:00:00', '2025-05-04 13:00:00', NULL
-);
-
--- 7) 외래키 제약 ON
+-- 6) 외래키 제약 ON
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## 🔎 작업 개요  
- 정책 기반 상태 필드인 `dueSoon`의 값이 실제 정책 기준과 일치하지 않는 문제를 해결했습니다.  
- 이에 따라 `init_schema.sql` 및 `더미 데이터`를 실 엔티티 기준으로 정비하고,  
- 빌드 설정(`build.gradle`)을 Flyway 및 테스트 환경에 맞춰 정리하였습니다.

## 🛠️ 주요 변경 사항  
### 1. 정책 기반 상태 필드(`dueSoon`) 정비
- `GroupBuyRepository` 내 `findDueSoonOnly()` JPQL 쿼리 유지
- `dueSoon` 값이 정책(`DueSoonPolicy`) 기준과 불일치하는 사례 발견
- 관련 조회 로직 로그 추가 및 정책 적용 여부 확인 로직 점검

### 2. `V1__init_schema.sql` 정비 (ORM 기준 스키마 반영)
- `orders` 테이블 생성 추가
- `deleted_at`, `deleted_count`, `modified_at`, `status` 등 공통 필드 추가
- `GroupBuy`, `Users` 등 주요 테이블 컬럼 순서 및 자료형 재정렬
- 실제 Entity 클래스와의 정합성 유지 목적

### 3. `V2__insert_dummy_data.sql` 더미 데이터 보강
- `dueSoon` 테스트를 위한 판매량(`leftAmount`, `totalAmount`) 조정
- 설명(description) 보완 및 상황별 상태 조합 다양화
- 테스트 시 사용자 흐름 검증 및 정책 테스트 가능하도록 구성

### 4. build.gradle 수정
- Flyway 의존성 명확히 추가 및 버전 고정
- 테스트/마이그레이션 환경을 고려한 의존성 정리
- 불필요하거나 중복된 의존성 제거로 빌드 속도 및 안정성 개선

### 5. GroupBuy 엔티티 및 매퍼 수정
- `dueSoon` 필드 접근 방식 점검 (`isDueSoon` vs `getDueSoon`)
- DTO 매핑 시 실제 정책 기준 값이 누락되지 않도록 매퍼 로직 보완

## ✅ 검증 방법  
- Postman으로 `GET /api/group-buys?orderBy=due_soon_only` 요청 시 `dueSoon=true`인 항목만 필터링되는지 확인
- 콘솔 로그를 통해 `dueSoon` 필드와 정책 기준 값의 일치 여부 확인
- 전체 데이터셋 대상으로 `updateDueSoonStatus()` 적용 후 상태 확인
- Flyway로 스키마 및 더미 데이터 정상 반영되는지 확인

## 🔍 머지 전 확인사항  
- 정책 기반 필드를 DB에 저장하는 방식 유지 여부 결정 필요 (추후 계산 필드 전환 가능성 고려)
- 향후 `dueSoon` 필드 갱신 주기(이벤트 기반 or 배치 처리) 논의 필요
- `V1__init_schema.sql`과 실제 운영 환경의 테이블 스키마 정합성 확인

## ➕ 이슈 링크  
- [#10 공동구매 상품 관리 기능 개선 및 확장](https://github.com/100-hours-a-week/14-YG-BE/issues/10)