### PR TITLE
feat(group-buy): temporarily change min value of hostQuantity (#10)

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
@@ -39,7 +39,7 @@ public class CreateGroupBuyRequest {
     private Integer unitAmount;
 
     @NotNull(message = "주최자 주문 수량은 필수 입력 항목입니다.")
-    @Min(value = 1, message = "주최자 주문 수량은 1 이상이어야 합니다.")
+    @Min(value = 0, message = "주최자 주문 수량은 0 이상이어야 합니다.")  /// 이후 1로 수정 필요
     private Integer hostQuantity;
 
     @NotBlank(message = "상품 상세 설명은 필수 입력 항목입니다.")


### PR DESCRIPTION
## 🔎 작업 개요
v1에서는 일반 사용자들이 직접 공구글을 작성할 수 없어 관리자가 대신 작성해야 함
이때 주최자의 구매 수량의 최소값을 1에서 0으로 조정하여 관리자가 글 생성 시 불필요한 주문이 등록되는 것을 방지

## 🛠️ 주요 변경 사항
- GroupBuy Entity에서 hostQuantity 최소값 0으로 조정

## ✅ 검증 방법
-

## 🔍 머지 전 확인사항  
- 

## ➕ 이슈 링크
- 