### PR TITLE
feat(order): "주문 생성 시, 채팅방 참여"

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderCreateService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderCreateService.java
@@ -1,5 +1,6 @@
 package com.moogsan.moongsan_backend.domain.order.service;
 
+import com.moogsan.moongsan_backend.domain.chatting.Facade.command.ChattingCommandFacade;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.policy.DueSoonPolicy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
@@ -23,6 +24,7 @@ public class OrderCreateService {
     private final GroupBuyRepository groupBuyRepository;
     private final OrderRepository orderRepository;
     private final DueSoonPolicy dueSoonPolicy;
+    private final ChattingCommandFacade chattingCommandFacade;
 
     // 주문 생성 서비스
     @Transactional
@@ -80,6 +82,7 @@ public class OrderCreateService {
 
         groupBuyRepository.save(groupBuy);
         orderRepository.save(order);
+        chattingCommandFacade.joinChatRoom(user, groupBuy.getId());
 
         return OrderCreateResponse.builder()
             .productName(groupBuy.getName())

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/LoginService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/LoginService.java
@@ -11,7 +11,6 @@ import com.moogsan.moongsan_backend.domain.user.repository.UserRepository;
 import com.moogsan.moongsan_backend.global.security.jwt.JwtUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -56,10 +55,6 @@ public class LoginService {
                 throw new UserException(UserErrorCode.UNAUTHORIZED, "비밀번호가 일치하지 않습니다.");
             }
 
-            // 탈퇴 복구 및 마지막 로그인 시간 기록
-            if (user.getDeletedAt() != null) {
-                user.setDeletedAt(null);
-            }
             user.setLastLoginAt();
 
             // JWT 토큰 발급

--- a/src/test/java/com/moogsan/moongsan_backend/unit/order/service/OrderCreateServiceTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/order/service/OrderCreateServiceTest.java
@@ -1,5 +1,6 @@
 package com.moogsan.moongsan_backend.unit.order.service;
 
+import com.moogsan.moongsan_backend.domain.chatting.Facade.command.ChattingCommandFacade;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.policy.DueSoonPolicy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
@@ -31,6 +32,7 @@ class OrderCreateServiceTest {
     @Mock private GroupBuyRepository groupBuyRepository;
     @Mock private OrderRepository orderRepository;
     @Mock private DueSoonPolicy dueSoonPolicy;
+    @Mock private ChattingCommandFacade chattingCommandFacade;
 
     private final Long userId = 1L;
     private final Long postId = 10L;


### PR DESCRIPTION
## feat(order): "주문 생성 시, 채팅방 참여"

## 🔎 작업 개요
feat(order): "주문 생성 시, 채팅방 참여"

## 🛠️ 주요 변경 사항
- 카카오 로그아웃 테스트 완료 -> 기존 로그아웃과 로직 일치, 변경 없음
- 주문 생성 시, 채팅방 참여
- 로그인 시 deleted_at 기록하던 부분 삭제

## ✅ 검증 방법
- build, 실행 확인
- postman 실행 확인
- 주문을 생성한 참여자가 db상으로 해당 채팅방에 참여되어 있는 것을 확인

## 🔍 머지 전 확인사항  
- [x] 테스트 통과 여부

## ➕ 이슈 링크
- #107 
