### PR TITLE
feat(user): Kakao OAuth 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,16 @@
-# 1단계: Builder
-FROM python:3.11-slim AS builder
-
+FROM eclipse-temurin:21-jdk AS builder
 WORKDIR /app
+COPY gradlew gradlew.bat ./
 
-COPY requirements.txt .
-RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+RUN chmod +x gradlew
 
-# 2단계: Runtime
-FROM python:3.11-slim
+COPY build.gradle settings.gradle ./
+COPY gradle ./gradle
+COPY src ./src
+RUN ./gradlew clean bootJar -x test
 
+FROM eclipse-temurin:21-jdk
 WORKDIR /app
-
-# 런타임에는 site-packages만 복사 (실행에 필요한 패키지만)
-COPY --from=builder /usr/local/lib/python3.11 /usr/local/lib/python3.11
-COPY --from=builder /usr/local/bin /usr/local/bin
-
-# 소스코드만 선택적으로 복사 (환경 변수 제외)
-COPY app/ ./
-# 포트 명시 (선택)
-EXPOSE 8100
-
-ENTRYPOINT ["bash", "-c", "uvicorn main:app --host 0.0.0.0 --port 8100 --log-level debug --access-log | tee -a /var/log/moongsan/ai_moongsan.log"]
+RUN mkdir -p /var/moongsan/log && chown -R 1000:1000 /var/moongsan/log
+COPY --from=builder /app/build/libs/*.jar app.jar
+CMD ["sh", "-c", "java -jar app.jar | tee -a /var/moongsan/log/be_moongsan.log"]

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // or jjwt-gson
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	testImplementation 'org.mockito:mockito-inline:5.2.0'
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/component/KakaoOAuthClient.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/component/KakaoOAuthClient.java
@@ -1,0 +1,82 @@
+package com.moogsan.moongsan_backend.domain.user.component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import com.moogsan.moongsan_backend.domain.user.dto.response.KakaoTokenResponse;
+import com.moogsan.moongsan_backend.domain.user.dto.response.KakaoUserInfoResponse;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+
+    // HTTP 요청을 위한 RestTemplate 인스턴스 생성
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // application.yml 또는 properties에서 Kakao REST API 키 주입
+    @Value("${oauth.kakao.client-id}")
+    private String clientId;
+
+    // Kakao OAuth redirect URI 설정
+    @Value("${oauth.kakao.redirect-uri}")
+    private String redirectUri;
+
+    // 인가 코드를 이용해 Kakao로부터 Access Token을 요청하는 메서드
+    public KakaoTokenResponse requestAccessToken(String code) {
+        String tokenUri = "https://kauth.kakao.com/oauth/token";
+
+        // HTTP 요청 헤더 설정 (Content-Type: application/x-www-form-urlencoded)
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // 요청 본문 설정
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        // 헤더와 바디를 포함한 HTTP 요청 객체 생성
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        // POST 요청 전송 및 응답 수신
+        ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+                tokenUri,
+                HttpMethod.POST,
+                request,
+                KakaoTokenResponse.class
+        );
+
+        // 응답 본문 반환 (Access Token 포함)
+        return response.getBody();
+    }
+
+    // Access Token을 사용해 Kakao 사용자 정보를 요청하는 메서드
+    public KakaoUserInfoResponse requestUserInfo(String accessToken) {
+        String userInfoUri = "https://kapi.kakao.com/v2/user/me";
+
+        // HTTP 요청 헤더 설정 (Authorization: Bearer {accessToken})
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        // 헤더만 포함한 HTTP 요청 객체 생성
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        // GET 요청 전송 및 응답 수신
+        ResponseEntity<KakaoUserInfoResponse> response = restTemplate.exchange(
+                userInfoUri,
+                HttpMethod.GET,
+                request,
+                KakaoUserInfoResponse.class
+        );
+
+        // 응답 본문 반환 (사용자 정보 포함)
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/controller/OAuthController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/controller/OAuthController.java
@@ -1,0 +1,31 @@
+package com.moogsan.moongsan_backend.domain.user.controller;
+
+import com.moogsan.moongsan_backend.domain.WrapperResponse;
+import com.moogsan.moongsan_backend.domain.user.dto.response.LoginResponse;
+import com.moogsan.moongsan_backend.domain.user.service.KakaoOAuthService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/oauth")
+@RequiredArgsConstructor
+public class OAuthController {
+    private final KakaoOAuthService kakaoOAuthService;
+
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<WrapperResponse<?>> kakaoCallback(@RequestParam("code") String code, HttpServletResponse response) {
+        LoginResponse loginResponse = kakaoOAuthService.kakaoLogin(code, response);
+
+        return ResponseEntity.ok(
+            WrapperResponse.builder()
+                .message("로그인에 성공했습니다.")
+                .data(loginResponse)
+                .build()
+        );
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.moogsan.moongsan_backend.domain.user.dto.request.SignUpRequest;
 import com.moogsan.moongsan_backend.domain.user.dto.response.LoginResponse;
 import com.moogsan.moongsan_backend.domain.user.dto.response.CheckDuplicationResponse;
 import com.moogsan.moongsan_backend.domain.user.dto.response.UserProfileResponse;
+import com.moogsan.moongsan_backend.domain.user.mapper.BankCodeMapper;
 import com.moogsan.moongsan_backend.domain.user.service.CheckDuplicationService;
 import com.moogsan.moongsan_backend.domain.user.service.LoginService;
 import com.moogsan.moongsan_backend.domain.user.service.LogoutService;
@@ -200,7 +201,18 @@ public class UserController {
             @RequestParam String name,
             @RequestParam String accountBank,
             @RequestParam String accountNumber) {
-        checkAccountService.checkBankAccountHolder(accountBank, accountNumber, name); // matched 확인, 예외 발생 시 자동 처리
+
+        String bankCode = BankCodeMapper.getBankCode(accountBank);
+        if (bankCode == null) {
+            return ResponseEntity.badRequest().body(
+                    WrapperResponse.<Void>builder()
+                            .message("지원하지 않는 은행입니다.")
+                            .data(null)
+                            .build()
+            );
+        }
+
+        checkAccountService.checkBankAccountHolder(bankCode, accountNumber, name); // matched 확인, 예외 발생 시 자동 처리
         return ResponseEntity.ok(
                 WrapperResponse.<Void>builder()
                         .message("본인인증이 성공하였습니다.")

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/request/SignUpRequest.java
@@ -21,10 +21,11 @@ public class SignUpRequest {
     @Email(message = "이메일의 형식이 올바르지 않습니다.")
     private String email; // 이메일
 
-    @Size(min = 8, max = 30, message = "비밀번호는 8자 이상 30자 이하여야 합니다.")
+    @Size(min = 8, max = 60, message = "비밀번호는 8자 이상 30자 이하여야 합니다.")
     @Pattern(
-            regexp = "^(?=.*[!@#$%^*+=-])[A-Za-z\\d!@#$%^*+=-]{8,30}$",
-            message = "비밀번호는 8~30자이며, 반드시 하나 이상의 특수문자(!@#$%^*+=-)를 포함해야 합니다."
+            regexp = "^\\{oauth\\}-[a-f0-9\\-]{36}$|^(?=.*[!@#$%^*+=-])[A-Za-z\\d!@#$%^*+=-]{8,60}$",
+            message = "비밀번호는 8~30자이며, 반드시 하나 이상의 특수문자(!@#$%^*+=-)를 포함해야 합니다. " +
+                    "OAuth 비밀번호는 '{oauth}-UUID' 형식이어야 합니다."
     )
     private String password; // 비밀번호
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,28 @@
+package com.moogsan.moongsan_backend.domain.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private int expiresIn;
+
+    @JsonProperty("refresh_token_expires_in")
+    private int refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/response/KakaoUserInfoResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/response/KakaoUserInfoResponse.java
@@ -1,0 +1,45 @@
+package com.moogsan.moongsan_backend.domain.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Getter
+@Setter
+public class KakaoUserInfoResponse {
+
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter
+    @Setter
+    public static class KakaoAccount {
+        private String email;
+
+        @JsonProperty("profile")
+        private Profile profile;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter
+    @Setter
+    public static class Profile {
+        private String nickname;
+
+        @JsonProperty("profile_image_url")
+        private String profileImageUrl;
+
+        @JsonProperty("thumbnail_image_url")
+        private String thumbnailImageUrl;
+    }
+
+    // 유틸 메서드
+    public String getEmail() {
+        return kakaoAccount != null ? kakaoAccount.email : null;
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/response/LoginResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/response/LoginResponse.java
@@ -1,9 +1,11 @@
 package com.moogsan.moongsan_backend.domain.user.dto.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class LoginResponse {
     private String nickname;    // 닉네임

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/response/OAuthSignUpInfoResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/dto/response/OAuthSignUpInfoResponse.java
@@ -1,0 +1,11 @@
+package com.moogsan.moongsan_backend.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OAuthSignUpInfoResponse {
+    private String email;
+    private String oauthPassword;
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/entity/OAuth.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/entity/OAuth.java
@@ -1,0 +1,33 @@
+package com.moogsan.moongsan_backend.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "oauth")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OAuth {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "provider", nullable = false)
+    private String provider; // "kakao"
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId; // 카카오 고유 ID
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "refresh_token")
+    private String refreshToken; // 카카오 리프레시 토큰
+
+    @Column(name = "refresh_token_expires_in", nullable = true)
+    private Integer refreshTokenExpiresIn; // 리프레시 토큰 만료까지 남은 초
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/exception/code/UserErrorCode.java
@@ -12,6 +12,9 @@ public enum UserErrorCode implements ErrorCodeType {
     // 401 Unauthorized
     UNAUTHORIZED("UNAUTHORIZED", HttpStatus.UNAUTHORIZED, "로그인 필요"),
 
+    // 401 Signup Required
+    SIGNUP_REQUIRED("SIGNUP_REQUIRED", HttpStatus.UNAUTHORIZED, "회원가입이 필요합니다."),
+
     // 403 Forbidden
     FORBIDDEN("FORBIDDEN", HttpStatus.FORBIDDEN, "권한 없음"),
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/mapper/BankCodeMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/mapper/BankCodeMapper.java
@@ -1,0 +1,38 @@
+package com.moogsan.moongsan_backend.domain.user.mapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BankCodeMapper {
+
+    private static final Map<String, String> bankCodeMap = new HashMap<>();
+
+    static {
+        bankCodeMap.put("KB국민은행", "004");
+        bankCodeMap.put("SC제일은행", "023");
+        bankCodeMap.put("경남은행", "039");
+        bankCodeMap.put("광주은행", "034");
+        bankCodeMap.put("기업은행", "003");
+        bankCodeMap.put("농협", "011");
+        bankCodeMap.put("대구은행", "031");
+        bankCodeMap.put("부산은행", "032");
+        bankCodeMap.put("산업은행", "002");
+        bankCodeMap.put("수협", "007");
+        bankCodeMap.put("신한은행", "088");
+        bankCodeMap.put("신협", "048");
+        bankCodeMap.put("외환은행", "005");
+        bankCodeMap.put("우리은행", "020");
+        bankCodeMap.put("우체국", "071");
+        bankCodeMap.put("전북은행", "037");
+        bankCodeMap.put("제주은행", "035");
+        bankCodeMap.put("축협", "012");
+        bankCodeMap.put("하나은행", "081");
+        bankCodeMap.put("한국씨티은행", "027");
+        bankCodeMap.put("K뱅크", "089");
+        bankCodeMap.put("카카오뱅크", "090");
+    }
+
+    public static String getBankCode(String bankName) {
+        return bankCodeMap.getOrDefault(bankName, null); // 못 찾으면 null 반환
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/repository/OAuthRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/repository/OAuthRepository.java
@@ -1,0 +1,12 @@
+package com.moogsan.moongsan_backend.domain.user.repository;
+
+import com.moogsan.moongsan_backend.domain.user.entity.OAuth;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface OAuthRepository extends JpaRepository<OAuth, Long> {
+
+    Optional<OAuth> findByProviderAndProviderId(String provider, String providerId);
+
+    boolean existsByProviderAndUserId(String provider, Long userId);
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/KakaoOAuthService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/KakaoOAuthService.java
@@ -1,0 +1,116 @@
+package com.moogsan.moongsan_backend.domain.user.service;
+
+import com.moogsan.moongsan_backend.domain.user.exception.base.UserException;
+import com.moogsan.moongsan_backend.domain.user.exception.code.UserErrorCode;
+import com.moogsan.moongsan_backend.global.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import com.moogsan.moongsan_backend.domain.user.dto.response.LoginResponse;
+import com.moogsan.moongsan_backend.domain.user.dto.response.OAuthSignUpInfoResponse;
+import com.moogsan.moongsan_backend.domain.user.entity.OAuth;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import com.moogsan.moongsan_backend.domain.user.repository.OAuthRepository;
+import com.moogsan.moongsan_backend.domain.user.repository.UserRepository;
+import com.moogsan.moongsan_backend.domain.user.component.KakaoOAuthClient;
+import com.moogsan.moongsan_backend.domain.user.dto.response.KakaoTokenResponse;
+import com.moogsan.moongsan_backend.domain.user.dto.response.KakaoUserInfoResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+import com.moogsan.moongsan_backend.domain.user.entity.Token;
+import com.moogsan.moongsan_backend.domain.user.repository.TokenRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService {
+
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final UserRepository userRepository;
+    private final OAuthRepository oauthRepository;
+    private final JwtUtil jwtUtil;
+    private final TokenRepository refreshTokenRepository;
+
+    @Transactional
+    public LoginResponse kakaoLogin(String code, HttpServletResponse response) {
+        // 카카오 토큰, 정보 요청
+        KakaoTokenResponse tokenResponse = kakaoOAuthClient.requestAccessToken(code);
+        KakaoUserInfoResponse kakaoUser = kakaoOAuthClient.requestUserInfo(tokenResponse.getAccessToken());
+
+        String email = kakaoUser.getEmail();
+        String kakaoId = String.valueOf(kakaoUser.getId());
+
+        // 기존 회원 여부 확인
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+
+        if (optionalUser.isEmpty()) {
+            String dummyPassword = "{oauth}-" + java.util.UUID.randomUUID();
+            throw new UserException(
+                UserErrorCode.SIGNUP_REQUIRED,
+                "회원가입이 필요합니다.",
+                new OAuthSignUpInfoResponse(email, dummyPassword)
+            );
+        }
+        User user = optionalUser.get();
+
+        // 기존 회원인 경우 OAuth 연동 여부 확인
+        boolean isAlreadyLinked = oauthRepository.existsByProviderAndUserId("kakao", user.getId());
+
+        if (!isAlreadyLinked) {
+            // 연동되어 있지 않다면 이메일 중복 여부 확인 후 연동
+            Optional<OAuth> existingOAuth = oauthRepository.findByProviderAndProviderId("kakao", kakaoId);
+            if (existingOAuth.isEmpty()) {
+                OAuth oauth = OAuth.builder()
+                        .provider("kakao")
+                        .providerId(kakaoId)
+                        .user(user)
+                        .refreshToken(tokenResponse.getRefreshToken())
+                        .refreshTokenExpiresIn(tokenResponse.getRefreshTokenExpiresIn())
+                        .build();
+                oauthRepository.save(oauth);
+            }
+        }
+
+        // JWT 토큰 발급
+        String accessToken = jwtUtil.generateAccessToken(user);
+        String refreshToken = jwtUtil.generateRefreshToken(user);
+        Long accessTokenExpireAt = jwtUtil.getAccessTokenExpireAt();
+        Long refreshTokenExpireMillis = jwtUtil.getRefreshTokenExpireMillis();
+
+        // 기존 리프레시 토큰 DB에서 제거
+        refreshTokenRepository.deleteByUserId(user.getId());
+
+        // 새로운 리프레시 토큰 DB에 저장
+        Token newToken = new Token(
+                null,
+                user.getId(),
+                refreshToken,
+                java.time.LocalDateTime.now().plusSeconds(refreshTokenExpireMillis / 1000)
+        );
+        refreshTokenRepository.save(newToken);
+
+        // 엑세스 쿠키 설정
+        Cookie accessTokenCookie = new Cookie("AccessToken", accessToken);
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge((int) (accessTokenExpireAt / 1000));
+        response.addHeader("Set-Cookie", "AccessToken=" + accessToken + "; HttpOnly; Secure; Path=/; SameSite=None");
+
+        // 리프레시 토큰 설정
+        Cookie refreshTokenCookie = new Cookie("RefreshToken", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge((int) (refreshTokenExpireMillis / 1000));
+        response.addHeader("Set-Cookie", "RefreshToken=" + refreshToken + "; HttpOnly; Secure; Path=/; SameSite=None");
+
+        return new LoginResponse(
+                user.getNickname(),
+                user.getName(),
+                user.getImageKey(),
+                user.getType()
+        );
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/LoginService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/LoginService.java
@@ -47,7 +47,11 @@ public class LoginService {
             User user = userRepository.findByEmail(request.getEmail())
                     .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND, "이메일이 존재하지 않습니다."));
 
-            // 비밀번호 검증
+            // {oauth}로 시작하는 비밀번호는 OAuth용 계정
+            if (user.getPassword().startsWith("{oauth}-")) {
+                throw new UserException(UserErrorCode.UNAUTHORIZED, "소셜 로그인으로 가입된 계정입니다.");
+            }
+
             if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
                 throw new UserException(UserErrorCode.UNAUTHORIZED, "비밀번호가 일치하지 않습니다.");
             }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/SignUpService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/SignUpService.java
@@ -97,8 +97,11 @@ public class SignUpService {
             throw new UserException(UserErrorCode.INVALID_INPUT, "이메일의 형식이 올바르지 않습니다.");
         }
 
-        if (request.getPassword() == null || !request.getPassword().matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^*+=-])[A-Za-z\\d!@#$%^*+=-]{8,30}$")) {
-            throw new UserException(UserErrorCode.INVALID_INPUT, "비밀번호가 올바르지 않습니다.\n(숫자와 영어, 특수문자로 이루어진 8자 이상, 30자 이하의 문자열,\n특수 문자(!@#$%^*+=-) 한개 이상 입력)");
+        if (request.getPassword() == null || (
+                !request.getPassword().matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^*+=-])[A-Za-z\\d!@#$%^*+=-]{8,30}$")
+                && !request.getPassword().startsWith("{oauth}-")
+        )) {
+            throw new UserException(UserErrorCode.INVALID_INPUT, "비밀번호가 올바르지 않습니다.\n(숫자와 영어, 특수문자로 이루어진 8자 이상, 30자 이하의 문자열,\n또는 OAuth 인증 시 자동 생성된 비밀번호)");
         }
 
         if (request.getNickname() == null || request.getNickname().length() < 2 || request.getNickname().length() > 12) {

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
@@ -56,8 +56,15 @@ public class SecurityConfig {
                                 "/api/group-buys/*/participants"        // 공구 참여자 조회
                         ).authenticated()
                         .requestMatchers(
-                                "/api/users", "/api/users/token", "/api/users/check-nickname", "/api/users/check-email",
-                                "/uploads/**", "/api/group-buys/generation/description", "/api/users/check/account").permitAll() // 해당 위치 외에는 토큰 적용
+                                "/api/users",
+                                "/api/users/token",
+                                "/api/users/check-nickname",
+                                "/api/users/check-email",
+                                "/uploads/**",
+                                "/api/group-buys/generation/description",
+                                "/api/users/check/account",
+                                "/api/oauth/kakao/callback"
+                        ).permitAll() // 해당 위치 외에는 토큰 적용
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,3 +38,6 @@ logging.level.org.springframework.security=DEBUG
 
 server.tomcat.connection-timeout=120s
 spring.mvc.async.request-timeout=120s
