### PR TITLE
feat(group-buy): 기본 조회 limit 상향 및 모집, 종료 스케줄러 주기 수정

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyQueryController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyQueryController.java
@@ -71,7 +71,7 @@ public class GroupBuyQueryController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
             LocalDateTime cursorCreatedAt,
             @RequestParam(value = "cursorPrice", required = false) Integer cursorPrice,
-            @RequestParam(value = "limit", defaultValue = "10") Integer limit
+            @RequestParam(value = "limit", defaultValue = "2147483647") Integer limit // defaultValue = "10" 변경 필요
     ) {
         Long userId;
         if (userDetails == null || userDetails.isEmpty()) {
@@ -138,7 +138,7 @@ public class GroupBuyQueryController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
             LocalDateTime cursorCreatedAt,
             @RequestParam(value = "cursor", required = false) Long cursor,
-            @RequestParam(value = "limit", defaultValue = "10") Integer limit
+            @RequestParam(value = "limit", defaultValue = "2147483647") Integer limit // defaultValue = "10" 추가 필요
     ) {
         PagedResponse<ParticipatedListResponse> pagedResponse = groupBuyService.getGroupBuyParticipatedList(
                 userDetails.getUser().getId(), sort, cursorCreatedAt, cursor, limit);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/scheduler/GroupBuyScheduler.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/scheduler/GroupBuyScheduler.java
@@ -13,15 +13,15 @@ public class GroupBuyScheduler {
 
     private final GroupBuyCommandService groupBuyCommandService;
 
-    // 공구 게시글 dueDate 기반 자동 공구 마감 스케줄러(매일 정각에 작동)
-    @Scheduled(cron = "0 0 0 * * *")
+    // 공구 게시글 dueDate 기반 자동 공구 마감 스케줄러(매 정각(0분)과 30분에 작동)
+    @Scheduled(cron = "0 0/30 * * * *")
     public void closeExpiredGroupBuys() {
         LocalDateTime now = LocalDateTime.now();
         groupBuyCommandService.closePastDueGroupBuys(now);
     }
 
-    // 공구 게시글 pickupDate 기반 자동 공구 종료 스케줄러 (매일 01:00에 작동)
-    @Scheduled(cron = "0 0 1 * * *")
+    // 공구 게시글 pickupDate 기반 자동 공구 종료 스케줄러 (매 정각(0분)과 30분에 작동)
+    @Scheduled(cron = "0 0/30 * * * *")
     public void endPastPickupGroupBuys() {
         LocalDateTime now = LocalDateTime.now();
         groupBuyCommandService.endPastPickupGroupBuys(now);


### PR DESCRIPTION
## 🔎 작업 개요  
프론트엔드에서 커서 기반 페이지네이션을 구현하지 않은 점을 감안하여, 백엔드의 기본 조회 `limit` 값을 매우 큰 수로 상향 조정하고, 모집 마감 및 공구 종료를 처리하는 스케줄러를 매 정각(0분)과 30분에 실행되도록 수정했습니다.

## 🛠️ 주요 변경 사항  
- **기본 조회 `limit` 상향**  
  - 공구 게시글 조회 API의 기본 `limit` 값을 `1_000_000`으로 설정  
- **스케줄러 cron 표현식 변경**  
  - 모집 마감 스케줄러: `@Scheduled(cron = "0 0,30 * * * *")`  
  - 공구 종료 스케줄러: `@Scheduled(cron = "0 0,30 * * * *")`  

## ✅ 검증 방법  
- [x] 기본 `limit` 파라미터 없이 호출 시에도 최대 1,000,000건까지 정상 반환 확인  
- [x] 매 시간 0분 및 30분에 두 스케줄러가 정상 실행되어 로그에 기록되는지 확인  

## 🔍 머지 전 확인사항  
- 기본 `limit` 상향이 네트워크 및 메모리에 과도한 부하를 주지 않는지 검토  
- 스케줄러 동시 실행 시 리소스 충돌 여부 및 성능 영향 점검  

## ➕ 이슈 링크  
- [#11 스케줄러 및 페이징 개선](https://github.com/100-hours-a-week/14-YG-BE/issues/11)