### PR TITLE
fix(group-buy): 주문 취소 후 dueSoon 필드 값에도 상태 변경 반영 (#10)

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService.java
@@ -10,6 +10,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyN
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
 import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyCommandMapper;
 import com.moogsan.moongsan_backend.domain.groupbuy.mapper.ImageMapper;
+import com.moogsan.moongsan_backend.domain.groupbuy.policy.DueSoonPolicy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.exception.specific.OrderInvalidStateException;
@@ -34,6 +35,7 @@ public class GroupBuyCommandService {
     private final GroupBuyCommandMapper groupBuyCommandMapper;
     private final OrderRepository orderRepository;
     private final AiClient aiClient;
+    private final DueSoonPolicy dueSoonPolicy;
 
     /// 공구 게시글 작성
     public Long createGroupBuy(User currentUser, CreateGroupBuyRequest createGroupBuyRequest) {
@@ -156,6 +158,8 @@ public class GroupBuyCommandService {
 
         // 해당 유저의 주문을 취소
         order.setStatus("CANCELED");
+
+        groupBuy.updateDueSoonStatus(dueSoonPolicy);
 
         orderRepository.save(order);
 


### PR DESCRIPTION
## 🔎 작업 개요
주문 취소 시 해당 공동구매 글의 `dueSoon` 상태값을 즉시 반영하도록 수정

## 🛠️ 주요 변경 사항
- 주문 취소 로직 수행 후 `groupBuy.updateDueSoonStatus(dueSoonPolicy);` 호출 추가  
- `dueSoonPolicy`를 활용해 남은 수량 기반으로 `dueSoon` 플래그 재계산  
- 응답 DTO나 매퍼 변경 없이 내부 상태만 갱신

## ✅ 검증 방법
- `./gradlew clean build` 및 `bootRun` 으로 애플리케이션 정상 기동 확인  
- Postman으로 주문 취소 API 호출 후  
  - 응답에서 `data.posts[].dueSoon` 값이 변경된 것 확인  
  - 관리 콘솔 또는 직접 조회 API 호출 시 즉시 반영된 상태 확인

## 🔍 머지 전 확인사항  
- [x] 모든 단위/통합 테스트 통과  
- [x] Postman을 통한 수동 검증 완료

## ➕ 이슈 링크
- [#10 공동구매 상품 관리 기능 개선 및 확장](https://github.com/100-hours-a-week/14-YG-BE/issues/10)