### PR TITLE
chore(group-buy): DetailResponse 매핑에서 chatRoomId null-safe 처리

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
@@ -101,9 +101,13 @@ public class GroupBuyQueryMapper {
                         .build())
                 .toList();
 
+        Long chatRoomId = gb.getParticipantChatRoom() != null
+                          ? gb.getParticipantChatRoom().getId()
+                          : null;
+
         return DetailResponse.builder()
                 .postId(gb.getId())
-                .chatRoomId(gb.getParticipantChatRoom().getId())
+                .chatRoomId(chatRoomId)
                 .title(gb.getTitle())
                 .name(gb.getName())
                 .postStatus(gb.getPostStatus())


### PR DESCRIPTION
## 🔎 작업 개요
- `toDetailResponse` 호출 시 `participantChatRoom`이 없으면 `chatRoomId`를 `null`로 반환하도록 수정해 NPE 방지

## 🛠️ 주요 변경 사항
- `DetailResponse` 빌더 로직에 `participantChatRoom` null 체크 추가  
- Optional 또는 삼항 연산자를 활용해 null-safe 매핑 구현

## ✅ 검증 방법
1. `participantChatRoom`이 있는 경우 → 기존처럼 `chatRoomId` 값 정상 출력  
2. `participantChatRoom`이 없는 경우 → `chatRoomId`가 `null`로 매핑되는지 확인  
3. `./gradlew test` 실행 시 모든 테스트 통과

## 🔍 머지 전 확인사항
- null-safe 처리로 다른 필드 매핑에 영향 없는지 확인

## ➕ 관련 이슈
- [#32 BE - GroupBuy 도메인 구조 개선 및 예외 처리](https://github.com/100-hours-a-week/14-YG-BE/issues/32)
