### PR TITLE
chore(config): WebClient, Tomcat 및 비동기 요청 타임아웃 120초로 연장

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
@@ -1,6 +1,7 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.Lob;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import org.hibernate.validator.constraints.URL;

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService.java
@@ -195,6 +195,11 @@ public class GroupBuyCommandService {
             throw new GroupBuyInvalidStateException("공구 종료는 모집 마감 이후에만 가능합니다.");
         }
 
+        // 해당 공구가 ENDED인지 조회 -> 맞으면 409
+        if (groupBuy.getPostStatus().equals("ENDED")) {
+            throw new GroupBuyInvalidStateException("이미 종료된 공구입니다.");
+        }
+
         // dueDate 이후인지 조회 -> 아니면 409
         if (groupBuy.getDueDate().isAfter(LocalDateTime.now())) {
             throw new GroupBuyInvalidStateException("공구 종료는 공구 마감 일자 이후에만 가능합니다.");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,7 @@ server.error.include-binding-errors=always
 
 logging.level.com.moogsan.moongsan_backend.global.security.jwt=DEBUG
 logging.level.org.springframework.security=DEBUG
+
+server.tomcat.connection-timeout=120s
+spring.mvc.async.request-timeout=120s
+


### PR DESCRIPTION
## 🔎 작업 개요  
AI 서버 응답 지연 가능성을 고려하여 WebClientConfig의 HttpClient 응답 타임아웃을 2분(120초)으로 수정하고, Spring Boot 내장 서버 및 비동기 요청 타임아웃을 120초로 조정했습니다.

## 🛠️ 주요 변경 사항  
- **WebClientConfig 변경**  
  - HttpClient에 `.responseTimeout(Duration.ofSeconds(120))` 설정 추가  
- **application.properties 변경**  
  - `server.tomcat.connection-timeout=120s`  
  - `spring.mvc.async.request-timeout=120s`

## ✅ 검증 방법  
- [x] WebClient를 통한 외부 호출 시 120초까지 응답 대기 확인  
- [x] 로컬 환경에서 120초 이상 지연되는 요청이 정상 유지되는지 테스트

## 🔍 머지 전 확인사항  
- WebClient 타임아웃 설정이 다른 HTTP 클라이언트 설정과 충돌 없는지 검토  
- Tomcat 커넥션 및 비동기 요청 타임아웃 조정이 서비스 전반에 미치는 영향 점검

## ➕ 이슈 링크  
- [#10 공동구매 상품 관리 기능 개선 및 확장](https://github.com/100-hours-a-week/14-YG-BE/issues/10)  