### PR TITLE
 feat(group-buy): 그룹구매 목록 응답 count 필드 명확화

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacade.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacade.java
@@ -17,7 +17,7 @@ public interface ChattingQueryFacade {
             String cursorId
     );
 
-    DeferredResult<List<ChatMessageResponse>> getLatesetMessages(
+    DeferredResult<List<ChatMessageResponse>> getLatestMessages(
             User currentUser,
             Long chatRoomId,
             String lastMessageId
@@ -25,8 +25,7 @@ public interface ChattingQueryFacade {
 
     SseEmitter getLatestMessagesSse(
             User currentUser,
-            Long chatRoomId,
-            String lastMessageId
+            Long chatRoomId
     );
 
     List<ChatRoomResponse> getChatRoomList (

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetLatestMessagesController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetLatestMessagesController.java
@@ -35,7 +35,7 @@ public class GetLatestMessagesController {
 
         // -- (B) Service로부터 rawResult 획득 (여긴 5초 타임아웃)
         DeferredResult<List<ChatMessageResponse>> rawResult =
-                chattingQueryFacade.getLatesetMessages(userDetails.getUser(), chatRoomId, lastMessageId);
+                chattingQueryFacade.getLatestMessages(userDetails.getUser(), chatRoomId, lastMessageId);
 
         // ─────────────────────────────────────────────────────────────────────────────
         // (1) rawResult가 정상적으로 메시지를 반환할 때

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetLatestMessagesSseController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetLatestMessagesSseController.java
@@ -3,6 +3,7 @@ package com.moogsan.moongsan_backend.domain.chatting.controller.query;
 import com.moogsan.moongsan_backend.domain.WrapperResponse;
 import com.moogsan.moongsan_backend.domain.chatting.Facade.query.ChattingQueryFacade;
 import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatMessageResponse;
+import com.moogsan.moongsan_backend.domain.chatting.service.query.GetLatestMessageSse;
 import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,9 +22,13 @@ public class GetLatestMessagesSseController {
     @GetMapping("/{chatRoomId}/sse/latest")
     public SseEmitter getLatestMessagesSse(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long chatRoomId,
-            @RequestParam(required = false) String lastMessageId
+            @PathVariable Long chatRoomId
     ) {
-        return chattingQueryFacade.getLatestMessagesSse(userDetails.getUser(), chatRoomId, lastMessageId);
+        return chattingQueryFacade.getLatestMessagesSse(userDetails.getUser(), chatRoomId);
+        // 1) DB 조회 · 검증 (트랜잭션 경계 안에서만 수행)
+        // getLatestMessageSse.validateParticipant(userDetails.getUser(), chatRoomId);
+
+        // 2) 검증 이후, 완전히 트랜잭션 닫힌 다음에야 Emitter 생성
+        // return getLatestMessageSse.createEmitter(chatRoomId);
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/CreateChatMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/CreateChatMessage.java
@@ -79,6 +79,7 @@ public class CreateChatMessage {
                 currentUser.getImageKey(),
                 context
         );
+
          */
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/JoinChatRoom.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/JoinChatRoom.java
@@ -39,12 +39,6 @@ public class JoinChatRoom {
         Boolean isHost = groupBuy.getUser().getId().equals(currentUser.getId());
 
         if (!isHost) {
-            // 해당 공구가 OPEN인지 조회, dueDate가 현재 이후인지 조회 -> 아니면 409
-            if (!groupBuy.getPostStatus().equals("OPEN")
-                    || groupBuy.getDueDate().isBefore(LocalDateTime.now())) {
-                throw new GroupBuyInvalidStateException("채팅방 참여는 공구가 열려있는 상태에서만 가능합니다.");
-            }
-
             // 해당 공구의 주문 테이블에 해당 유저의 주문이 존재하는지 조회 -> 아니면 404
             Order order = orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(currentUser.getId(), groupBuy.getId(), "CANCELED")
                     .orElseThrow(() -> new OrderNotFoundException("공구의 참여자만 참가 가능합니다."));

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessageSse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessageSse.java
@@ -79,6 +79,7 @@ public class GetLatestMessageSse {
             };
 
             Runnable securedTask = new DelegatingSecurityContextRunnable(task, context);
+            // securedTask.run();
             Thread.startVirtualThread(securedTask); // 새로운 Loom 가상 스레드를 띄워서 r.setResult(...)를 비동기적으로 실행
         }
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessageSse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessageSse.java
@@ -38,7 +38,7 @@ public class GetLatestMessageSse {
     private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     public SseEmitter getLatestMessagesSse(
-            User currentUser, Long chatRoomId, String lastMessageId
+            User currentUser, Long chatRoomId
     ) {
         // 채팅방 조회 -> 없으면 404
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
@@ -102,4 +102,3 @@ public class GetLatestMessageSse {
         }
     }
 }
-

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessages.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessages.java
@@ -93,8 +93,8 @@ public class GetLatestMessages {
             };
 
             Runnable securedTask = new DelegatingSecurityContextRunnable(task, context);
-            securedTask.run(); // 현재 스레드에서 즉시 실행 (r.setResult(...)가 현재 스레드에서 동기적 실행
-            // Thread.startVirtualThread(securedTask); // 새로운 Loom 가상 스레드를 띄워서 r.setResult(...)를 비동기적으로 실행
+            // securedTask.run(); // 현재 스레드에서 즉시 실행 (r.setResult(...)가 현재 스레드에서 동기적 실행
+            Thread.startVirtualThread(securedTask); // 새로운 Loom 가상 스레드를 띄워서 r.setResult(...)를 비동기적으로 실행
         }
 
         results.clear();

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
@@ -107,7 +107,7 @@ public class GetGroupBuyListByCursor {
         }
 
         return PagedResponse.<BasicListResponse>builder()
-                .count(posts.size())
+                .count(result.getTotalElements())
                 .posts(posts)
                 .nextCursor(nextCursorId != null ? nextCursorId.intValue() : null)
                 .nextCursorPrice(nextCursorPrice)

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/ConditionalOsivFilter.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/ConditionalOsivFilter.java
@@ -1,0 +1,13 @@
+package com.moogsan.moongsan_backend.global.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConditionalOsivFilter extends OpenEntityManagerInViewFilter {
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return request.getRequestURI().endsWith("/latest");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,7 @@ server.tomcat.connection-timeout=120s
 spring.mvc.async.request-timeout=120s
 
 spring.datasource.hikari.maximum-pool-size=250
+spring.datasource.hikari.leak-detection-threshold=5000
 
 server.tomcat.threads.max=300
 server.tomcat.threads.min-spare=30


### PR DESCRIPTION
## 🔎 작업 개요

커서 기반 그룹 구매 목록 API에서 `PagedResponse.count` 필드에 사용되던 `result.getSize()`는  
**현재 페이지의 항목 수**만을 의미하고 있어, 실제 전체 개수와는 차이가 있었습니다.

이번 작업에서는 해당 필드를 **전체 조건에 부합하는 데이터 개수**로 명확하게 정의하기 위해  
`result.getTotalElements()`로 변경하였습니다.

---

## 🛠️ 주요 변경 사항

1. **count 계산 방식 변경**
   - 기존: `count(result.getSize())`  
     → 현재 페이지의 item 수 (ex. limit이 10이면 항상 10)
   - 변경: `count(result.getTotalElements())`  
     → 조건에 맞는 전체 group buy 게시글 수 반환

2. **응답 의미 명확화**
   - 프론트에서 페이지네이션 UI 구성 시 총 개수 기반으로 총 페이지 수 계산 가능

3. **일부 코드 변경**
    - 부하 테스트 중 롱폴링(일반, 버추얼 플랫폼), SSE(일반, 버추얼 플랫폼) 검증에 필요한 일부 코드를 변경하였습니다

---

## ✅ 검증 방법

- 다양한 조건 (`keyword`, `categoryId`, `openOnly`, etc.) 조합으로 요청 후 `count` 정확성 확인
- 프론트에서 `posts.length`, `count`, `hasMore`의 불일치 여부 확인
- 테스트 케이스에서 반환된 `count` 값이 실제 DB 조건 필터링과 일치하는지 검증

---

## 🔍 머지 전 확인사항

- [x] 커서 기반 페이징에서 `count`가 반드시 필요한지, 성능 상 문제가 없는지 재검토
- [x] 클라이언트에서 해당 필드를 실제로 사용하는지 확인
- [x] 향후 성능 이슈 발생 시 count 필드를 조건부 응답 또는 제거하는 방안 고려

---

## ➕ 이슈 링크

- [#32 공동구매 기능 리팩토링 및 보안 개선](https://github.com/100-hours-a-week/14-YG-BE/issues/32)
