### PR TITLE
feat(group-buy): 공구 설명 생성 시 사용자 세션 쿠키를 AI 요청에 포함

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/client/AiClient.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/client/AiClient.java
@@ -27,7 +27,7 @@ public class AiClient {
     /**
      * 외부 AI API 호출 → ApiResponse<DescriptionDto> 로 파싱 → DescriptionDto 추출
      */
-    public Mono<DescriptionDto> generateDescription(String url) {
+    public Mono<DescriptionDto> generateDescription(String url, String sessionId) {
         log.info("[AiClient] aiBaseUrl = {}", aiBaseUrl);
         log.info("[AiClient] full endpoint = {}", aiBaseUrl + "/generation/description");
 
@@ -37,6 +37,7 @@ public class AiClient {
 
         return webClient.post()
                 .uri(aiBaseUrl + "/generation/description")
+                .cookie("Session", sessionId)
                 .bodyValue(req)
                 .retrieve()
                 // 4xx 클라이언트 에러면 Bad Request로 매핑

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyCommandController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/GroupBuyCommandController.java
@@ -12,6 +12,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandServi
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryService;
 import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,8 @@ import reactor.core.publisher.Mono;
 import java.net.URI;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static com.moogsan.moongsan_backend.global.util.CookieUtils.extractCookie;
 
 @RestController
 @RequiredArgsConstructor
@@ -60,9 +63,12 @@ public class GroupBuyCommandController {
     // 공구 게시글 상세 설명 생성
     @PostMapping("/generation/description")
     public Mono<ResponseEntity<WrapperResponse<DescriptionDto>>> generate(
-            @RequestBody @Valid DescriptionGenerationRequest req) {
+            @RequestBody @Valid DescriptionGenerationRequest req,
+            HttpServletRequest servletRequest) {
 
-        return groupBuyService.generate(req.getUrl())
+        String sessionId = extractCookie(servletRequest, "SESSION");
+
+        return groupBuyService.generate(req.getUrl(), sessionId)
                 // 성공 시: 내부 WrapperResponse 로 감싸서 200 OK
                 .map(data -> {
                     WrapperResponse<DescriptionDto> body =

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService.java
@@ -60,8 +60,8 @@ public class GroupBuyCommandService {
 
 
     /// 공구 게시글 상세 설명 생성
-    public Mono<DescriptionDto> generate(String url) {
-        return aiClient.generateDescription(url);
+    public Mono<DescriptionDto> generate(String url, String sessionId) {
+        return aiClient.generateDescription(url, sessionId);
     }
 
 

--- a/src/main/java/com/moogsan/moongsan_backend/global/util/CookieUtils.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/util/CookieUtils.java
@@ -1,0 +1,17 @@
+package com.moogsan.moongsan_backend.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class CookieUtils {
+
+    public static String extractCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## 🔎 작업 개요  
사용자의 세션 쿠키(HTTP Only)를 외부 AI 서버 요청 시 WebClient에 포함하도록 수정했습니다.  
AI 서버가 인증된 사용자만 요청할 수 있도록 하기 위한 처리입니다.

## 🛠️ 주요 변경 사항  
- Controller에서 HttpServletRequest를 통해 `SESSION` 쿠키 추출  
- `groupBuyService.generate()` 및 `AiClient.generateDescription()` 메서드에 `sessionId` 파라미터 추가  
- WebClient 요청 시 `.cookie("SESSION", sessionId)`로 AI 서버에 전달  
- `CookieUtils` 유틸 클래스 추가하여 쿠키 추출 로직 재사용 가능하도록 분리

## ✅ 검증 방법     
- 로컬 환경에서 `./gradlew clean build` 및 `bootRun` 실행 후 정상 기동 확인

## 🔍 머지 전 확인사항  
- [x] 세션 쿠키가 실제 WebClient 요청에 포함되는지 로그로 확인  
- [x] 유효/무효 세션에 따라 AI 응답이 달라지는지 확인  

## ➕ 이슈 링크  
- [#10 공동구매 상품 관리 기능 개선 및 확장](https://github.com/100-hours-a-week/14-YG-BE/issues/10)