### PR TITLE
feat(chatting): SSE·롱폴링 가상 스레드 전환 및 OSIV 필터 개선

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacade.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacade.java
@@ -17,7 +17,7 @@ public interface ChattingQueryFacade {
             String cursorId
     );
 
-    DeferredResult<List<ChatMessageResponse>> getLatesetMessages(
+    DeferredResult<List<ChatMessageResponse>> getLatestMessages(
             User currentUser,
             Long chatRoomId,
             String lastMessageId
@@ -25,8 +25,7 @@ public interface ChattingQueryFacade {
 
     SseEmitter getLatestMessagesSse(
             User currentUser,
-            Long chatRoomId,
-            String lastMessageId
+            Long chatRoomId
     );
 
     List<ChatRoomResponse> getChatRoomList (

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetLatestMessagesController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetLatestMessagesController.java
@@ -35,7 +35,7 @@ public class GetLatestMessagesController {
 
         // -- (B) Service로부터 rawResult 획득 (여긴 5초 타임아웃)
         DeferredResult<List<ChatMessageResponse>> rawResult =
-                chattingQueryFacade.getLatesetMessages(userDetails.getUser(), chatRoomId, lastMessageId);
+                chattingQueryFacade.getLatestMessages(userDetails.getUser(), chatRoomId, lastMessageId);
 
         // ─────────────────────────────────────────────────────────────────────────────
         // (1) rawResult가 정상적으로 메시지를 반환할 때

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetLatestMessagesSseController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetLatestMessagesSseController.java
@@ -3,6 +3,7 @@ package com.moogsan.moongsan_backend.domain.chatting.controller.query;
 import com.moogsan.moongsan_backend.domain.WrapperResponse;
 import com.moogsan.moongsan_backend.domain.chatting.Facade.query.ChattingQueryFacade;
 import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatMessageResponse;
+import com.moogsan.moongsan_backend.domain.chatting.service.query.GetLatestMessageSse;
 import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,9 +22,13 @@ public class GetLatestMessagesSseController {
     @GetMapping("/{chatRoomId}/sse/latest")
     public SseEmitter getLatestMessagesSse(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long chatRoomId,
-            @RequestParam(required = false) String lastMessageId
+            @PathVariable Long chatRoomId
     ) {
-        return chattingQueryFacade.getLatestMessagesSse(userDetails.getUser(), chatRoomId, lastMessageId);
+        return chattingQueryFacade.getLatestMessagesSse(userDetails.getUser(), chatRoomId);
+        // 1) DB 조회 · 검증 (트랜잭션 경계 안에서만 수행)
+        // getLatestMessageSse.validateParticipant(userDetails.getUser(), chatRoomId);
+
+        // 2) 검증 이후, 완전히 트랜잭션 닫힌 다음에야 Emitter 생성
+        // return getLatestMessageSse.createEmitter(chatRoomId);
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/CreateChatMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/CreateChatMessage.java
@@ -79,6 +79,7 @@ public class CreateChatMessage {
                 currentUser.getImageKey(),
                 context
         );
+
          */
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/JoinChatRoom.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/JoinChatRoom.java
@@ -39,12 +39,6 @@ public class JoinChatRoom {
         Boolean isHost = groupBuy.getUser().getId().equals(currentUser.getId());
 
         if (!isHost) {
-            // 해당 공구가 OPEN인지 조회, dueDate가 현재 이후인지 조회 -> 아니면 409
-            if (!groupBuy.getPostStatus().equals("OPEN")
-                    || groupBuy.getDueDate().isBefore(LocalDateTime.now())) {
-                throw new GroupBuyInvalidStateException("채팅방 참여는 공구가 열려있는 상태에서만 가능합니다.");
-            }
-
             // 해당 공구의 주문 테이블에 해당 유저의 주문이 존재하는지 조회 -> 아니면 404
             Order order = orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(currentUser.getId(), groupBuy.getId(), "CANCELED")
                     .orElseThrow(() -> new OrderNotFoundException("공구의 참여자만 참가 가능합니다."));

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessageSse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessageSse.java
@@ -79,6 +79,7 @@ public class GetLatestMessageSse {
             };
 
             Runnable securedTask = new DelegatingSecurityContextRunnable(task, context);
+            // securedTask.run();
             Thread.startVirtualThread(securedTask); // 새로운 Loom 가상 스레드를 띄워서 r.setResult(...)를 비동기적으로 실행
         }
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessageSse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessageSse.java
@@ -38,7 +38,7 @@ public class GetLatestMessageSse {
     private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     public SseEmitter getLatestMessagesSse(
-            User currentUser, Long chatRoomId, String lastMessageId
+            User currentUser, Long chatRoomId
     ) {
         // 채팅방 조회 -> 없으면 404
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
@@ -102,4 +102,3 @@ public class GetLatestMessageSse {
         }
     }
 }
-

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessages.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessages.java
@@ -93,8 +93,8 @@ public class GetLatestMessages {
             };
 
             Runnable securedTask = new DelegatingSecurityContextRunnable(task, context);
-            securedTask.run(); // 현재 스레드에서 즉시 실행 (r.setResult(...)가 현재 스레드에서 동기적 실행
-            // Thread.startVirtualThread(securedTask); // 새로운 Loom 가상 스레드를 띄워서 r.setResult(...)를 비동기적으로 실행
+            // securedTask.run(); // 현재 스레드에서 즉시 실행 (r.setResult(...)가 현재 스레드에서 동기적 실행
+            Thread.startVirtualThread(securedTask); // 새로운 Loom 가상 스레드를 띄워서 r.setResult(...)를 비동기적으로 실행
         }
 
         results.clear();

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/ConditionalOsivFilter.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/ConditionalOsivFilter.java
@@ -1,0 +1,13 @@
+package com.moogsan.moongsan_backend.global.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConditionalOsivFilter extends OpenEntityManagerInViewFilter {
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return request.getRequestURI().endsWith("/latest");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,7 @@ server.tomcat.connection-timeout=120s
 spring.mvc.async.request-timeout=120s
 
 spring.datasource.hikari.maximum-pool-size=250
+spring.datasource.hikari.leak-detection-threshold=5000
 
 server.tomcat.threads.max=300
 server.tomcat.threads.min-spare=30


### PR DESCRIPTION
## 🔎 작업 개요
- **DB 커넥션 수명 최소화**를 위해 **SSE·롱폴링 엔드포인트에서만 OSIV(Open-Session-In-View) 비활성화**  
- OSIV 제거 과정에서 발생한 **`401 Unauthorized` 문제**를 별도 필터로 해결  
- **부하 테스트** 결과를 반영해 **DeferredResult·SseEmitter 처리 스레드를 JDK 21 Virtual Thread**로 전환  
- **HikariCP 누수 감지**를 위해 `spring.datasource.hikari.leak-detection-threshold=5000` 추가  

---

## 🛠️ 주요 변경 사항
1. **OSIV 필터 개선**  
   - `OsivExclusionFilter`(커스텀 `OncePerRequestFilter`) 추가  
     - `/api/chats/**/latest` 경로에서만 `OpenSessionInViewFilter`를 건너뛰도록 구현  
   - `shouldNotFilter` 로직 분리로 인증 필터 체인은 그대로 유지 → 401 문제 해결  

2. **Virtual Thread 적용**  
   - `spring.threads.virtual.enabled=true` 설정  
   - `Executors.newVirtualThreadPerTaskExecutor()` 기반으로  
     - **DeferredResult** 롱폴링 콜백  
     - **SseEmitter** 비동기 이벤트 전송 로직 실행  

3. **SSE 서비스 로직 추가**  
   - `GetLatestMessageSse` 서비스 클래스  
     - `SseEmitter` 등록·제거 및 `"new-message"` 이벤트 푸시  
   - 신규 엔드포인트 `GET /api/chats/participant/{chatRoomId}/sse/latest` 매핑  

4. **롱폴링 코드 유지·보완**  
   - 기존 `GetLatestMessages`(DeferredResult) 로직 그대로 유지해 프론트 호환성 확보  
   - Virtual Thread 환경에 맞춰 `DelegatingSecurityContextRunnable` 적용으로 SecurityContext 전파  

5. **HikariCP 설정 강화**  
   - `spring.datasource.hikari.leak-detection-threshold=5000` → 5초 이상 점유 커넥션 경고 로그 출력  

---

## ✅ 검증 방법
- **동시 접속 부하 테스트**  
  - Locust 200 VU로 SSE·롱폴링 각각 연결 → DB 풀 사용률·응답 지연 모니터링  
- **SecurityContext 유지 확인**  
  - 인증 사용자로 메시지 전송 → 로그에 사용자 ID 반영 여부 확인  
- **OSIV 제외 검증**  
  - `/latest` 호출 시 Lazy Loading 금지, DB 커넥션 즉시 반환 여부 확인  
- **Hikari 누수 감지**  
  - 5초 이상 커넥션 점유 시 경고 로그 발생하는지 확인  

---

## 🔍 머지 전 확인사항
- 글로벌 `spring.jpa.open-in-view=true` 유지 여부 확인 (다른 API 영향 X)  
- `TIMEOUT_MILLIS` / `SseEmitter` 타임아웃 전략 확정 필요  
- 클라이언트 구독 해제 시 emitter 정리 로직 정상 동작 확인  
- Virtual Thread 사용 시 JVM 옵션 및 모니터링 도구 대응 점검  

---

## ➕ 이슈 링크
- [#93 BE - 실시간 참여자 채팅 서버 구축](https://github.com/100-hours-a-week/14-YG-BE/issues/93)