### PR TITLE
GroupBuy 업데이트용 조회 시 URL 추가 반환 및 MockMvc 설정 보완

### DIFF
--- a/config/application-secrets.yml
+++ b/config/application-secrets.yml
@@ -9,7 +9,7 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    driver-class-name: ${DB_DRIVER}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   data:
     mongodb:
       database: ${MONGO_DB}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyUpdate/GroupBuyForUpdateResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyUpdate/GroupBuyForUpdateResponse.java
@@ -19,6 +19,7 @@ public class GroupBuyForUpdateResponse {
 
     // 본문
     private String description;            // 공구 상세 설명
+    private String url;                    // 공구 상품 URL
     private List<ImageResponse> imageKeys; // 이미지 URL 리스트
     private LocalDateTime dueDate;         // 마감 일자
     private String location;               // 거래 장소

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyQueryMapper.java
@@ -39,6 +39,7 @@ public class GroupBuyQueryMapper {
                 .title(gb.getTitle())
                 .name(gb.getName())
                 .description(gb.getDescription())
+                .url(gb.getUrl())
                 .imageKeys(imageUrls)
                 .hostQuantity(gb.getHostQuantity())
                 .leftAmount(gb.getLeftAmount() + gb.getHostQuantity())

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyHostAccountInfoTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyHostAccountInfoTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(GroupBuyHostAccountController.class)
+@AutoConfigureMockMvc(addFilters = false)
 public class GetGroupBuyHostAccountInfoTest {
 
     @Autowired

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyHostedListTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyHostedListTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = GroupBuyHostedListController.class)
 @ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
 class GetGroupBuyHostedListTest {
 
     @Autowired


### PR DESCRIPTION
## 🔎 작업 개요
- `GroupBuy` 업데이트 URL 리턴 기능 추가 및 MockMvc 설정 보완
- 드라이버 이름 입력 방식을 변수 전달에서 직접 입력으로 분기 처리

---

## 🛠️ 주요 변경 사항
1. update groupbuy API 호출 후 반환된 URL 리턴 기능 구현
2. @AutoConfigureMockMvc` 어노테이션 추가하여 컨트롤러 테스트 설정 보완  
3. 드라이버 이름 입력을 변수 파라미터 대신 Interactive Prompt로 전환  

---

## ✅ 검증 방법
- [x] `./gradlew clean test` 를 통해 모든 유닛·통합 테스트 통과 확인  
- [x] Postman을 이용해 공구 수정용 상세 응답 및 반환 URL 정상 동작 확인  

---

## 🔍 머지 전 확인사항
- 모든 테스트가 성공했는지 (`./gradlew clean test`)  
- Postman 스크린샷 첨부 및 주요 API 응답 코드/내용 검토  
- `@AutoConfigureMockMvc` 적용으로 MockMvc 테스트가 정상 수행되는지 점검  
- 드라이버 이름 입력 로직 분기 처리 정상 동작 여부 확인  

---

## ➕ 이슈 링크
- [#32 공동구매 기능 리팩토링 및 보안 개선](https://github.com/100-hours-a-week/14-YG-BE/issues/32)
