### PR TITLE
feat(chatting): 롱폴링 기반 유지, SSE 도입

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacade.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacade.java
@@ -23,7 +23,7 @@ public interface ChattingQueryFacade {
             String lastMessageId
     );
 
-    SseEmitter getLatesetMessagesSse(
+    SseEmitter getLatestMessagesSse(
             User currentUser,
             Long chatRoomId,
             String lastMessageId

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacadeImpl.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacadeImpl.java
@@ -22,7 +22,7 @@ public class ChattingQueryFacadeImpl implements ChattingQueryFacade{
 
     private final GetPastMessages getPastMessages;
     private final GetLatestMessages getLatestMessages;
-    private final GetLatestMessageSse getLatesetMessagesSse;
+    private final GetLatestMessageSse getLatestMessagesSse;
     private final GetChatRoomList getChatRoomList;
 
     @Override
@@ -40,10 +40,10 @@ public class ChattingQueryFacadeImpl implements ChattingQueryFacade{
         return getLatestMessages.getLatesetMessages(currentUser, chatRoomId, lastMessageId);
     }
 
-    public SseEmitter getLatesetMessagesSse(
+    public SseEmitter getLatestMessagesSse(
             User currentUser, Long chatRoomId, String lastMessageId
     ) {
-        return getLatesetMessagesSse.getLatesetMessagesSse(currentUser, chatRoomId, lastMessageId);
+        return getLatestMessagesSse.getLatestMessagesSse(currentUser, chatRoomId, lastMessageId);
     }
 
     public List<ChatRoomResponse> getChatRoomList (Long userId, LocalDateTime cursorJoinedAt, Long cursorId, Integer limit) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetLatestMessagesSseController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetLatestMessagesSseController.java
@@ -1,11 +1,29 @@
 package com.moogsan.moongsan_backend.domain.chatting.controller.query;
 
+import com.moogsan.moongsan_backend.domain.WrapperResponse;
+import com.moogsan.moongsan_backend.domain.chatting.Facade.query.ChattingQueryFacade;
+import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatMessageResponse;
+import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.async.DeferredResult;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chats/participant")
 public class GetLatestMessagesSseController {
+    private final ChattingQueryFacade chattingQueryFacade;
+
+    @GetMapping("/{chatRoomId}/sse/latest")
+    public SseEmitter getLatestMessagesSse(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long chatRoomId,
+            @RequestParam(required = false) String lastMessageId
+    ) {
+        return chattingQueryFacade.getLatestMessagesSse(userDetails.getUser(), chatRoomId, lastMessageId);
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/CreateChatMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/CreateChatMessage.java
@@ -11,6 +11,7 @@ import com.moogsan.moongsan_backend.domain.chatting.mapper.ChatMessageCommandMap
 import com.moogsan.moongsan_backend.domain.chatting.repository.ChatMessageRepository;
 import com.moogsan.moongsan_backend.domain.chatting.repository.ChatParticipantRepository;
 import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
+import com.moogsan.moongsan_backend.domain.chatting.service.query.GetLatestMessageSse;
 import com.moogsan.moongsan_backend.domain.chatting.service.query.GetLatestMessages;
 import com.moogsan.moongsan_backend.domain.chatting.util.MessageSequenceGenerator;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
@@ -33,6 +34,7 @@ public class CreateChatMessage {
     private final MessageSequenceGenerator messageSequenceGenerator;
     private final ChatMessageCommandMapper chatMessageCommandMapper;
     private final GetLatestMessages getLatestMessages;
+    private final GetLatestMessageSse getLatestMessageSse;
 
     public void createChatMessage(User currentUser, CreateChatMessageRequest request, Long chatRoomId) {
 
@@ -65,6 +67,18 @@ public class CreateChatMessage {
                 .toMessageDocument(chatRoom, participant.getId(), request, nextSeq);
         SecurityContext context = SecurityContextHolder.getContext();
         chatMessageRepository.save(document);
+
+        // 롱 폴링
         getLatestMessages.notifyNewMessage(document, currentUser.getNickname(), currentUser.getImageKey(), context);
+
+        // sse
+        /*
+        getLatestMessageSse.notifyNewMessageSse(
+                document,
+                currentUser.getNickname(),
+                currentUser.getImageKey(),
+                context
+        );
+         */
     }
 }


### PR DESCRIPTION
## 🔎 작업 개요
- 기존 DeferredResult 기반 롱폴링 이외에 SseEmitter 기반 SSE를 추가했습니다. 다만 프론트엔드의 작업을 위해 현재 시점에서의 기본 방식은 롱 폴링으로 그대로 유지됩니다.

---

## 🛠️ 주요 변경 사항

1. **SSE 서비스 로직 추가**  
   - `GetLatestMessageSse` 클래스에 `SseEmitter` 생성·등록 및 제거 로직 구현  
   - `notifyNewMessage`에서 `SseEmitter.event()`로 `"new-message"` 이벤트 푸시  

2. **롱폴링 관련 코드 유지**  
   - DeferredResult 기반 메서드 및 관련 콜백 유지  
   - `GetLatestMessages` 서비스의 롱폴링 전용 코드 유지

3. **보안 컨텍스트 전파 보장**  
   - `DelegatingSecurityContextRunnable` 적용하여 Spring SecurityContext를 가상 스레드에서도 안전하게 유지  

4. **컨트롤러 매핑 수정**  
   - `/api/chats/participant/{chatRoomId}/sse/latest` 엔드포인트로 SSE 연결  
   - `ChattingQueryFacade#getLatestMessagesSse` 호출하도록 추가  

---

## ✅ 검증 방법

- **SSE 연결 테스트**  
  - 클라이언트에서 `new EventSource("/api/chats/participant/{chatRoomId}/sse/latest")` 생성 후  
    `"new-message"` 이벤트 정상 수신 확인  

- **SecurityContext 유지 확인**  
  - 메시지 전송 시 인증된 사용자 정보가 로그·응답에 반영되는지 검증  

- **타임아웃·종료 처리**  
  - 클라이언트 연결 종료 시 emitter가 제거되어 메모리 누수 없는지 확인  

---

## 🔍 머지 전 확인사항

- 롱폴링 관련 모든 레거시 코드 유지됨 (프론트 작업 위함) 
- `TIMEOUT_MILLIS` 설정 및 `SseEmitter` 타임아웃 로직 적절성  
- 예외 발생 시 `completeWithError` 처리 일관성  
- 클라이언트 측 구독 해제 시나리오 검증  

---

## ➕ 이슈 링크

- [#93 BE - 실시간 참여자 채팅 서버 구축](https://github.com/100-hours-a-week/14-YG-BE/issues/93)