+
+oauth.kakao.client-id=${OAUTH_KAKAO_CLIENT_ID}
+oauth.kakao.redirect-uri=${OAUTH_KAKAO_REDIRECT_URI}

--- a/src/main/resources/db/migration/V9__add_oauth_schema.sql
+++ b/src/main/resources/db/migration/V9__add_oauth_schema.sql
@@ -1,0 +1,19 @@
+-- ============================================
+-- Filename: V9_add_oauth_schema
+-- Purpose : OAuth 테이블 생성
+-- Encoding: UTF-8 (이모지, 한글 포함 대응)
+-- ============================================
+
+CREATE TABLE oauth (
+  id                        BIGINT              NOT NULL AUTO_INCREMENT,
+  user_id                   BIGINT              NOT NULL COMMENT '참조: users.id',
+  provider                  VARCHAR(20)         NOT NULL COMMENT 'google, kakao, naver 등',
+  provider_id               VARCHAR(50)         NOT NULL COMMENT '해당 OAuth 제공자에서의 고유 사용자 ID',
+  refresh_token             VARCHAR(2048)       NOT NULL COMMENT '리프레시 토큰',
+  refresh_token_expires_in  INT UNSIGNED        NOT NULL COMMENT '리프레시 토큰 만료까지 남은 초',
+  PRIMARY KEY (id),
+  INDEX idx_oauth_user (user_id),
+  CONSTRAINT fk_oauth_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB
+DEFAULT CHARSET=utf8mb4
+COMMENT='OAuth 연동 정보 테이블';


### PR DESCRIPTION
## feat(user): Kakao OAuth 2.0 추가

## 🔎 작업 개요
Kakao OAuth 추가 및 기존 로컬 계정과 연동 로직 설계, 계좌조회 시 은행코드 매핑 추가

## 🛠️ 주요 변경 사항
- Kakao OAuth 작동 추가
- OAuth 추가로 인한 비밀번호 제한 변경
- OAuth를 통한 연동 로직 추가 (연동 기준은 이메일을 기준으로 연동)
- Kakao 로그인 시, 회원가입이 안되어 있으면, 이메일과 더미비밀번호를 프론트에 전달, 회원가입 유도
- Kakao 로그인 시, 연동이 되어있지 않는 동일 이메일의 로컬 정보가 있으면 자동 연동, Kakao 로그인 가능
- Kakao 로그인 시, 토큰 발급 및 기존의 로그인 흐름을 그대로 가져감
- 계좌인증 시, 한글 은행 명 입력 받아 숫자 코드로 변환 매핑 "[은행코드](https://www.notion.so/1fbabfbf55db8085ac68fa9bd70c0716)"
- 테스트나 실행 시, env에 추가할 항목
```
# Kakao OAuth 설정 - 로컬 환경
export OAUTH_KAKAO_CLIENT_ID=6317f0b1ed13c2f34f60fe743b3b79bc
export OAUTH_KAKAO_REDIRECT_URI=http://localhost:8080/api/oauth/kakao/callback
```
```
# Kakao OAuth 설정 - 배포 환경, REDIRECT_URI 추가 필요 시, 알려주셔야 합니다
export OAUTH_KAKAO_CLIENT_ID=6317f0b1ed13c2f34f60fe743b3b79bc
export OAUTH_KAKAO_REDIRECT_URI=https://moongsan.com/api/oauth/kakao/callback
```
- Kakao 로그인 Redirect URL
- 아래의 URL을 버튼으로 연결해주시면 될 것 같습니다.
- 테스트 시에도 해당 링크로 들어가서 로그인 해주시면 됩니다.

- 로컬 환경
```
https://kauth.kakao.com/oauth/authorize?response_type=code
&client_id=6317f0b1ed13c2f34f60fe743b3b79bc
&redirect_uri=http://localhost:8080/api/oauth/kakao/callback
```
- 배포 환경
```
https://kauth.kakao.com/oauth/authorize?response_type=code
&client_id=6317f0b1ed13c2f34f60fe743b3b79bc
&redirect_uri=https://moongsan.com/api/oauth/kakao/callback
```

## ✅ 검증 방법
- ./gradlew build 확인
- java -jar build/libs/moongsan-backend-0.0.1-SNAPSHOT.jar 확인
- 위의 url을 통한 회원가입, 로그인, 연동을 db를 통해 확인
- oauth를 이용하여 발급한 쿠키로 postman 확인

## 🔍 머지 전 확인사항  
- [ ] 테스트 통과 여부

## ➕ 이슈 링크
- (#92)
