### PR TITLE
feat(group-buy): 게시글 상세 조회 response dto에 주최자 실명 추가(#10)

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/UserProfileResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/UserProfileResponse.java
@@ -12,6 +12,7 @@ public class UserProfileResponse {
     private String nickname;              // 닉네임
 
     // 본문
+    private String name;                  // 실명
     private String accountNumber;         // 계좌 번호
     private String accountBank;           // 은행
     private String profileImageUrl;       // 프로필 이미지

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
@@ -114,6 +114,7 @@ public class GroupBuyQueryMapper {
         return UserProfileResponse.builder()
                 .authorId(u.getId())
                 .nickname(u.getNickname())
+                .name(u.getName())
                 .accountNumber(u.getAccountNumber())
                 .accountBank(u.getAccountBank())
                 .profileImageUrl(u.getImageKey())


### PR DESCRIPTION
## 🔎 작업 개요
모달에서 주최자 실명 필요

## 🛠️ 주요 변경 사항
- 공구 게시글 상세 조회 UserProfileResponse dto에 name 추가
- UserProfileResponse 매퍼에 name 매핑

## ✅ 검증 방법
-

## 🔍 머지 전 확인사항  
- 

## ➕ 이슈 링크
- 