### PR TITLE
feat(group-buy): 주최 및 참여 공구 리스트 response에 참여자 채팅방 아이디 추가

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/repository/ChatRoomRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/repository/ChatRoomRepository.java
@@ -4,11 +4,14 @@ import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByGroupBuy_IdAndType(Long postId, String type);
+
+    List<ChatRoom> findByGroupBuy_IdInAndType(List<Long> groupBuyIds, String type);
 
     Optional<ChatRoom> findById(Long Id);
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/HostedList/HostedListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/HostedList/HostedListResponse.java
@@ -13,6 +13,7 @@ public class HostedListResponse {
 
     // 식별/메타
     private Long postId;           // 공구 게시글 아이디
+    private Long chatRoomId;       // 참여자 채팅방 아이디
     private String title;          // 공구 게시글 제목
     private String postStatus;     // 공구 진행 상태(OPEN, CLOSED, ENDED)
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipatedList/ParticipatedListResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/ParticipatedList/ParticipatedListResponse.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 public class ParticipatedListResponse {
 
     // 식별/메타
-    private Long postId;         // 공구 게시글 아이디
+    private Long postId;           // 공구 게시글 아이디
+    private Long chatRoomId;       // 참여자 채팅방 아이디
     private String title;          // 공구 게시글 제목
     private String postStatus;     // 공구 진행 상태(OPEN, CLOSED, ENDED)
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyParticipatedList.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyParticipatedList.java
@@ -1,5 +1,7 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryService;
 
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.PagedResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipatedList.ParticipatedListResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -26,6 +29,7 @@ import java.util.Map;
 public class GetGroupBuyParticipatedList {
 
     private final OrderRepository orderRepository;
+    private final ChatRoomRepository chatRoomRepository;
     private final GroupBuyQueryMapper groupBuyQueryMapper;
     private final FetchWishUtil fetchWishUtil;
 
@@ -70,8 +74,19 @@ public class GetGroupBuyParticipatedList {
                 .toList();
         Map<Long, Boolean> wishMap = fetchWishUtil.fetchWishMap(userId, groupBuys);
 
+
+        List<Long> groupBuyIds = groupBuys.stream()
+                .map(GroupBuy::getId)
+                .collect(Collectors.toList());
+
+        List<ChatRoom> chatRooms = chatRoomRepository.findByGroupBuy_IdInAndType(
+                groupBuyIds,
+                "PARTICIPANT"
+        );
+
         // DTO 매핑
-        List<ParticipatedListResponse> posts = groupBuyQueryMapper.toParticipatedListWishResponse(orders, wishMap);
+        List<ParticipatedListResponse> posts = groupBuyQueryMapper
+                .toParticipatedListWishResponse(orders, wishMap, chatRooms);
 
         // 다음 커서 및 더보기 여부
         Long nextCursor = posts.isEmpty()


### PR DESCRIPTION
## 🔎 작업 개요

- 참여·주최 공구 리스트 조회 시 `participantChatRoomId`를 응답에 포함하도록 개선
- 한 번의 `IN` 조회로 모든 참가자용 채팅방을 가져와 효율적으로 매핑

---

## 🛠️ 주요 변경 사항

1. **ChatRoom 조회 로직 개선**
   - `chatRoomRepository.findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT")` 호출로 한 번에 모든 채팅방 조회
   - 조회된 결과를 `(groupBuyId → chatRoomId)` 형태의 Map으로 변환

2. **Mapper 시그니처 확장**
   - `toParticipatedListWishResponse(List<Order> orders, Map<Long, Boolean> wishMap, List<ChatRoom> chatRooms)`
   - `toParticipatedListResponse(Order o, boolean isWish, Long participantChatRoomId)`
   - 주최 공구용 `toHostedListWishResponse`, `toHostedListResponse`도 동일하게 확장

3. **DTO 필드 추가**
   - `ParticipatedListResponse`와 `HostedListResponse`에 `participantChatRoomId: Long` 필드 추가

4. **서비스 레이어 수정**
   - `GetGroupBuyParticipatedList` 및 `GetGroupBuyHostedList`에서  
     1) `List<GroupBuy>` → `groupBuyIds` 추출  
     2) `List<ChatRoom> chatRooms = findByGroupBuy_IdInAndType(...)`  
     3) `to...WishResponse(orders/공구목록, wishMap, chatRooms)` 호출

---

## ✅ 검증 방법

1. **API 응답 확인**
   - 참여 공구 조회(`GET /participated`) 및 주최 공구 조회(`GET /hosted`) 시  
     - 각 항목에 `participantChatRoomId` 필드가 포함되어 있는지 확인  
     - 채팅방이 있는 경우 해당 ID, 없는 경우 `null` 반환 검증

2. **Mapper 단위 테스트**
   - 임의의 `orders`, `wishMap`, `chatRooms`를 사용해 결과 DTO에 올바르게 매핑되는지 확인

3. **통합 테스트**
   - 실제 DB에 데이터 세팅 후, 채팅방 유무별로 API 호출하여 응답 일치 확인

---

## 🔍 머지 전 체크리스트

- [x] `ChatRoomRepository.findByGroupBuy_IdInAndType(...)`가 `List<ChatRoom>`을 정상 반환하는지 확인
- [x] Mapper 내 Map 변환 로직에서 NPE나 누락이 없는지 검토
- [x] DTO (`ParticipatedListResponse`, `HostedListResponse`)에 `participantChatRoomId` 필드가 정상 반영되었는지 확인
- [x] 단위 및 통합 테스트 모두 통과 여부 확인

---

## ➕ 관련 이슈
- [#32 공동구매 기능 리팩토링 및 보안 개선](https://github.com/100-hours-a-week/14-YG-BE/issues/32)