### PR TITLE
fix(security): 401 상황 시, 401 정상 출력하게 수정

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
@@ -34,6 +34,13 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(401);
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write("{\"message\": \"로그인이 필요합니다.\", \"data\": null}");
+                        })
+                )
                 .authorizeHttpRequests(auth -> auth
                         // 에러 핸들러 공개
                         .requestMatchers("/error", "/error/**").permitAll()


### PR DESCRIPTION
## fix(security): 401 상황 시, 401 정상 출력하게 수정

## 🔎 작업 개요
403으로 나오던 401이 401로 정상 출력 하도록 수정하였습니다

## 🛠️ 주요 변경 사항
- 403으로 나오던 401이 401로 정상 출력 하도록 securityConfig에서 변경

## ✅ 검증 방법
- build, bootrun, postman 확인 완료

## 🔍 머지 전 확인사항  
- [ ] 테스트 통과 여부

## ➕ 이슈 링크
- (#8)
