### PR TITLE
chore(group-buy): change authorId into userId, move name to userAccountResponse

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/UserAccountResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/UserAccountResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Builder
 public class UserAccountResponse {
 
+    private String name;                  // 실명
     private String accountBank;      // 주최자 계좌 은행
     private String accountNumber;    // 주최자 계좌 번호
     

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/UserProfileResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyDetail/UserProfileResponse.java
@@ -8,11 +8,10 @@ import lombok.Getter;
 public class UserProfileResponse {
 
     // 식별/메타
-    private Long authorId;                // 작성자 아이디
+    private Long userId;                // 작성자 아이디
     private String nickname;              // 닉네임
 
     // 본문
-    private String name;                  // 실명
     private String profileImageUrl;       // 프로필 이미지
 
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
@@ -129,7 +129,6 @@ public class GroupBuyQueryMapper {
         return UserProfileResponse.builder()
                 .authorId(u.getId())
                 .nickname(u.getNickname())
-                .name(u.getName())
                 .profileImageUrl(u.getImageKey())
                 .build();
     }
@@ -137,6 +136,7 @@ public class GroupBuyQueryMapper {
     // 공동구매 유저 계좌 정보 조회용 DTO
     public UserAccountResponse toHostAccount(GroupBuy gb) {
         return UserAccountResponse.builder()
+                .name(gb.getUser().getName())
                 .accountBank(gb.getUser().getAccountBank())
                 .accountNumber(gb.getUser().getAccountNumber())
                 .build();

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyHostAccountInfo.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyHostAccountInfo.java
@@ -33,6 +33,11 @@ public class GetGroupBuyHostAccountInfo {
         GroupBuy groupBuy = groupBuyRepository.findById(postId)
                 .orElseThrow(GroupBuyNotFoundException::new);
 
+        // 만약 요청한 유저가 해당 공구의 주최자라면 주문 여부 검사 없이 바로 리턴
+        if (groupBuy.getUser().getId().equals(userId)) {
+            return groupBuyQueryMapper.toHostAccount(groupBuy);
+        }
+
         // 해당 공구의 주문 테이블에 해당 유저의 주문이 존재하는지 조회 -> 아니면 404
         Order order = orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(userId, groupBuy.getId(), "CANCELED")
                 .orElseThrow(GroupBuyNotParticipantException::new);


### PR DESCRIPTION
## 🔎 작업 개요

- **호스트**(작성자)가 자신의 주문 여부 확인 없이 계정 정보를 조회할 수 있도록 기능 추가  
- 내부 식별자 변경 및 응답 구조 개선을 위해 `authorId`를 `userId`로 변경하고, `name` 필드를 `UserAccountResponse`로 이동  

---

## 🛠️ 주요 변경 사항

### 1. feat(group-buy): 호스트 계정 정보 조회 기능 추가
- 호스트가 자신이 작성한 공동구매 게시글에 대해 주문 여부와 관계없이 계정 정보를 조회할 수 있도록 API 예외 로직 조정  
  - 기존: 주문 내역이 없는 경우 조회 제한  
  - 변경: 호스트 권한 확인 로직만 남기고 `order` 체크 로직 제거  
- 관련 서비스 메서드 및 컨트롤러 코드 수정  
  - `GroupBuyService#getAccountInfoForHost(...)` 메서드 추가  
  - `GroupBuyController#getHostAccountInfo(...)` 엔드포인트 경로 및 권한 검증 로직 업데이트  

### 2. chore(group-buy): 식별자 및 응답 DTO 리팩토링 (#32)
- 엔티티·DTO 필드명 변경
  - `authorId` → `userId` (모든 관련 쿼리, 매퍼, 서비스 레이어 반영)  
- 응답 구조 수정
  - 기존: 계정 정보 응답에 `name` 필드를 포함  
  - 변경: `UserAccountResponse`로 `name` 필드 옮김  
  - `GroupBuyResponse` 및 `AccountInfoResponse`에서 `name` 필드 제거 후, `UserAccountResponse` 참조 구조로 변경  
- 관련 매퍼, 서비스, 테스트 코드에 네임스페이스 및 필드명 일괄 반영  

---

## ✅ 검증 방법

1. **호스트 계정 정보 조회**
   - 호스트로 로그인 후, `GET /api/group-buys/{groupBuyId}/host-account` 호출  
   - 해당 호스트가 주문 내역이 없는 상태에서도 **200 OK** 및 본인 계정 정보(이메일, 닉네임 등) 응답 확인  
   - 다른 사용자가 해당 엔드포인트 호출 시 **403 Forbidden** 반환 확인  

2. **식별자 및 DTO 변경**
   - 기존 `authorId`가 사용된 서비스 메서드, 쿼리 테스트 모두 통과 여부 확인  
   - `UserAccountResponse` 응답 스펙에서 `name` 필드가 정상적으로 노출되는지 확인  
   - `GroupBuyResponse` 반환 시, 기존 `name` 필드가 제거되고 `userAccount` 객체로 포함되는지 검증  

3. **통합/단위 테스트**
   - `GroupBuyService`와 `GroupBuyController` 관련 테스트 모두 성공  
   - 매퍼 테스트 내에 `authorId` → `userId` 변경 사항이 반영되어 있는지 확인  

---

## 🔍 머지 전 확인사항

- [x] `authorId` → `userId` 변경으로 인한 API 스펙 변화 여부(문서/Postman 업데이트)  
- [ ] `UserAccountResponse` 구조 변경에 따른 프론트엔드 의존성 영향 검토 및 논의  
- [ ] 호스트 권한 검증 로직 추가로 인한 Security 관련 예외 케이스 누락 확인  
- [ ] 모든 단위·통합 테스트가 통과하는지 최종 확인

---

## ➕ 관련 이슈
- 
