### PR TITLE
refactor(group-buy): V1 테스트 코드 리팩토링 및 메시지 상수화 ( #175, #176, #138)

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/CreateGroupBuyController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/CreateGroupBuyController.java
@@ -5,9 +5,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.CreateGr
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.response.CommandGroupBuyResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.facade.command.GroupBuyCommandFacade;
 import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
-import com.moogsan.moongsan_backend.global.exception.specific.DuplicateRequestException;
 import com.moogsan.moongsan_backend.global.exception.specific.UnauthenticatedAccessException;
-import com.moogsan.moongsan_backend.global.lock.DuplicateRequestPreventer;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +18,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.CREATE_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.CREATE_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/CreateGroupBuyController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/CreateGroupBuyController.java
@@ -20,6 +20,8 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.CREATE_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys")
@@ -41,7 +43,7 @@ public class CreateGroupBuyController {
 
         return ResponseEntity.created(location)
                 .body(WrapperResponse.<CommandGroupBuyResponse>builder()
-                        .message("공구 게시글이 성공적으로 업로드되었습니다.")
+                        .message(CREATE_SUCCESS)
                         .data(new CommandGroupBuyResponse(postId))
                         .build());
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/DeleteGroupBuyController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/DeleteGroupBuyController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.DELETE_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys")
@@ -31,7 +33,7 @@ public class DeleteGroupBuyController {
 
         return ResponseEntity.ok(
                 WrapperResponse.<CommandGroupBuyResponse>builder()
-                        .message("공구 게시글이 성공적으로 삭제되었습니다.")
+                        .message(DELETE_SUCCESS)
                         .build());
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/DeleteGroupBuyController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/DeleteGroupBuyController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.DELETE_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.DELETE_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/EndGroupBuyController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/EndGroupBuyController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.END_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys")
@@ -31,7 +33,7 @@ public class EndGroupBuyController {
 
         return ResponseEntity.ok(
                 WrapperResponse.<EmptyResponse>builder()
-                        .message("공구가 성공적으로 종료되었습니다.")
+                        .message(END_SUCCESS)
                         .build());
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/EndGroupBuyController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/EndGroupBuyController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.END_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.END_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/GenerateDescriptionController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/GenerateDescriptionController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.GENERATE_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GENERATE_SUCCESS;
 import static com.moogsan.moongsan_backend.global.util.CookieUtils.extractCookie;
 
 @RestController

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/GenerateDescriptionController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/GenerateDescriptionController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.GENERATE_SUCCESS;
 import static com.moogsan.moongsan_backend.global.util.CookieUtils.extractCookie;
 
 @RestController
@@ -39,7 +40,7 @@ public class GenerateDescriptionController {
 
         return groupBuyFacade.generateDescription(req.getUrl(), sessionId)
                 .map(data -> ResponseEntity.ok(
-                        new WrapperResponse<>("상품 상세 설명이 성공적으로 생성되었습니다.", data)))
+                        new WrapperResponse<>(GENERATE_SUCCESS, data)))
                 .onErrorResume(IllegalArgumentException.class, e ->
                         Mono.just(ResponseEntity.badRequest()
                                 .body(new WrapperResponse<>(e.getMessage(), null))))

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/LeaveGroupBuyController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/LeaveGroupBuyController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.LEAVE_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.LEAVE_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/LeaveGroupBuyController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/LeaveGroupBuyController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.LEAVE_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys")
@@ -31,7 +33,7 @@ public class LeaveGroupBuyController {
 
         return ResponseEntity.ok(
                 WrapperResponse.<EmptyResponse>builder()
-                        .message("공구 참여가 성공적으로 취소되었습니다.")
+                        .message(LEAVE_SUCCESS)
                         .build());
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/UpdateGroupBuyController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/UpdateGroupBuyController.java
@@ -12,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.UPDATE_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys")
@@ -31,7 +33,7 @@ public class UpdateGroupBuyController {
 
         return ResponseEntity.ok(
                 WrapperResponse.<CommandGroupBuyResponse>builder()
-                        .message("공구 게시글이 성공적으로 수정되었습니다.")
+                        .message(UPDATE_SUCCESS)
                         .data(new CommandGroupBuyResponse(postId))
                         .build());
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/UpdateGroupBuyController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/command/UpdateGroupBuyController.java
@@ -12,7 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.UPDATE_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.UPDATE_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyDetailController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyDetailController.java
@@ -9,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_DETAIL_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys/{postId}")
@@ -24,7 +26,7 @@ public class GroupBuyDetailController {
         DetailResponse detail = queryFacade.getGroupBuyDetailInfo(userId, postId);
         return ResponseEntity.ok(
                 WrapperResponse.<DetailResponse>builder()
-                        .message("공구 게시글 상세 정보를 성공적으로 조회했습니다.")
+                        .message(GET_DETAIL_SUCCESS)
                         .data(detail)
                         .build()
         );

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyEditController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyEditController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_UPDATE_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys/{postId}/edit")
@@ -28,7 +30,7 @@ public class GroupBuyEditController {
         GroupBuyForUpdateResponse groupBuyForUpdate = queryFacade.getGroupBuyEditInfo(postId);
         return ResponseEntity.ok(
                 WrapperResponse.<GroupBuyForUpdateResponse>builder()
-                        .message("공구 게시글 수정용 정보를 성공적으로 조회했습니다.")
+                        .message(GET_UPDATE_SUCCESS)
                         .data(groupBuyForUpdate)
                         .build()
         );

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyHostAccountController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyHostAccountController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_ACCOUNT_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys/{postId}/host/account")
@@ -31,7 +33,7 @@ public class GroupBuyHostAccountController {
         );
         return ResponseEntity.ok(
                 WrapperResponse.<UserAccountResponse>builder()
-                        .message("공구 게시글 주최자 계좌 정보를 성공적으로 조회했습니다.")
+                        .message(GET_ACCOUNT_SUCCESS)
                         .data(accountResponse)
                         .build()
         );

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyHostedListController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyHostedListController.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_HOSTED_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys/users/me/hosts")
@@ -33,7 +35,7 @@ public class GroupBuyHostedListController {
                 userDetails.getUser().getId(), sort, cursorId, limit);
         return ResponseEntity.ok(
                 WrapperResponse.<PagedResponse<HostedListResponse>>builder()
-                        .message("주최 공구 리스트를 성공적으로 조회했습니다.")
+                        .message(GET_HOSTED_SUCCESS)
                         .data(pagedResponse)
                         .build()
         );

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyListController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyListController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_LIST_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys")
@@ -39,7 +41,7 @@ public class GroupBuyListController {
                         cursorId, cursorCreatedAt, cursorPrice, limit, openOnly, keyword);
         return ResponseEntity.ok(
                 WrapperResponse.<PagedResponse<BasicListResponse>>builder()
-                        .message("전체 공구 리스트를 성공적으로 조회했습니다.")
+                        .message(GET_LIST_SUCCESS)
                         .data(pagedResponse)
                         .build()
         );

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyParticipantsController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyParticipantsController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_PARTICIPANTS_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys/{postId}/participants")
@@ -30,7 +32,7 @@ public class GroupBuyParticipantsController {
                 userDetails.getUser().getId(), postId);
         return ResponseEntity.ok(
                 WrapperResponse.<ParticipantListResponse>builder()
-                        .message("공구 참여자 리스트를 성공적으로 조회했습니다.")
+                        .message(GET_PARTICIPANTS_SUCCESS)
                         .data(participantList)
                         .build()
         );

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyParticipatedListController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyParticipatedListController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_PARTICIPATED_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys/users/me/participants")
@@ -37,7 +39,7 @@ public class GroupBuyParticipatedListController {
                 userDetails.getUser().getId(), sort, cursorCreatedAt, cursorId, limit);
         return ResponseEntity.ok(
                 WrapperResponse.<PagedResponse<ParticipatedListResponse>>builder()
-                        .message("참여 공구 리스트를 성공적으로 조회했습니다.")
+                        .message(GET_PARTICIPATED_SUCCESS)
                         .data(pagedResponse)
                         .build()
         );

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyWishListController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyWishListController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_WISH_SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/group-buys/users/me/wishes")
@@ -37,7 +39,7 @@ public class GroupBuyWishListController {
                 userDetails.getUser().getId(), sort, cursorCreatedAt, cursorId, limit);
         return ResponseEntity.ok(
                 WrapperResponse.<PagedResponse<WishListResponse>>builder()
-                        .message("관심 공구 리스트를 성공적으로 조회했습니다.")
+                        .message(GET_WISH_SUCCESS)
                         .data(pagedResponse)
                         .build()
         );

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
@@ -52,8 +52,8 @@ public class CreateGroupBuyRequest {
     @Size(min = 2, max = 2000, message = DESCRIPTION_SIZE)
     private String description;
 
-    @NotNull(message = BLANK_DUEDATE)
-    @Future(message = PAST_DUEDATE)
+    @NotNull(message = INVALID_DUEDATE)
+    @Future(message = INVALID_DUEDATE)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime dueDate;
 
@@ -62,13 +62,13 @@ public class CreateGroupBuyRequest {
     @Size(min = 2, max = 85, message = LOCATION_SIZE)
     private String location;
 
-    @NotNull(message = PAST_PICKUPDATE)
-    @Future(message = PAST_PICKUPDATE)
+    @NotNull(message = INVALID_PICKUPDATE)
+    @Future(message = INVALID_PICKUPDATE)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime pickupDate;
 
-    @NotNull(message = BLANK_IMAGE)
-    @Size(min=1, max = 5, message = BLANK_IMAGE)
+    @NotNull(message = INVALID_IMAGE)
+    @Size(min=1, max = 5, message = INVALID_IMAGE)
     private List<
             @NotBlank(message = INVALID_IMAGE)
             @Pattern(

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
@@ -9,68 +9,70 @@ import org.hibernate.validator.constraints.URL;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ValidationMessage.*;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class CreateGroupBuyRequest {
 
-    @NotNull(message = "제목은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요.")
-    @NotBlank(message = "제목은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요.")
-    @Size(min = 1, max = 100, message = "제목은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요.")
+    @NotNull(message = TITLE_SIZE)
+    @NotBlank(message = TITLE_SIZE)
+    @Size(min = 1, max = 100, message = TITLE_SIZE)
     private String title;
 
-    @NotNull(message = "상품명은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요.")
-    @NotBlank(message = "상품명은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요.")
-    @Size(min = 1, max = 100, message = "상품명은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요.")
+    @NotNull(message = NAME_SIZE)
+    @NotBlank(message = NAME_SIZE)
+    @Size(min = 1, max = 100, message = NAME_SIZE)
     private String name;
 
-    @Size(min = 1, max = 2000, message = "URL은 1자 이상, 2000자 이하로 입력해주세요.")
-    @URL(message = "URL 형식이 올바르지 않습니다.")
+    @Size(min = 1, max = 2000, message = URL_SIZE)
+    @URL(message = INVALID_URL)
     private String url;
 
-    @NotNull(message = "상품 가격은 필수 입력 항목입니다.")
-    @Min(value = 1, message = "상품 가격은 1 이상이어야 합니다.")
+    @NotNull(message = BLANK_PRICE)
+    @Min(value = 1, message = PRICE_SIZE)
     private Integer price;
 
-    @NotNull(message = "상품 전체 수량은 필수 입력 항목입니다.")
-    @Min(value = 1, message = "상품 전체 수량은 1 이상이어야 합니다.")
+    @NotNull(message = BLANK_TOTAL_AMOUNT)
+    @Min(value = 1, message = TOTAL_AMOUNT_SIZE)
     private Integer totalAmount;
 
-    @NotNull(message = "상품 주문 단위는 필수 입력 항목입니다.")
-    @Min(value = 1, message = "상품 주문 단위는 1 이상이어야 합니다.")
+    @NotNull(message = BLANK_UNIT_AMOUNT)
+    @Min(value = 1, message = UNIT_AMOUNT_SIZE)
     private Integer unitAmount;
 
-    @NotNull(message = "주최자 주문 수량은 필수 입력 항목입니다.")
-    @Min(value = 0, message = "주최자 주문 수량은 0 이상이어야 합니다.")  /// 이후 1로 수정 필요
+    @NotNull(message = BLANK_HOST_QUANTITY)
+    @Min(value = 0, message = HOST_QUANTITY_SIZE)  /// 이후 1로 수정 필요
     private Integer hostQuantity;
 
-    @NotNull(message = "상품 설명은 공백을 제외한 2자 이상, 2000자 이하로 입력해주세요.")
-    @NotBlank(message = "상품 설명은 공백을 제외한 2자 이상, 2000자 이하로 입력해주세요.")
-    @Size(min = 2, max = 2000, message = "상품 설명은 공백을 제외한 2자 이상, 2000자 이하로 입력해주세요.")
+    @NotNull(message = DESCRIPTION_SIZE)
+    @NotBlank(message = DESCRIPTION_SIZE)
+    @Size(min = 2, max = 2000, message = DESCRIPTION_SIZE)
     private String description;
 
-    @NotNull(message = "마감 일자는 필수 입력 항목입니다.")
-    @Future(message = "마감 일자는 현재 시간 이후여야 합니다.")
+    @NotNull(message = BLANK_DUEDATE)
+    @Future(message = PAST_DUEDATE)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime dueDate;
 
-    @NotNull(message = "거래 장소는 공백을 제외한 2자 이상, 85자 이하로 입력해주세요.")
-    @NotBlank(message = "거래 장소는 공백을 제외한 2자 이상, 85자 이하로 입력해주세요.")
-    @Size(min = 2, max = 85, message = "거래 장소는 공백을 제외한 2자 이상, 85자 이하로 입력해주세요.")
+    @NotNull(message = LOCATION_SIZE)
+    @NotBlank(message = LOCATION_SIZE)
+    @Size(min = 2, max = 85, message = LOCATION_SIZE)
     private String location;
 
-    @NotNull(message = "픽업 일자는 필수 입력 항목입니다.")
-    @Future(message = "픽업 일자는 현재 시간 이후여야 합니다.")
+    @NotNull(message = PAST_PICKUPDATE)
+    @Future(message = PAST_PICKUPDATE)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime pickupDate;
 
-    @NotNull(message = "이미지는 1장 이상, 5장 이하로 등록해주세요.")
-    @Size(min=1, max = 5, message = "이미지는 1장 이상, 5장 이하로 등록해주세요.")
+    @NotNull(message = BLANK_IMAGE)
+    @Size(min=1, max = 5, message = BLANK_IMAGE)
     private List<
-            @NotBlank(message = "이미지는 반드시 images/로 시작해야 합니다")
+            @NotBlank(message = INVALID_IMAGE)
             @Pattern(
                     regexp = "^.*images/.*$",
-                    message = "이미지는 반드시 images/로 시작해야 합니다"
+                    message = INVALID_IMAGE
             ) String> imageKeys;
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
@@ -1,6 +1,7 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.moogsan.moongsan_backend.domain.groupbuy.validator.NotBlankIfPresent;
 import com.moogsan.moongsan_backend.domain.groupbuy.validator.RequireReasonIfPickupDateChanged;
 import jakarta.validation.constraints.*;
 import lombok.*;
@@ -10,6 +11,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ValidationMessage.*;
+
 @RequireReasonIfPickupDateChanged
 @Data
 @NoArgsConstructor
@@ -17,29 +20,38 @@ import java.util.List;
 @Builder
 public class UpdateGroupBuyRequest {
 
-    @Size(min = 1, max = 30, message = "제목은 1자 이상, 30자 이하로 입력해주세요.")
+    @NotBlankIfPresent(message = TITLE_SIZE)
+    @Size(min = 1, max = 30, message = TITLE_SIZE)
     private String title;
 
-    @Size(min = 1, max = 30, message = "상품명은 1자 이상, 30자 이하로 입력해주세요.")
+    @NotBlankIfPresent(message = NAME_SIZE)
+    @Size(min = 1, max = 30, message = NAME_SIZE)
     private String name;
 
-    @Size(min = 2, max = 2000, message = "상품 설명은 2자 이상, 2000자 이하로 입력해주세요.")
+    @NotBlankIfPresent(message = DESCRIPTION_SIZE)
+    @Size(min = 2, max = 2000, message = DESCRIPTION_SIZE)
     private String description;
 
-    @Min(value = 0, message = "주최자 주문 수량은 0 이상이어야 합니다.")  /// 이후 1로 수정 필요
+    @Min(value = 0, message = BLANK_HOST_QUANTITY)  /// 이후 1로 수정 필요
     private Integer hostQuantity;
 
-    @Future(message = "마감일자는 현재 시간 이후여야 합니다.")
+    @Future(message = PAST_DUEDATE)
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime dueDate;
 
-    @Future(message = "픽업 일자는 현재 시간 이후여야 합니다.")
+    @Future(message = PAST_PICKUPDATE)
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime pickupDate;
 
-    @Size(min = 2, max = 85, message = "픽업 일자 변경 사유는 2자 이상, 85자 이하로 입력해주세요.")
+    @NotBlankIfPresent(message = BLANK_DATEMODIFICATION_REASON)
+    @Size(min = 2, max = 85, message = BLANK_DATEMODIFICATION_REASON)
     private String dateModificationReason;
 
-    @Size(min=1, max = 5, message = "이미지는 1장 이상, 5장 이하까지 등록할 수 있습니다.")
-    private List<String> imageKeys;
+    @Size(min=1, max = 5, message = BLANK_IMAGE)
+    private List<
+            @NotBlankIfPresent(message = INVALID_IMAGE)
+            @Pattern(
+                    regexp = "^.*images/.*$",
+                    message = INVALID_IMAGE
+            ) String> imageKeys;
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
@@ -35,11 +35,11 @@ public class UpdateGroupBuyRequest {
     @Min(value = 0, message = BLANK_HOST_QUANTITY)  /// 이후 1로 수정 필요
     private Integer hostQuantity;
 
-    @Future(message = PAST_DUEDATE)
+    @Future(message = INVALID_DUEDATE)
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime dueDate;
 
-    @Future(message = PAST_PICKUPDATE)
+    @Future(message = INVALID_PICKUPDATE)
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime pickupDate;
 
@@ -47,7 +47,7 @@ public class UpdateGroupBuyRequest {
     @Size(min = 2, max = 85, message = BLANK_DATEMODIFICATION_REASON)
     private String dateModificationReason;
 
-    @Size(min=1, max = 5, message = BLANK_IMAGE)
+    @Size(min=1, max = 5, message = INVALID_IMAGE)
     private List<
             @NotBlankIfPresent(message = INVALID_IMAGE)
             @Pattern(

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/entity/GroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/entity/GroupBuy.java
@@ -86,7 +86,7 @@ public class GroupBuy extends BaseEntity {
     @Column(nullable = false, length = 10)
     private String postStatus = "OPEN";
 
-    private String pickupChangeReason;
+    private String dateModificationReason;
 
     @Builder.Default
     private boolean isFinalized = false;
@@ -194,7 +194,7 @@ public class GroupBuy extends BaseEntity {
         }
         if (req.getPickupDate() != null) {
             this.pickupDate = req.getPickupDate();
-            this.pickupChangeReason = req.getDateModificationReason();
+            this.dateModificationReason = req.getDateModificationReason();
         }
 
         return this;

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/CategoryNotFoundException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/CategoryNotFoundException.java
@@ -3,7 +3,7 @@ package com.moogsan.moongsan_backend.domain.groupbuy.exception.specific;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_EXIST_CATEGORY;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_EXIST_CATEGORY;
 
 public class CategoryNotFoundException extends GroupBuyException {
     public CategoryNotFoundException() {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/CategoryNotFoundException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/CategoryNotFoundException.java
@@ -3,9 +3,11 @@ package com.moogsan.moongsan_backend.domain.groupbuy.exception.specific;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_EXIST_CATEGORY;
+
 public class CategoryNotFoundException extends GroupBuyException {
     public CategoryNotFoundException() {
-        super(GroupBuyErrorCode.CATEGORY_NOT_FOUND, "존재하지 않는 카테고리입니다.");
+        super(GroupBuyErrorCode.CATEGORY_NOT_FOUND, NOT_EXIST_CATEGORY);
     }
 
     public CategoryNotFoundException(String message) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyInvalidStateException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyInvalidStateException.java
@@ -3,9 +3,11 @@ package com.moogsan.moongsan_backend.domain.groupbuy.exception.specific;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.AFTER_ENDED;
+
 public class GroupBuyInvalidStateException extends GroupBuyException {
     public GroupBuyInvalidStateException() {
-        super(GroupBuyErrorCode.INVALID_STATE, "종료된 공구에는 요청할 수 없습니다.");
+        super(GroupBuyErrorCode.INVALID_STATE, AFTER_ENDED);
     }
 
     public GroupBuyInvalidStateException(String message) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyInvalidStateException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyInvalidStateException.java
@@ -3,7 +3,7 @@ package com.moogsan.moongsan_backend.domain.groupbuy.exception.specific;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.AFTER_ENDED;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.AFTER_ENDED;
 
 public class GroupBuyInvalidStateException extends GroupBuyException {
     public GroupBuyInvalidStateException() {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotFoundException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotFoundException.java
@@ -3,7 +3,7 @@ package com.moogsan.moongsan_backend.domain.groupbuy.exception.specific;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_EXIST;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_EXIST;
 
 public class GroupBuyNotFoundException extends GroupBuyException {
     public GroupBuyNotFoundException() {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotFoundException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotFoundException.java
@@ -3,9 +3,11 @@ package com.moogsan.moongsan_backend.domain.groupbuy.exception.specific;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_EXIST;
+
 public class GroupBuyNotFoundException extends GroupBuyException {
     public GroupBuyNotFoundException() {
-        super(GroupBuyErrorCode.GROUPBUY_NOT_FOUND, "존재하지 않는 공구입니다.");
+        super(GroupBuyErrorCode.GROUPBUY_NOT_FOUND, NOT_EXIST);
     }
 
     public GroupBuyNotFoundException(String message) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotHostException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotHostException.java
@@ -3,7 +3,7 @@ package com.moogsan.moongsan_backend.domain.groupbuy.exception.specific;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_HOST;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_HOST;
 
 public class GroupBuyNotHostException extends GroupBuyException {
     public GroupBuyNotHostException() {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotHostException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotHostException.java
@@ -3,9 +3,11 @@ package com.moogsan.moongsan_backend.domain.groupbuy.exception.specific;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_HOST;
+
 public class GroupBuyNotHostException extends GroupBuyException {
     public GroupBuyNotHostException() {
-        super(GroupBuyErrorCode.NOT_HOST, "공구의 주최자만 요청 가능합니다.");
+        super(GroupBuyErrorCode.NOT_HOST, NOT_HOST);
     }
 
     public GroupBuyNotHostException(String message) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotParticipantException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotParticipantException.java
@@ -3,9 +3,11 @@ package com.moogsan.moongsan_backend.domain.groupbuy.exception.specific;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_PARTICIPANT;
+
 public class GroupBuyNotParticipantException extends GroupBuyException {
     public GroupBuyNotParticipantException() {
-        super(GroupBuyErrorCode.NOT_PARTICIPANT, "공구의 참여자만 요청 가능합니다.");
+        super(GroupBuyErrorCode.NOT_PARTICIPANT, NOT_PARTICIPANT);
     }
 
     public GroupBuyNotParticipantException(String message) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotParticipantException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/exception/specific/GroupBuyNotParticipantException.java
@@ -3,7 +3,7 @@ package com.moogsan.moongsan_backend.domain.groupbuy.exception.specific;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_PARTICIPANT;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_PARTICIPANT;
 
 public class GroupBuyNotParticipantException extends GroupBuyException {
     public GroupBuyNotParticipantException() {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/GroupBuyResponseMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/GroupBuyResponseMessage.java
@@ -1,0 +1,65 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.message;
+
+public final class GroupBuyResponseMessage {
+
+    private GroupBuyResponseMessage() {}
+
+    /// SUCCESS
+
+    public static final String CREATE_SUCCESS =
+            "공구 게시글이 성공적으로 업로드되었습니다.";
+
+    public static final String UPDATE_SUCCESS =
+            "공구 게시글이 성공적으로 수정되었습니다.";
+
+    public static final String LEAVE_SUCCESS =
+            "공구 참여가 성공적으로 취소되었습니다.";
+
+    public static final String GENERATE_SUCCESS =
+            "상품 상세 설명이 성공적으로 생성되었습니다.";
+
+    public static final String END_SUCCESS =
+            "공구 게시글이 성공적으로 종료되었습니다.";
+
+    public static final String DELETE_SUCCESS =
+            "공구 게시글이 성공적으로 삭제되었습니다.";
+
+
+    ///  FAIL
+
+    public static final String NOT_DIVISOR =
+            "상품 주문 단위는 상품 전체 수량의 약수여야 합니다.";
+
+    public static final String NOT_OPEN =
+            "공구가 열려있는 상태에서만 요청 가능합니다.";
+
+    public static final String NOT_EXIST =
+            "존재하지 않는 공구입니다";
+
+    public static final String NOT_EXIST_ORDER =
+            "존재하지 않는 주문입니다.";
+
+    public static final String NOT_HOST =
+            "공구의 주최자만 요청 가능합니다.";
+
+    public static final String NOT_PARTICIPANT =
+            "공구의 참여자만 요청 가능합니다.";
+
+    public static final String EXIST_PARTICIPANT =
+            "참여자가 1명 이상일 경우 공구를 삭제할 수 없습니다.";
+
+    public static final String BEFORE_CLOSED =
+            "모집 마감 이후에만 요청 가능합니다.";
+
+    public static final String AFTER_ENDED =
+            "이미 종료된 공구입니다.";
+
+    public static final String BEFORE_PICKUP_DATE =
+            "공구 종료는 공구 픽업 일자 이후에만 가능합니다.";
+
+    public static final String BEFORE_FIXED =
+            "공구 종료는 공구 체결 이후에만 가능합니다.";
+
+    public static final String NOT_EXIST_CATEGORY =
+            "존재하지 않는 카테고리입니다.";
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ResponseMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ResponseMessage.java
@@ -1,8 +1,8 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.message;
 
-public final class GroupBuyResponseMessage {
+public final class ResponseMessage {
 
-    private GroupBuyResponseMessage() {}
+    private ResponseMessage() {}
 
     /// SUCCESS
 
@@ -24,6 +24,30 @@ public final class GroupBuyResponseMessage {
     public static final String DELETE_SUCCESS =
             "공구 게시글이 성공적으로 삭제되었습니다.";
 
+    public static final String GET_DETAIL_SUCCESS =
+            "공구 게시글 상세 정보를 성공적으로 조회했습니다.";
+
+    public static final String GET_UPDATE_SUCCESS =
+            "공구 게시글 수정용 정보를 성공적으로 조회했습니다.";
+
+    public static final String GET_ACCOUNT_SUCCESS =
+            "공구 게시글 주최자 계좌 정보를 성공적으로 조회했습니다.";
+
+    public static final String GET_HOSTED_SUCCESS =
+            "주최 공구 리스트를 성공적으로 조회했습니다.";
+
+    public static final String GET_PARTICIPATED_SUCCESS =
+            "참여 공구 리스트를 성공적으로 조회했습니다.";
+
+    public static final String GET_WISH_SUCCESS =
+            "관심 공구 리스트를 성공적으로 조회했습니다.";
+
+    public static final String GET_LIST_SUCCESS =
+            "전체 공구 리스트를 성공적으로 조회했습니다.";
+
+    public static final String GET_PARTICIPANTS_SUCCESS =
+            "공구 참여자 리스트를 성공적으로 조회했습니다.";
+
 
     ///  FAIL
 
@@ -34,7 +58,10 @@ public final class GroupBuyResponseMessage {
             "공구가 열려있는 상태에서만 요청 가능합니다.";
 
     public static final String NOT_EXIST =
-            "존재하지 않는 공구입니다";
+            "존재하지 않는 공구입니다.";
+
+    public static final String AFTER_DELETED =
+            "삭제된 공구입니다.";
 
     public static final String NOT_EXIST_ORDER =
             "존재하지 않는 주문입니다.";

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ResponseMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ResponseMessage.java
@@ -89,4 +89,7 @@ public final class ResponseMessage {
 
     public static final String NOT_EXIST_CATEGORY =
             "존재하지 않는 카테고리입니다.";
+
+    public static final String BAD_REQUEST =
+            "입력 형식이 올바르지 않습니다.";
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ValidationMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ValidationMessage.java
@@ -15,12 +15,9 @@ public class ValidationMessage {
     public static final String BLANK_HOST_QUANTITY = "주최자 주문 수량은 필수 입력 항목입니다.";
     public static final String HOST_QUANTITY_SIZE = "주최자 주문 수량은 0 이상이어야 합니다.";
     public static final String DESCRIPTION_SIZE = "상품 설명은 공백을 제외한 2자 이상, 2000자 이하로 입력해주세요.";
-    public static final String BLANK_DUEDATE = "마감 일자는 필수 입력 항목입니다.";
-    public static final String PAST_DUEDATE = "마감 일자는 현재 시간 이후여야 합니다.";
+    public static final String INVALID_DUEDATE = "마감 일자는 현재 시간 이후여야 합니다.";
     public static final String LOCATION_SIZE = "거래 장소는 공백을 제외한 2자 이상, 85자 이하로 입력해주세요.";
-    public static final String BLANK_PICKUPDATE = "픽업 일자는 필수 입력 항목입니다.";
-    public static final String PAST_PICKUPDATE = "픽업 일자는 현재 시간 이후여야 합니다.";
-    public static final String BLANK_IMAGE = "이미지는 1장 이상, 5장 이하로 등록해주세요.";
-    public static final String INVALID_IMAGE = "이미지는 반드시 images/로 시작해야 합니다";
+    public static final String INVALID_PICKUPDATE = "픽업 일자는 현재 시간 이후여야 합니다.";
+    public static final String INVALID_IMAGE = "images/로 시작하는 이미지를 1장 이상, 5장 이하로 등록해주세요.";
     public static final String BLANK_DATEMODIFICATION_REASON = "픽업 일자가 변경된 경우 사유를 2자 이상, 85자 이하로 작성해야 합니다.";
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ValidationMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ValidationMessage.java
@@ -1,0 +1,4 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.message;
+
+public class ValidationMessage {
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ValidationMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ValidationMessage.java
@@ -1,4 +1,26 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.message;
 
 public class ValidationMessage {
+    public static final String NOT_BLANK = "공백만으로는 입력할 수 없습니다.";
+    public static final String TITLE_SIZE = "제목은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요.";
+    public static final String NAME_SIZE = "상품명은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요.";
+    public static final String URL_SIZE = "URL은 1자 이상, 2000자 이하로 입력해주세요.";
+    public static final String INVALID_URL = "URL 형식이 올바르지 않습니다.";
+    public static final String BLANK_PRICE = "상품 가격은 필수 입력 항목입니다.";
+    public static final String PRICE_SIZE = "상품 가격은 1 이상이어야 합니다.";
+    public static final String BLANK_TOTAL_AMOUNT = "상품 전체 수량은 필수 입력 항목입니다.";
+    public static final String TOTAL_AMOUNT_SIZE = "상품 전체 수량은 1 이상이어야 합니다.";
+    public static final String BLANK_UNIT_AMOUNT = "상품 주문 단위는 필수 입력 항목입니다.";
+    public static final String UNIT_AMOUNT_SIZE = "상품 주문 단위는 1 이상이어야 합니다.";
+    public static final String BLANK_HOST_QUANTITY = "주최자 주문 수량은 필수 입력 항목입니다.";
+    public static final String HOST_QUANTITY_SIZE = "주최자 주문 수량은 0 이상이어야 합니다.";
+    public static final String DESCRIPTION_SIZE = "상품 설명은 공백을 제외한 2자 이상, 2000자 이하로 입력해주세요.";
+    public static final String BLANK_DUEDATE = "마감 일자는 필수 입력 항목입니다.";
+    public static final String PAST_DUEDATE = "마감 일자는 현재 시간 이후여야 합니다.";
+    public static final String LOCATION_SIZE = "거래 장소는 공백을 제외한 2자 이상, 85자 이하로 입력해주세요.";
+    public static final String BLANK_PICKUPDATE = "픽업 일자는 필수 입력 항목입니다.";
+    public static final String PAST_PICKUPDATE = "픽업 일자는 현재 시간 이후여야 합니다.";
+    public static final String BLANK_IMAGE = "이미지는 1장 이상, 5장 이하로 등록해주세요.";
+    public static final String INVALID_IMAGE = "이미지는 반드시 images/로 시작해야 합니다";
+    public static final String BLANK_DATEMODIFICATION_REASON = "픽업 일자가 변경된 경우 사유를 2자 이상, 85자 이하로 작성해야 합니다.";
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CreateGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CreateGroupBuy.java
@@ -21,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_DIVISOR;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -45,7 +47,7 @@ public class CreateGroupBuy {
         }
 
         if (unit == 0 || total % unit != 0) {
-            throw new GroupBuyInvalidStateException("상품 주문 단위는 상품 전체 수량의 약수여야 합니다.");
+            throw new GroupBuyInvalidStateException(NOT_DIVISOR);
         }
 
         GroupBuy gb = groupBuyCommandMapper.create(createGroupBuyRequest, currentUser);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CreateGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CreateGroupBuy.java
@@ -1,14 +1,9 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService;
 
 import com.moogsan.moongsan_backend.domain.chatting.Facade.command.ChattingCommandFacade;
-import com.moogsan.moongsan_backend.domain.chatting.entity.ChatParticipant;
-import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
-import com.moogsan.moongsan_backend.domain.chatting.repository.ChatParticipantRepository;
-import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.CreateGroupBuyRequest;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
-import com.moogsan.moongsan_backend.domain.groupbuy.facade.command.GroupBuyCommandFacade;
 import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyCommandMapper;
 import com.moogsan.moongsan_backend.domain.image.mapper.ImageMapper;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
@@ -19,9 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_DIVISOR;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_DIVISOR;
 
 @Service
 @Transactional

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/DeleteGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/DeleteGroupBuy.java
@@ -13,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -32,18 +34,18 @@ public class DeleteGroupBuy {
         // 해당 공구의 status가 open인지 조회 -> 아니면 409
         if (!groupBuy.getPostStatus().equals("OPEN")
                 || groupBuy.getDueDate().isBefore(LocalDateTime.now())) {
-            throw new GroupBuyInvalidStateException("공구 삭제는 공구가 열려있는 상태에서만 가능합니다.");
+            throw new GroupBuyInvalidStateException(NOT_OPEN);
         }
 
         // 해당 공구의 참여자가 0명인지 조회 -> 아니면 409
         int participantCount = orderRepository.countByGroupBuyIdAndStatusNot(postId, "CANCELED");
         if(participantCount != 0) {
-            throw new GroupBuyInvalidStateException("참여자가 1명 이상일 경우 공구를 삭제할 수 없습니다.");
+            throw new GroupBuyInvalidStateException(EXIST_PARTICIPANT);
         }
 
         // 해당 공구의 주최자가 해당 유저인지 조회 -> 아니면 403
         if(!groupBuy.getUser().getId().equals(currentUser.getId())) {
-            throw new GroupBuyNotHostException("공구 삭제는 공구의 주최자만 요청 가능합니다.");
+            throw new GroupBuyNotHostException(NOT_HOST);
         }
 
         groupBuy.changePostStatus("DELETED");

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/DeleteGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/DeleteGroupBuy.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
 
 @Service
 @Transactional

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
 
 @Service
 @Transactional

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
@@ -12,6 +12,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -28,31 +30,31 @@ public class EndGroupBuy {
 
         // 해당 공구가 OPEN인지 조회 -> 아니면 409
         if (groupBuy.getPostStatus().equals("OPEN")) {
-            throw new GroupBuyInvalidStateException("공구 종료는 모집 마감 이후에만 가능합니다.");
+            throw new GroupBuyInvalidStateException(BEFORE_CLOSED);
         }
 
         // 해당 공구가 ENDED인지 조회 -> 맞으면 409
         if (groupBuy.getPostStatus().equals("ENDED")) {
-            throw new GroupBuyInvalidStateException("이미 종료된 공구입니다.");
+            throw new GroupBuyInvalidStateException(AFTER_ENDED);
         }
 
         // dueDate 이후인지 조회 -> 아니면 409
         if (groupBuy.getDueDate().isAfter(LocalDateTime.now())) {
-            throw new GroupBuyInvalidStateException("공구 종료는 공구 마감 일자 이후에만 가능합니다.");
+            throw new GroupBuyInvalidStateException(BEFORE_CLOSED);
         }
 
         // pickupDate 이후인지 조회 -> 아니면 409
         if (groupBuy.getPickupDate().isAfter(LocalDateTime.now())) {
-            throw new GroupBuyInvalidStateException("공구 종료는 공구 픽업 일자 이후에만 가능합니다.");
+            throw new GroupBuyInvalidStateException(BEFORE_PICKUP_DATE);
         }
 
         if (!groupBuy.isFixed()) {
-            throw new GroupBuyInvalidStateException("공구 종료는 공구 체결 이후에만 가능합니다.");
+            throw new GroupBuyInvalidStateException(BEFORE_FIXED);
         }
 
         // 해당 공구의 주최자가 해당 유저인지 조회 -> 아니면 403
         if(!groupBuy.getUser().getId().equals(currentUser.getId())) {
-            throw new GroupBuyNotHostException("공구 종료는 공구의 주최자만 요청 가능합니다.");
+            throw new GroupBuyNotHostException(NOT_HOST);
         }
 
         //공구 게시글 status ENDED로 변경

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/LeaveGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/LeaveGroupBuy.java
@@ -7,7 +7,6 @@ import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyN
 import com.moogsan.moongsan_backend.domain.groupbuy.policy.DueSoonPolicy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
-import com.moogsan.moongsan_backend.domain.order.exception.specific.OrderInvalidStateException;
 import com.moogsan.moongsan_backend.domain.order.exception.specific.OrderNotFoundException;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
@@ -17,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_OPEN;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_OPEN;
 
 
 @Service

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/LeaveGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/LeaveGroupBuy.java
@@ -17,6 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_OPEN;
+
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -37,7 +40,7 @@ public class LeaveGroupBuy {
         // 해당 공구가 OPEN인지 조회, dueDate가 현재 이후인지 조회 -> 아니면 409
         if (!groupBuy.getPostStatus().equals("OPEN")
                 || groupBuy.getDueDate().isBefore(LocalDateTime.now())) {
-            throw new GroupBuyInvalidStateException("공구 참여 취소는 공구가 열려있는 상태에서만 가능합니다.");
+            throw new GroupBuyInvalidStateException(NOT_OPEN);
         }
 
         // 해당 공구의 주문 테이블에 해당 유저의 주문이 존재하는지 조회 -> 아니면 404

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/UpdateGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/UpdateGroupBuy.java
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
 
 @Service
 @Transactional

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/UpdateGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/UpdateGroupBuy.java
@@ -14,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -32,12 +34,12 @@ public class UpdateGroupBuy {
         // 해당 공구의 status가 open인지 조회 -> 아니면 409
         if (!groupBuy.getPostStatus().equals("OPEN")
                 || groupBuy.getDueDate().isBefore(LocalDateTime.now())) {
-            throw new GroupBuyInvalidStateException("공구 수정은 공구가 열려있는 상태에서만 가능합니다.");
+            throw new GroupBuyInvalidStateException(NOT_OPEN);
         }
 
         // 해당 공구의 주최자가 해당 유저인지 조회 -> 아니면 403
         if(!groupBuy.getUser().getId().equals(currentUser.getId())) {
-            throw new GroupBuyNotHostException("공구 수정은 공구의 주최자만 요청 가능합니다.");
+            throw new GroupBuyNotHostException(NOT_HOST);
         }
 
         // GroupBuy 기본 필드 매핑 (팩토리 메서드 사용)

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyDetailInfo.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyDetailInfo.java
@@ -15,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.AFTER_DELETED;
+
 @Slf4j
 @Service
 @Transactional(readOnly=true)
@@ -33,7 +35,7 @@ public class GetGroupBuyDetailInfo {
                 .orElseThrow(GroupBuyNotFoundException::new);
 
         if (groupBuy.getPostStatus().equals("DELETED")) {
-            throw new GroupBuyInvalidStateException("삭제된 공구글은 조회할 수 없습니다.");
+            throw new GroupBuyInvalidStateException(AFTER_DELETED);
         }
 
         //log.info("Checking participant: userId={}, postId={}", userId, postId);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyParticipantsInfo.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyParticipantsInfo.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_HOST;
+
 @Slf4j
 @Service
 @Transactional(readOnly=true)
@@ -35,7 +37,7 @@ public class GetGroupBuyParticipantsInfo {
 
         // 해당 공구의 주최자가 해당 유저인지 조회 -> 아니면 403
         if(!groupBuy.getUser().getId().equals(userId)) {
-            throw new GroupBuyNotHostException("공구 참여자 조회는 공구의 주최자만 요청 가능합니다.");
+            throw new GroupBuyNotHostException(NOT_HOST);
         }
 
         List<Order> orders = orderRepository.findByGroupBuyIdAndStatusNot(postId, "canceled");

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/validator/NotBlankIfPresent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/validator/NotBlankIfPresent.java
@@ -1,0 +1,18 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ValidationMessage.NOT_BLANK;
+
+@Documented
+@Constraint(validatedBy = NotBlankIfPresentValidator.class)
+@Target({ElementType.TYPE_USE, ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NotBlankIfPresent {
+    String message() default NOT_BLANK;
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/validator/NotBlankIfPresentValidator.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/validator/NotBlankIfPresentValidator.java
@@ -1,0 +1,17 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NotBlankIfPresentValidator implements ConstraintValidator<NotBlankIfPresent, String> {
+
+    @Override
+    public void initialize(NotBlankIfPresent constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+        return s == null || !s.trim().isEmpty();
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/validator/PickupDateReasonValidator.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/validator/PickupDateReasonValidator.java
@@ -4,6 +4,8 @@ import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.UpdateGr
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ValidationMessage.BLANK_DATEMODIFICATION_REASON;
+
 ///  validator 구현
 public class PickupDateReasonValidator implements ConstraintValidator<RequireReasonIfPickupDateChanged, UpdateGroupBuyRequest> {
 
@@ -18,7 +20,7 @@ public class PickupDateReasonValidator implements ConstraintValidator<RequireRea
 
         if (request.getDateModificationReason() == null || request.getDateModificationReason().trim().isEmpty()) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate("픽업 일자가 변경된 경우 사유를 작성해야 합니다.")
+            context.buildConstraintViolationWithTemplate(BLANK_DATEMODIFICATION_REASON)
                     .addPropertyNode("dateModificationReason")
                     .addConstraintViolation();
             return false;

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/validator/RequireReasonIfPickupDateChanged.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/validator/RequireReasonIfPickupDateChanged.java
@@ -5,13 +5,15 @@ import jakarta.validation.Payload;
 
 import java.lang.annotation.*;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ValidationMessage.BLANK_DATEMODIFICATION_REASON;
+
 /// 커스텀 어노테이션 정의
-@Target({ ElementType.TYPE })
+@Target({ ElementType.TYPE, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = PickupDateReasonValidator.class)
 @Documented
 public @interface RequireReasonIfPickupDateChanged {
-    String message() default "픽업 일자가 변경된 경우 사유를 작성해야 합니다.";
+    String message() default BLANK_DATEMODIFICATION_REASON;
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/CreateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/CreateGroupBuyTest.java
@@ -708,7 +708,7 @@ class CreateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.dueDate").value(BLANK_DUEDATE));
+                .andExpect(jsonPath("$.data.dueDate").value(INVALID_DUEDATE));
     }
 
     @Test
@@ -730,7 +730,7 @@ class CreateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.dueDate").value(PAST_DUEDATE));
+                .andExpect(jsonPath("$.data.dueDate").value(INVALID_DUEDATE));
     }
 
     /*
@@ -886,7 +886,7 @@ class CreateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.pickupDate").value(BLANK_PICKUPDATE));
+                .andExpect(jsonPath("$.data.pickupDate").value(INVALID_PICKUPDATE));
     }
 
     @Test
@@ -908,7 +908,7 @@ class CreateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.pickupDate").value(PAST_PICKUPDATE));
+                .andExpect(jsonPath("$.data.pickupDate").value(INVALID_PICKUPDATE));
     }
 
 
@@ -933,7 +933,7 @@ class CreateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.imageKeys").value("이미지는 1장 이상, 5장 이하로 등록해주세요."));
+                .andExpect(jsonPath("$.data.imageKeys").value(INVALID_IMAGE));
     }
 
     @Test
@@ -955,7 +955,7 @@ class CreateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.imageKeys").value(BLANK_IMAGE));
+                .andExpect(jsonPath("$.data.imageKeys").value(INVALID_IMAGE));
     }
 
     @Test
@@ -980,7 +980,7 @@ class CreateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.imageKeys").value(BLANK_IMAGE));
+                .andExpect(jsonPath("$.data.imageKeys").value(INVALID_IMAGE));
     }
 
     @Test

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/CreateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/CreateGroupBuyTest.java
@@ -46,13 +46,9 @@ class CreateGroupBuyTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Test
-    @DisplayName("공구 게시글 생성 성공 시 201 반환")
-    @WithMockCustomUser(id = 1L, username = "tester@example.com")
-    void createGroupBuySuccess() throws Exception {
-        // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("라면 공구")
+    private static CreateGroupBuyRequest.CreateGroupBuyRequestBuilder defaultValidRequest() {
+        return CreateGroupBuyRequest.builder()
+                .title("진라면 싸게 데려가세요!")
                 .name("진라면")
                 .url("https://example.com")
                 .price(10000)
@@ -63,7 +59,15 @@ class CreateGroupBuyTest {
                 .dueDate(LocalDateTime.now().plusDays(3))
                 .location("카카오테크 교육장")
                 .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
+                .imageKeys(List.of("images/image1.jpg"));
+    }
+
+    @Test
+    @DisplayName("공구 게시글 생성 성공 시 201 반환")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void createGroupBuySuccess() throws Exception {
+        // ====== 요청 바디 준비 ======
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .build();
 
         // ====== Facade 스텁 ======
@@ -87,18 +91,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_without_title() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
+        CreateGroupBuyRequest request = defaultValidRequest()
+                .title(null)
                 .build();
 
         // ====== Facade 스텁 ======
@@ -119,19 +113,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_blank_title() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .title("   ")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -152,19 +135,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_title_too_short() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .title("")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -185,21 +157,10 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_title_too_long() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .title("초특가 한정 수량 프리미엄 친환경 무농약 유기농 수제 천연 발효 장아찌 세트 " +
                         "지금 주문하면 무료 배송과 함께 사은품까지 증정되는 놀라운 기회를 놓치지 마세요 " +
                         "지금 바로 참여하여 건강한 한 끼의 행복을 경험하세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -223,18 +184,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_without_name() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
+        CreateGroupBuyRequest request = defaultValidRequest()
+                .name(null)
                 .build();
 
         // ====== Facade 스텁 ======
@@ -255,19 +206,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_blank_name() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .name("   ")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -288,19 +228,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_name_too_short() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .name("")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -321,21 +250,10 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_name_too_long() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .name("진라면 얼큰하고 깊은 맛에 해물과 한우 사골을 더해 더욱 진하고 풍부해진 국물, " +
                         "정통 수타식 면발로 즐기는 프리미엄 대용량 가정용 패밀리팩 5+1 이벤트 한정판, " +
                         "캠핑·홈파티 필수 아이템")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -359,19 +277,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_url_too_short() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .url("")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -392,9 +299,7 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_url_too_long() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .url("https://www.example.com/product/jinramen?q=" +
                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
@@ -417,15 +322,6 @@ class CreateGroupBuyTest {
                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -446,19 +342,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_invalid_url() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .url("hi")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -482,18 +367,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_without_price() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
+        CreateGroupBuyRequest request = defaultValidRequest()
+                .price(null)
                 .build();
 
         // ====== Facade 스텁 ======
@@ -514,19 +389,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_price_too_small() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .price(0)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -550,18 +414,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_without_totalAmount() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
+        CreateGroupBuyRequest request = defaultValidRequest()
+                .totalAmount(null)
                 .build();
 
         // ====== Facade 스텁 ======
@@ -582,19 +436,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_totalAmount_too_small() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .totalAmount(0)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -618,18 +461,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_without_unitAmount() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(10)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
+        CreateGroupBuyRequest request = defaultValidRequest()
+                .unitAmount(null)
                 .build();
 
         // ====== Facade 스텁 ======
@@ -650,19 +483,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_unitAmount_too_small() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(10000)
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .unitAmount(0)
-                .hostQuantity(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -686,18 +508,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_without_hostQuantity() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(10)
-                .unitAmount(1)
-                .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
+        CreateGroupBuyRequest request = defaultValidRequest()
+                .hostQuantity(null)
                 .build();
 
         // ====== Facade 스텁 ======
@@ -756,18 +568,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_without_description() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
+        CreateGroupBuyRequest request = defaultValidRequest()
+                .description(null)
                 .build();
 
         // ====== Facade 스텁 ======
@@ -788,19 +590,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_blank_description() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .description("   ")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -821,19 +612,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_description_too_short() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .description("진")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -854,14 +634,7 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_description_too_long() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .description("진라면 맛있어요라는 단순한 문장 속에는 깊고 진한 국물 맛과 탱글탱글한 면발의 조화, " +
                         "그리고 누구나 부담 없이 즐길 수 있는 매력적인 얼큰함이 모두 담겨 있습니다. " +
                         "봉지를 뜯는 순간 퍼지는 고추와 마늘, 파향을 머금은 스프의 향긋한 아로마는 바쁜 일상 속에서 잠시나마 따뜻한 위안을 전해 주고, " +
@@ -896,10 +669,6 @@ class CreateGroupBuyTest {
                         "진라면은 한 치의 고민 없이 꺼내어 “진라면 맛있어요”라고 외치게 만드는 마법 같은 경험을 선사합니다. " +
                         "끝없이 쏟아지는 수많은 라면 신제품 속에서도 꾸준히 사랑받아 온 이유는 명확합니다. 한결같은 맛과 품질, " +
                         "그리고 언제나 든든한 한 그릇으로 우리 곁을 지켜 온 신뢰가 있기 때문입니다. 진라면 맛있어요—이 한마디면 충분합니다.")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -923,18 +692,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_without_dueDate() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
+        CreateGroupBuyRequest request = defaultValidRequest()
+                .dueDate(null)
                 .build();
 
         // ====== Facade 스텁 ======
@@ -955,19 +714,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_dueDate_too_early() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .dueDate(LocalDateTime.now().minusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -1029,18 +777,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_without_location() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .description("진라면 사실 분")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
+        CreateGroupBuyRequest request = defaultValidRequest()
+                .location(null)
                 .build();
 
         // ====== Facade 스텁 ======
@@ -1061,19 +799,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_blank_location() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
-                .dueDate(LocalDateTime.now().plusDays(3))
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .location("   ")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -1094,19 +821,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_location_too_short() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
-                .dueDate(LocalDateTime.now().plusDays(3))
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .location("카")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -1127,21 +843,10 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_location_too_long() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
-                .dueDate(LocalDateTime.now().plusDays(3))
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .location("어디서 뵐까요? 카카오테크 교육장은 판교 테크노밸리 인근에 위치해 있어 접근성이 뛰어납니다. " +
                         "넓고 쾌적한 강의실은 최신형 컴퓨터와 대형 스크린을 갖추고 있으며, 자유로운 토론을 위한 휴게 라운지와 그룹 프로젝트룸이 마련되어 있습니다. " +
                         "현업 전문가가 실습 중심으로 진행하는 커리큘럼과 소규모 멘토링 세션을 통해 개발 역량을 더욱 높일 수 있는 최적의 학습 공간입니다.")
-                .pickupDate(LocalDateTime.now().plusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -1165,18 +870,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_without_pickupDate() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
-                .dueDate(LocalDateTime.now().plusDays(4))
-                .location("카카오테크 교육장")
-                .imageKeys(List.of("images/image1.jpg"))
+        CreateGroupBuyRequest request = defaultValidRequest()
+                .pickupDate(null)
                 .build();
 
         // ====== Facade 스텁 ======
@@ -1197,19 +892,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_pickupDate_too_early() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .pickupDate(LocalDateTime.now().minusDays(4))
-                .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ======
@@ -1233,18 +917,8 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_without_imageKeys() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
+        CreateGroupBuyRequest request = defaultValidRequest()
+                .imageKeys(null)
                 .build();
 
         // ====== Facade 스텁 ======
@@ -1265,18 +939,7 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_imageKeys_too_small() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .imageKeys(List.of())
                 .build();
 
@@ -1298,18 +961,7 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_imageKeys_too_large() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .imageKeys(List.of(
                         "images/image1.jpg", "images/image2.jpg",
                         "images/image3.jpg", "images/image4.jpg",
@@ -1334,18 +986,7 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_blank_imageKeys() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .imageKeys(List.of("   ", "images/image2.jpg"))
                 .build();
 
@@ -1367,18 +1008,7 @@ class CreateGroupBuyTest {
     @WithMockCustomUser(id = 1L, username = "tester@example.com")
     void createGroupBuyFail_invalid_imageKeys() throws Exception {
         // ====== 요청 바디 준비 ======
-        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
-                .title("진라면 싸게 데려가세요!")
-                .name("진라면")
-                .url("https://example.com")
-                .price(10000)
-                .totalAmount(100)
-                .unitAmount(10)
-                .hostQuantity(1)
-                .description("진라면 사실 분")
-                .dueDate(LocalDateTime.now().plusDays(3))
-                .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
+        CreateGroupBuyRequest request = defaultValidRequest()
                 .imageKeys(List.of("image1.jpg"))
                 .build();
 

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/CreateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/CreateGroupBuyTest.java
@@ -20,7 +20,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.BAD_REQUEST;
 import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.CREATE_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ValidationMessage.*;
 import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -104,8 +106,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.title").value("제목은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.title").value(TITLE_SIZE));
     }
 
     @Test
@@ -126,8 +128,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.title").value("제목은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.title").value(TITLE_SIZE));
     }
 
     @Test
@@ -148,8 +150,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.title").value("제목은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.title").value(TITLE_SIZE));
     }
 
     @Test
@@ -172,8 +174,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.title").value("제목은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.title").value(TITLE_SIZE));
     }
 
 
@@ -197,8 +199,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.name").value("상품명은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.name").value(NAME_SIZE));
     }
 
     @Test
@@ -219,8 +221,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.name").value("상품명은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.name").value(NAME_SIZE));
     }
 
     @Test
@@ -241,8 +243,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.name").value("상품명은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.name").value(NAME_SIZE));
     }
 
     @Test
@@ -265,8 +267,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.name").value("상품명은 공백을 제외한 1자 이상, 100자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.name").value(NAME_SIZE));
     }
 
 
@@ -290,8 +292,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.url").value("URL은 1자 이상, 2000자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.url").value(URL_SIZE));
     }
 
     @Test
@@ -333,8 +335,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.url").value("URL은 1자 이상, 2000자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.url").value(URL_SIZE));
     }
 
     @Test
@@ -355,8 +357,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.url").value("URL 형식이 올바르지 않습니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.url").value(INVALID_URL));
     }
 
 
@@ -380,8 +382,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.price").value("상품 가격은 필수 입력 항목입니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.price").value(BLANK_PRICE));
     }
 
     @Test
@@ -402,8 +404,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.price").value("상품 가격은 1 이상이어야 합니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.price").value(PRICE_SIZE));
     }
 
 
@@ -427,8 +429,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.totalAmount").value("상품 전체 수량은 필수 입력 항목입니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.totalAmount").value(BLANK_TOTAL_AMOUNT));
     }
 
     @Test
@@ -449,8 +451,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.totalAmount").value("상품 전체 수량은 1 이상이어야 합니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.totalAmount").value(TOTAL_AMOUNT_SIZE));
     }
 
 
@@ -474,8 +476,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.unitAmount").value("상품 주문 단위는 필수 입력 항목입니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.unitAmount").value(BLANK_UNIT_AMOUNT));
     }
 
     @Test
@@ -496,8 +498,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.unitAmount").value("상품 주문 단위는 1 이상이어야 합니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.unitAmount").value(UNIT_AMOUNT_SIZE));
     }
 
 
@@ -521,8 +523,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.hostQuantity").value("주최자 주문 수량은 필수 입력 항목입니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.hostQuantity").value(BLANK_HOST_QUANTITY));
     }
 
     /*
@@ -556,7 +558,7 @@ class CreateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.hostQuantity").value("주최자 주문 수량은 0 이상이어야 합니다."));
+                .andExpect(jsonPath("$.data.hostQuantity").value(HOST_QUANTITY_SIZE));
     }
      */
 
@@ -581,8 +583,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.description").value("상품 설명은 공백을 제외한 2자 이상, 2000자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.description").value(DESCRIPTION_SIZE));
     }
 
     @Test
@@ -603,8 +605,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.description").value("상품 설명은 공백을 제외한 2자 이상, 2000자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.description").value(DESCRIPTION_SIZE));
     }
 
     @Test
@@ -625,8 +627,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.description").value("상품 설명은 공백을 제외한 2자 이상, 2000자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.description").value(DESCRIPTION_SIZE));
     }
 
     @Test
@@ -680,8 +682,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.description").value("상품 설명은 공백을 제외한 2자 이상, 2000자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.description").value(DESCRIPTION_SIZE));
     }
 
 
@@ -705,8 +707,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.dueDate").value("마감 일자는 필수 입력 항목입니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.dueDate").value(BLANK_DUEDATE));
     }
 
     @Test
@@ -727,8 +729,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.dueDate").value("마감 일자는 현재 시간 이후여야 합니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.dueDate").value(PAST_DUEDATE));
     }
 
     /*
@@ -763,7 +765,7 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
                 .andExpect(jsonPath("$.data.dueDate").value("마감 일자는 yyyy-MM-dd'T'HH:mm 형식으로 입력해주세요."));
     }
 
@@ -790,8 +792,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.location").value("거래 장소는 공백을 제외한 2자 이상, 85자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.location").value(LOCATION_SIZE));
     }
 
     @Test
@@ -812,8 +814,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.location").value("거래 장소는 공백을 제외한 2자 이상, 85자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.location").value(LOCATION_SIZE));
     }
 
     @Test
@@ -834,8 +836,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.location").value("거래 장소는 공백을 제외한 2자 이상, 85자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.location").value(LOCATION_SIZE));
     }
 
     @Test
@@ -858,8 +860,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.location").value("거래 장소는 공백을 제외한 2자 이상, 85자 이하로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.location").value(LOCATION_SIZE));
     }
 
 
@@ -883,8 +885,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.pickupDate").value("픽업 일자는 필수 입력 항목입니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.pickupDate").value(BLANK_PICKUPDATE));
     }
 
     @Test
@@ -905,8 +907,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.pickupDate").value("픽업 일자는 현재 시간 이후여야 합니다."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.pickupDate").value(PAST_PICKUPDATE));
     }
 
 
@@ -930,7 +932,7 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
                 .andExpect(jsonPath("$.data.imageKeys").value("이미지는 1장 이상, 5장 이하로 등록해주세요."));
     }
 
@@ -952,8 +954,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.imageKeys").value("이미지는 1장 이상, 5장 이하로 등록해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.imageKeys").value(BLANK_IMAGE));
     }
 
     @Test
@@ -977,8 +979,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.imageKeys").value("이미지는 1장 이상, 5장 이하로 등록해주세요."));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.imageKeys").value(BLANK_IMAGE));
     }
 
     @Test
@@ -999,8 +1001,8 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.*", hasItem("이미지는 반드시 images/로 시작해야 합니다")));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.*", hasItem(INVALID_IMAGE)));
     }
 
     @Test
@@ -1021,7 +1023,7 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.*", hasItem("이미지는 반드시 images/로 시작해야 합니다")));
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.*", hasItem(INVALID_IMAGE)));
     }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/CreateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/CreateGroupBuyTest.java
@@ -5,7 +5,6 @@ import com.moogsan.moongsan_backend.domain.groupbuy.controller.command.CreateGro
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.CreateGroupBuyRequest;
 import com.moogsan.moongsan_backend.domain.groupbuy.facade.command.GroupBuyCommandFacade;
 import com.moogsan.moongsan_backend.global.lock.DuplicateRequestPreventer;
-import com.moogsan.moongsan_backend.support.fake.InMemoryDuplicateRequestPreventer;
 import com.moogsan.moongsan_backend.support.security.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -22,7 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.CREATE_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.CREATE_SUCCESS;
 import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/CreateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/CreateGroupBuyTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.CREATE_SUCCESS;
 import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -76,7 +77,7 @@ class CreateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.message").value("공구 게시글이 성공적으로 업로드되었습니다."))
+                .andExpect(jsonPath("$.message").value(CREATE_SUCCESS))
                 .andExpect(jsonPath("$.data.postId").value(42L));
     }
 

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/DeleteGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/DeleteGroupBuyTest.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.DELETE_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.DELETE_SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/DeleteGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/DeleteGroupBuyTest.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.DELETE_SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -51,7 +52,7 @@ public class DeleteGroupBuyTest {
         mockMvc.perform(delete("/api/group-buys/{postId}", 20L)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("공구 게시글이 성공적으로 삭제되었습니다."));
+                .andExpect(jsonPath("$.message").value(DELETE_SUCCESS));
 
         Mockito.verify(groupBuyCommandFacade)
                 .deleteGroupBuy(any(), eq(20L));

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/EndGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/EndGroupBuyTest.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.END_SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -51,7 +52,7 @@ public class EndGroupBuyTest {
         mockMvc.perform(patch("/api/group-buys/{postId}/end", 20L)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("공구가 성공적으로 종료되었습니다."));
+                .andExpect(jsonPath("$.message").value(END_SUCCESS));
 
         Mockito.verify(groupBuyCommandFacade)
                 .endGroupBuy(any(), eq(20L));

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/EndGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/EndGroupBuyTest.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.END_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.END_SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/LeaveGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/LeaveGroupBuyTest.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.LEAVE_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.LEAVE_SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/LeaveGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/LeaveGroupBuyTest.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.LEAVE_SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -51,7 +52,7 @@ public class LeaveGroupBuyTest {
         mockMvc.perform(delete("/api/group-buys/{postId}/participants", 20L)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("공구 참여가 성공적으로 취소되었습니다."));
+                .andExpect(jsonPath("$.message").value(LEAVE_SUCCESS));
 
         Mockito.verify(groupBuyCommandFacade)
                 .leaveGroupBuy(any(), eq(20L));

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/UpdateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/UpdateGroupBuyTest.java
@@ -2,12 +2,14 @@ package com.moogsan.moongsan_backend.unit.groupbuy.controller.command;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moogsan.moongsan_backend.domain.groupbuy.controller.command.UpdateGroupBuyController;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.CreateGroupBuyRequest;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.UpdateGroupBuyRequest;
 import com.moogsan.moongsan_backend.domain.groupbuy.facade.command.GroupBuyCommandFacade;
 import com.moogsan.moongsan_backend.support.fake.InMemoryDuplicateRequestPreventer;
 import com.moogsan.moongsan_backend.support.security.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -20,7 +22,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.BAD_REQUEST;
 import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.UPDATE_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ValidationMessage.*;
+import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -41,6 +46,18 @@ public class UpdateGroupBuyTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    private static UpdateGroupBuyRequest.UpdateGroupBuyRequestBuilder defaultValidRequest() {
+        return UpdateGroupBuyRequest.builder()
+                .title("라면 공구")
+                .name("진라면")
+                .hostQuantity(2)
+                .description("라면 맛있어요")
+                .dueDate(LocalDateTime.now().plusDays(3))
+                .pickupDate(LocalDateTime.now().plusDays(10))
+                .dateModificationReason("배송이 늦네요...")
+                .imageKeys(List.of("images/image1.jpg"));
+    }
 
     @Test
     @DisplayName("공구 게시글 수정 성공 시 200 반환")
@@ -69,6 +86,417 @@ public class UpdateGroupBuyTest {
     }
 
     @Test
+    @DisplayName("공구 게시글 수정 실패 시 401 반환 - 비인증 사용자 접근 불가")
+    void getGroupBuyEditInfo_unauthorized() throws Exception {
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /// title
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - title 공백")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_blank_title() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .title("   ")
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.title").value(TITLE_SIZE));
+    }
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - title 최소값 미만")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_title_too_short() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .title("")
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.title").value(TITLE_SIZE));
+    }
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - title 최대 값 초과")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_title_too_long() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .title("초특가 한정 수량 프리미엄 친환경 무농약 유기농 수제 천연 발효 장아찌 세트 " +
+                        "지금 주문하면 무료 배송과 함께 사은품까지 증정되는 놀라운 기회를 놓치지 마세요 " +
+                        "지금 바로 참여하여 건강한 한 끼의 행복을 경험하세요!")
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.title").value(TITLE_SIZE));
+    }
+
+
+    /// name
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - name 공백")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_blank_name() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .name("  ")
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.name").value(NAME_SIZE));
+    }
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - name 최소값 미만")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_name_too_short() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .name("")
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.name").value(NAME_SIZE));
+    }
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - name 최대 값 초과")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_name_too_long() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .name("진라면 얼큰하고 깊은 맛에 해물과 한우 사골을 더해 더욱 진하고 풍부해진 국물, " +
+                        "정통 수타식 면발로 즐기는 프리미엄 대용량 가정용 패밀리팩 5+1 이벤트 한정판, " +
+                        "캠핑·홈파티 필수 아이템")
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.name").value(NAME_SIZE));
+    }
+
+    /// hostQuantity
+
+    /*
+    @Test
+    @DisplayName("공구 게시글 실패 시 400 반환 - hostQuantity 최소값 미만")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void createGroupBuyFail_hostQuantity_too_small() throws Exception {
+        // ====== 요청 바디 준비 ======
+        CreateGroupBuyRequest request = CreateGroupBuyRequest.builder()
+                .title("진라면 싸게 데려가세요!")
+                .name("진라면")
+                .url("https://example.com")
+                .price(10000)
+                .totalAmount(10000)
+                .unitAmount(10)
+                .hostQuantity(0)
+                .description("라면 맛있어요")
+                .dueDate(LocalDateTime.now().plusDays(3))
+                .location("카카오테크 교육장")
+                .pickupDate(LocalDateTime.now().plusDays(4))
+                .imageKeys(List.of("images/image1.jpg"))
+                .build();
+
+        // ====== Facade 스텁 ======
+        Mockito.when(groupBuyCommandFacade.createGroupBuy(any(), any()))
+                .thenReturn(42L);
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(post("/api/group-buys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
+                .andExpect(jsonPath("$.data.hostQuantity").value("주최자 주문 수량은 0 이상이어야 합니다."));
+    }
+     */
+
+
+    /// description
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - description 공백")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_blank_description() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .description("   ")
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.description").value(DESCRIPTION_SIZE));
+    }
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - description 최소값 미만")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_description_too_short() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .description("진")
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.description").value(DESCRIPTION_SIZE));
+    }
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - description 최대 값 초과")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_description_too_long() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .description("진라면 맛있어요라는 단순한 문장 속에는 깊고 진한 국물 맛과 탱글탱글한 면발의 조화, " +
+                        "그리고 누구나 부담 없이 즐길 수 있는 매력적인 얼큰함이 모두 담겨 있습니다. " +
+                        "봉지를 뜯는 순간 퍼지는 고추와 마늘, 파향을 머금은 스프의 향긋한 아로마는 바쁜 일상 속에서 잠시나마 따뜻한 위안을 전해 주고, " +
+                        "120g의 면과 40g의 스프가 어우러져 완성되는 550ml의 국물 한 그릇은 그 자체로 훌륭한 한 끼 식사가 됩니다. " +
+                        "면은 반죽과 숙성 과정을 최적화해 쫀득함이 살아있고, " +
+                        "국물은 6가지 향신료와 자연 조미료의 균형 잡힌 배합으로 느껴지는 감칠맛이 진하면서도 깔끔해 마지막 한 방울까지 놓치고 싶지 않게 만듭니다. " +
+                        "간편 조리법 또한 진라면의 큰 장점으로, 끓는 물에 면과 스프, 건더기를 넣고 4분만 기다리면 완성되어 시간 대비 최고의 만족을 선사하고, " +
+                        "취향에 따라 계란, 대파, 김치, 치즈 등 각종 토핑을 추가해 나만의 레시피로 재해석할 수 있습니다. " +
+                        "특히 소비자 설문 조사에서 매년 “가장 맛있는 라면”으로 선정되며 스테디셀러로 자리매김한 브랜드 히스토리는, " +
+                        "엄선된 원재료와 철저한 품질 관리, 그리고 오랜 전통과 노하우가 결합되어 매 제품마다 일관된 맛을 유지해 온 결과입니다. " +
+                        "포장 단위는 4개입, 10개입, 20개입으로 선택할 수 있어 가정용으로는 물론, 사무실 비치용, 캠핑 등의 야외 활동에도 부담 없이 가져갈 수 있으며, " +
+                        "유통기한은 제조일로부터 9개월로 넉넉해 여유 있게 보관 가능합니다. " +
+                        "진라면 한 봉지는 칼로리 460kcal로 적당한 에너지를 공급해 주며, 보관은 직사광선을 피해 상온에 두는 것만으로도 충분합니다. " +
+                        "온 가족이 둘러앉아 뜨끈한 한 끼를 나눌 때나, 혼자만의 시간에 잔잔한 위로가 필요할 때, 급히 끓여야 하는 야식 타임에도, " +
+                        "진라면은 한 치의 고민 없이 꺼내어 “진라면 맛있어요”라고 외치게 만드는 마법 같은 경험을 선사합니다. " +
+                        "끝없이 쏟아지는 수많은 라면 신제품 속에서도 꾸준히 사랑받아 온 이유는 명확합니다. 한결같은 맛과 품질, " +
+                        "그리고 언제나 든든한 한 그릇으로 우리 곁을 지켜 온 신뢰가 있기 때문입니다. 진라면 맛있어요—이 한마디면 충분합니다." +
+                        "진라면 맛있어요라는 단순한 문장 속에는 깊고 진한 국물 맛과 탱글탱글한 면발의 조화, " +
+                        "그리고 누구나 부담 없이 즐길 수 있는 매력적인 얼큰함이 모두 담겨 있습니다. " +
+                        "봉지를 뜯는 순간 퍼지는 고추와 마늘, 파향을 머금은 스프의 향긋한 아로마는 바쁜 일상 속에서 잠시나마 따뜻한 위안을 전해 주고, " +
+                        "120g의 면과 40g의 스프가 어우러져 완성되는 550ml의 국물 한 그릇은 그 자체로 훌륭한 한 끼 식사가 됩니다. " +
+                        "면은 반죽과 숙성 과정을 최적화해 쫀득함이 살아있고, " +
+                        "국물은 6가지 향신료와 자연 조미료의 균형 잡힌 배합으로 느껴지는 감칠맛이 진하면서도 깔끔해 마지막 한 방울까지 놓치고 싶지 않게 만듭니다. " +
+                        "간편 조리법 또한 진라면의 큰 장점으로, 끓는 물에 면과 스프, 건더기를 넣고 4분만 기다리면 완성되어 시간 대비 최고의 만족을 선사하고, " +
+                        "취향에 따라 계란, 대파, 김치, 치즈 등 각종 토핑을 추가해 나만의 레시피로 재해석할 수 있습니다. " +
+                        "특히 소비자 설문 조사에서 매년 “가장 맛있는 라면”으로 선정되며 스테디셀러로 자리매김한 브랜드 히스토리는, " +
+                        "엄선된 원재료와 철저한 품질 관리, 그리고 오랜 전통과 노하우가 결합되어 매 제품마다 일관된 맛을 유지해 온 결과입니다. " +
+                        "포장 단위는 4개입, 10개입, 20개입으로 선택할 수 있어 가정용으로는 물론, 사무실 비치용, 캠핑 등의 야외 활동에도 부담 없이 가져갈 수 있으며, " +
+                        "유통기한은 제조일로부터 9개월로 넉넉해 여유 있게 보관 가능합니다. " +
+                        "진라면 한 봉지는 칼로리 460kcal로 적당한 에너지를 공급해 주며, 보관은 직사광선을 피해 상온에 두는 것만으로도 충분합니다. " +
+                        "온 가족이 둘러앉아 뜨끈한 한 끼를 나눌 때나, 혼자만의 시간에 잔잔한 위로가 필요할 때, 급히 끓여야 하는 야식 타임에도, " +
+                        "진라면은 한 치의 고민 없이 꺼내어 “진라면 맛있어요”라고 외치게 만드는 마법 같은 경험을 선사합니다. " +
+                        "끝없이 쏟아지는 수많은 라면 신제품 속에서도 꾸준히 사랑받아 온 이유는 명확합니다. 한결같은 맛과 품질, " +
+                        "그리고 언제나 든든한 한 그릇으로 우리 곁을 지켜 온 신뢰가 있기 때문입니다. 진라면 맛있어요—이 한마디면 충분합니다.")
+                .build();
+
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.description").value(DESCRIPTION_SIZE));
+    }
+
+
+    /// dueDate
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - dueDate 최소값 미만")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_dueDate_too_early() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .dueDate(LocalDateTime.now().minusDays(3))
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.dueDate").value(PAST_DUEDATE));
+    }
+
+    /*
+    @Test
+    @DisplayName("공구 게시글 실패 시 400 반환 - dueDate 형식 위반")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void createGroupBuyFail_invalid_dueDate() throws Exception {
+
+        String dueDate = "2025-05-26 11:03:33";
+
+        String json = "{"
+                + "\"title\":\"진라면 공구\","
+                + "\"name\":\"진라면\","
+                + "\"url\":\"https://example.com\","
+                + "\"price\":1000,"
+                + "\"totalAmount\":10,"
+                + "\"unitAmount\":1,"
+                + "\"hostQuantity\":1,"
+                + "\"description\":\"유효한 설명입니다.\","
+                + "\"dueDate\":\"2025-05-26T11:03:33\","
+                + "\"location\":\"테스트 장소\","
+                + "\"pickupDate\":\"2025-05-28T10:00\","
+                + "\"imageKeys\":[\"images/image1.jpg\"]"
+                + "}";
+
+        // ====== Facade 스텁 ======
+        Mockito.when(groupBuyCommandFacade.createGroupBuy(any(), any()))
+                .thenReturn(42L);
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(post("/api/group-buys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
+                .andExpect(jsonPath("$.data.dueDate").value("마감 일자는 yyyy-MM-dd'T'HH:mm 형식으로 입력해주세요."));
+    }
+
+     */
+
+    /// pickupDate
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - pickupDate 최소값 미만")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_pickupDate_too_early() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .pickupDate(LocalDateTime.now().minusDays(4))
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.pickupDate").value(PAST_PICKUPDATE));
+    }
+
+
+    ///  imageKeys
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - imageKeys 최소 값 미만")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_imageKeys_too_small() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .imageKeys(List.of())
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.imageKeys").value(BLANK_IMAGE));
+    }
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - imageKeys 최대 값 초과")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_imageKeys_too_large() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .imageKeys(List.of(
+                        "images/image1.jpg", "images/image2.jpg",
+                        "images/image3.jpg", "images/image4.jpg",
+                        "images/image5.jpg", "images/image6.jpg"))
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.imageKeys").value(BLANK_IMAGE));
+    }
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - imageKeys 공백")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_blank_imageKeys() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .imageKeys(List.of("   ", "images/image2.jpg"))
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.*", hasItem(INVALID_IMAGE)));
+    }
+
+    @Test
+    @DisplayName("공구 게시글 수정 실패 시 400 반환 - imageKeys 형식 오류")
+    @WithMockCustomUser(id = 1L, username = "tester@example.com")
+    void updateGroupBuyFail_invalid_imageKeys() throws Exception {
+        // ====== 요청 바디 준비 ======
+        UpdateGroupBuyRequest request = defaultValidRequest()
+                .imageKeys(List.of("image1.jpg"))
+                .build();
+
+        // ====== 요청 & 검증 ======
+        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.*", hasItem(INVALID_IMAGE)));
+    }
+
+    @Test
     @DisplayName("공구 게시글 수정 실패 시 400 반환 - reason 명시 없이 pickupDate 변경")
     void updateGroupBuy_change_pickupDate_without_reason() throws Exception {
         // ====== 요청 바디 준비 ======
@@ -83,16 +511,7 @@ public class UpdateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("입력 형식이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.data.dateModificationReason").value("픽업 일자가 변경된 경우 사유를 작성해야 합니다."));
-    }
-
-    @Test
-    @DisplayName("공구 게시글 수정 실패 시 401 반환 - 비인증 사용자 접근 불가")
-    void getGroupBuyEditInfo_unauthorized() throws Exception {
-        mockMvc.perform(patch("/api/group-buys/{postId}", 20L)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{}"))
-                .andExpect(status().isUnauthorized());
+                .andExpect(jsonPath("$.message").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.data.dateModificationReason").value(BLANK_DATEMODIFICATION_REASON));
     }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/UpdateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/UpdateGroupBuyTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.UPDATE_SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -64,7 +65,7 @@ public class UpdateGroupBuyTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("공구 게시글이 성공적으로 수정되었습니다."));
+                .andExpect(jsonPath("$.message").value(UPDATE_SUCCESS));
     }
 
     @Test

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/UpdateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/UpdateGroupBuyTest.java
@@ -20,7 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.UPDATE_SUCCESS;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.UPDATE_SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/UpdateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/UpdateGroupBuyTest.java
@@ -357,7 +357,7 @@ public class UpdateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.dueDate").value(PAST_DUEDATE));
+                .andExpect(jsonPath("$.data.dueDate").value(INVALID_DUEDATE));
     }
 
     /*
@@ -415,7 +415,7 @@ public class UpdateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.pickupDate").value(PAST_PICKUPDATE));
+                .andExpect(jsonPath("$.data.pickupDate").value(INVALID_PICKUPDATE));
     }
 
 
@@ -436,7 +436,7 @@ public class UpdateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.imageKeys").value(BLANK_IMAGE));
+                .andExpect(jsonPath("$.data.imageKeys").value(INVALID_IMAGE));
     }
 
     @Test
@@ -457,7 +457,7 @@ public class UpdateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.imageKeys").value(BLANK_IMAGE));
+                .andExpect(jsonPath("$.data.imageKeys").value(INVALID_IMAGE));
     }
 
     @Test

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyDetailInfoTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyDetailInfoTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_DETAIL_SUCCESS;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -76,7 +77,7 @@ public class GetGroupBuyDetailInfoTest {
         // When & Then
         mockMvc.perform(get("/api/group-buys/100"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("공구 게시글 상세 정보를 성공적으로 조회했습니다."));
+                .andExpect(jsonPath("$.message").value(GET_DETAIL_SUCCESS));
 
         Mockito.verify(queryFacade).getGroupBuyDetailInfo(eq(1L), eq(100L));
     }
@@ -120,7 +121,7 @@ public class GetGroupBuyDetailInfoTest {
 
         mockMvc.perform(get("/api/group-buys/100"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("공구 게시글 상세 정보를 성공적으로 조회했습니다."));
+                .andExpect(jsonPath("$.message").value(GET_DETAIL_SUCCESS));
 
         Mockito.verify(queryFacade).getGroupBuyDetailInfo(eq(null), eq(100L));
     }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyEditInfoTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyEditInfoTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_UPDATE_SUCCESS;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -57,7 +58,7 @@ public class GetGroupBuyEditInfoTest {
         // When & Then
         mockMvc.perform(get("/api/group-buys/{postId}/edit", 20L))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("공구 게시글 수정용 정보를 성공적으로 조회했습니다."));
+                .andExpect(jsonPath("$.message").value(GET_UPDATE_SUCCESS));
 
         Mockito.verify(queryFacade).getGroupBuyEditInfo(eq(20L));
     }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyHostAccountInfoTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyHostAccountInfoTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_ACCOUNT_SUCCESS;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -47,7 +48,7 @@ public class GetGroupBuyHostAccountInfoTest {
         // When & Then
         mockMvc.perform(get("/api/group-buys/{postId}/host/account", 20L))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("공구 게시글 주최자 계좌 정보를 성공적으로 조회했습니다."));
+                .andExpect(jsonPath("$.message").value(GET_ACCOUNT_SUCCESS));
         //.andExpect(jsonPath("$.data.content[0].postId").value(100));
 
         Mockito.verify(queryFacade).getGroupBuyHostAccountInfo(eq(1L), eq(20L));

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyHostedListTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyHostedListTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.Collections;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_HOSTED_SUCCESS;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -79,7 +80,7 @@ class GetGroupBuyHostedListTest {
                         .param("limit", "5")
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("주최 공구 리스트를 성공적으로 조회했습니다."));
+                .andExpect(jsonPath("$.message").value(GET_HOSTED_SUCCESS));
                 //.andExpect(jsonPath("$.data.content[0].postId").value(100));
 
         Mockito.verify(queryFacade).getGroupBuyHostedList(

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyListByCursorTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyListByCursorTest.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_LIST_SUCCESS;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -89,7 +90,7 @@ public class GetGroupBuyListByCursorTest {
                         .param("openOnly", "false")
                         .param("keyword", "참치"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("전체 공구 리스트를 성공적으로 조회했습니다."));
+                .andExpect(jsonPath("$.message").value(GET_LIST_SUCCESS));
 
         Mockito.verify(queryFacade).getGroupBuyListByCursor(
                 eq(1L),                                         // userId

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyParticipantsInfoTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyParticipantsInfoTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_PARTICIPANTS_SUCCESS;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -59,7 +60,7 @@ public class GetGroupBuyParticipantsInfoTest {
         // When & Then
         mockMvc.perform(get("/api/group-buys/{postId}/participants", 20L))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("공구 참여자 리스트를 성공적으로 조회했습니다."));
+                .andExpect(jsonPath("$.message").value(GET_PARTICIPANTS_SUCCESS));
 
         Mockito.verify(queryFacade).getGroupBuyParticipantsInfo(
                 eq(1L), eq(20L)

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyParticipatedListTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyParticipatedListTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.Collections;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_PARTICIPATED_SUCCESS;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -81,7 +82,7 @@ public class GetGroupBuyParticipatedListTest {
                         .param("limit", "5")
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("참여 공구 리스트를 성공적으로 조회했습니다."));
+                .andExpect(jsonPath("$.message").value(GET_PARTICIPATED_SUCCESS));
         //.andExpect(jsonPath("$.data.content[0].postId").value(100));
 
         Mockito.verify(queryFacade).getGroupBuyParticipatedList(

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyWishListTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyWishListTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.Collections;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.GET_WISH_SUCCESS;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -79,7 +80,7 @@ public class GetGroupBuyWishListTest {
                         .param("limit", "5")
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("관심 공구 리스트를 성공적으로 조회했습니다."));
+                .andExpect(jsonPath("$.message").value(GET_WISH_SUCCESS));
         //.andExpect(jsonPath("$.data.content[0].postId").value(100));
 
         Mockito.verify(queryFacade).getGroupBuyWishList(

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/CreateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/CreateGroupBuyTest.java
@@ -3,7 +3,6 @@ package com.moogsan.moongsan_backend.unit.groupbuy.service.command;
 import com.moogsan.moongsan_backend.domain.chatting.Facade.command.ChattingCommandFacade;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.CreateGroupBuyRequest;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
-import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
 import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyCommandMapper;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
@@ -11,7 +10,6 @@ import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandServi
 import com.moogsan.moongsan_backend.domain.image.mapper.ImageMapper;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import com.moogsan.moongsan_backend.global.lock.DuplicateRequestPreventer;
-import com.moogsan.moongsan_backend.support.fake.InMemoryDuplicateRequestPreventer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,13 +17,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ContextConfiguration;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_DIVISOR;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_DIVISOR;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/CreateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/CreateGroupBuyTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.ContextConfiguration;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.NOT_DIVISOR;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
@@ -104,7 +105,7 @@ public class CreateGroupBuyTest {
 
         assertThatThrownBy(() -> createGroupBuy.createGroupBuy(user, request))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("상품 주문 단위는 상품 전체 수량의 약수여야 합니다.");
+                .hasMessageContaining(NOT_DIVISOR);
     }
 
     @Test
@@ -114,6 +115,6 @@ public class CreateGroupBuyTest {
 
         assertThatThrownBy(() -> createGroupBuy.createGroupBuy(user, request))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("상품 주문 단위는 상품 전체 수량의 약수여야 합니다.");
+                .hasMessageContaining(NOT_DIVISOR);
     }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/DeleteGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/DeleteGroupBuyTest.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -75,7 +76,7 @@ public class DeleteGroupBuyTest {
 
         assertThatThrownBy(() -> deleteGroupBuy.deleteGroupBuy(hostUser, 1L))
                 .isInstanceOf(GroupBuyNotFoundException.class)
-                .hasMessageContaining("존재하지 않는 공구입니다");
+                .hasMessageContaining(NOT_EXIST);
     }
 
     @Test
@@ -87,7 +88,7 @@ public class DeleteGroupBuyTest {
 
         assertThatThrownBy(() -> deleteGroupBuy.deleteGroupBuy(hostUser, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("공구 삭제는 공구가 열려있는 상태에서만 가능합니다.");
+                .hasMessageContaining(NOT_OPEN);
     }
 
     @Test
@@ -101,7 +102,7 @@ public class DeleteGroupBuyTest {
 
         assertThatThrownBy(() -> deleteGroupBuy.deleteGroupBuy(hostUser, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("공구 삭제는 공구가 열려있는 상태에서만 가능합니다.");
+                .hasMessageContaining(NOT_OPEN);
     }
 
     @Test
@@ -117,7 +118,7 @@ public class DeleteGroupBuyTest {
 
         assertThatThrownBy(() -> deleteGroupBuy.deleteGroupBuy(hostUser, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("참여자가 1명 이상일 경우 공구를 삭제할 수 없습니다.");
+                .hasMessageContaining(EXIST_PARTICIPANT);
     }
 
     @Test
@@ -135,6 +136,6 @@ public class DeleteGroupBuyTest {
 
         assertThatThrownBy(() -> deleteGroupBuy.deleteGroupBuy(otherUser, 1L))
                 .isInstanceOf(GroupBuyNotHostException.class)
-                .hasMessageContaining("공구 삭제는 공구의 주최자만 요청 가능합니다.");
+                .hasMessageContaining(NOT_HOST);
     }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/DeleteGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/DeleteGroupBuyTest.java
@@ -1,13 +1,11 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.command;
 
-import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.UpdateGroupBuyRequest;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.DeleteGroupBuy;
-import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.UpdateGroupBuy;
 import com.moogsan.moongsan_backend.domain.image.mapper.ImageMapper;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
@@ -20,10 +18,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/EndGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/EndGroupBuyTest.java
@@ -6,11 +6,6 @@ import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyN
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.EndGroupBuy;
-import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.LeaveGroupBuy;
-import com.moogsan.moongsan_backend.domain.image.mapper.ImageMapper;
-import com.moogsan.moongsan_backend.domain.order.entity.Order;
-import com.moogsan.moongsan_backend.domain.order.exception.specific.OrderNotFoundException;
-import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/EndGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/EndGroupBuyTest.java
@@ -23,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -74,7 +75,7 @@ public class EndGroupBuyTest {
 
         assertThatThrownBy(() -> endGroupBuy.endGroupBuy(participant, 1L))
                 .isInstanceOf(GroupBuyNotFoundException.class)
-                .hasMessageContaining("존재하지 않는 공구입니다");
+                .hasMessageContaining(NOT_EXIST);
     }
 
     @Test
@@ -87,7 +88,7 @@ public class EndGroupBuyTest {
 
         assertThatThrownBy(() -> endGroupBuy.endGroupBuy(participant, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("공구 종료는 모집 마감 이후에만 가능합니다.");
+                .hasMessageContaining(BEFORE_CLOSED);
     }
 
     @Test
@@ -100,7 +101,7 @@ public class EndGroupBuyTest {
 
         assertThatThrownBy(() -> endGroupBuy.endGroupBuy(participant, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("이미 종료된 공구입니다.");
+                .hasMessageContaining(AFTER_ENDED);
     }
 
     @Test
@@ -115,7 +116,7 @@ public class EndGroupBuyTest {
 
         assertThatThrownBy(() -> endGroupBuy.endGroupBuy(participant, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("공구 종료는 공구 마감 일자 이후에만 가능합니다.");
+                .hasMessageContaining(BEFORE_CLOSED);
     }
 
     @Test
@@ -132,7 +133,7 @@ public class EndGroupBuyTest {
 
         assertThatThrownBy(() -> endGroupBuy.endGroupBuy(participant, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("공구 종료는 공구 픽업 일자 이후에만 가능합니다.");
+                .hasMessageContaining(BEFORE_PICKUP_DATE);
     }
 
     @Test
@@ -151,7 +152,7 @@ public class EndGroupBuyTest {
 
         assertThatThrownBy(() -> endGroupBuy.endGroupBuy(participant, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("공구 종료는 공구 체결 이후에만 가능합니다.");
+                .hasMessageContaining(BEFORE_FIXED);
     }
 
     @Test
@@ -171,6 +172,6 @@ public class EndGroupBuyTest {
 
         assertThatThrownBy(() -> endGroupBuy.endGroupBuy(participant, 1L))
                 .isInstanceOf(GroupBuyNotHostException.class)
-                .hasMessageContaining("공구 종료는 공구의 주최자만 요청 가능합니다.");
+                .hasMessageContaining(NOT_HOST);
     }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/LeaveGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/LeaveGroupBuyTest.java
@@ -27,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -78,7 +79,7 @@ public class LeaveGroupBuyTest {
 
         assertThatThrownBy(() -> leaveGroupBuy.leaveGroupBuy(participant, 1L))
                 .isInstanceOf(GroupBuyNotFoundException.class)
-                .hasMessageContaining("존재하지 않는 공구입니다");
+                .hasMessageContaining(NOT_EXIST);
     }
 
     @Test
@@ -91,7 +92,7 @@ public class LeaveGroupBuyTest {
 
         assertThatThrownBy(() -> leaveGroupBuy.leaveGroupBuy(participant, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("공구 참여 취소는 공구가 열려있는 상태에서만 가능합니다.");
+                .hasMessageContaining(NOT_OPEN);
     }
 
     @Test
@@ -105,7 +106,7 @@ public class LeaveGroupBuyTest {
 
         assertThatThrownBy(() -> leaveGroupBuy.leaveGroupBuy(participant, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("공구 참여 취소는 공구가 열려있는 상태에서만 가능합니다.");
+                .hasMessageContaining(NOT_OPEN);
     }
 
     @Test
@@ -122,6 +123,6 @@ public class LeaveGroupBuyTest {
 
         assertThatThrownBy(() -> leaveGroupBuy.leaveGroupBuy(participant, 1L))
                 .isInstanceOf(OrderNotFoundException.class)
-                .hasMessageContaining("존재하지 않는 주문입니다.");
+                .hasMessageContaining(NOT_EXIST_ORDER);
     }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/LeaveGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/LeaveGroupBuyTest.java
@@ -1,17 +1,11 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.command;
 
 import com.moogsan.moongsan_backend.domain.chatting.Facade.command.ChattingCommandFacade;
-import com.moogsan.moongsan_backend.domain.chatting.service.command.LeaveChatRoom;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
-import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
-import com.moogsan.moongsan_backend.domain.groupbuy.facade.command.GroupBuyCommandFacade;
-import com.moogsan.moongsan_backend.domain.groupbuy.facade.command.GroupBuyCommandFacadeImpl;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
-import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.DeleteGroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.LeaveGroupBuy;
-import com.moogsan.moongsan_backend.domain.image.mapper.ImageMapper;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.exception.specific.OrderNotFoundException;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
@@ -27,7 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/UpdateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/UpdateGroupBuyTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -84,7 +85,7 @@ class UpdateGroupBuyTest {
 
         assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(hostUser, updateRequest, 1L))
                 .isInstanceOf(GroupBuyNotFoundException.class)
-                .hasMessageContaining("존재하지 않는 공구입니다");
+                .hasMessageContaining(NOT_EXIST);
     }
 
     @Test
@@ -96,7 +97,7 @@ class UpdateGroupBuyTest {
 
         assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(hostUser, updateRequest, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("공구 수정은 공구가 열려있는 상태에서만 가능합니다.");
+                .hasMessageContaining(NOT_OPEN);
     }
 
     @Test
@@ -110,11 +111,11 @@ class UpdateGroupBuyTest {
 
         assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(hostUser, updateRequest, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
-                .hasMessageContaining("공구 수정은 공구가 열려있는 상태에서만 가능합니다.");
+                .hasMessageContaining(NOT_OPEN);
     }
 
     @Test
-    @DisplayName("공구글 작성자가 아님 - 403")
+    @DisplayName("공구글 주최자가 아님 - 403")
     void updateGroupBuy_notHost() {
         User otherUser = User.builder().id(2L).build();
         when(groupBuyRepository.findById(1L)).thenReturn(Optional.of(before));
@@ -124,6 +125,6 @@ class UpdateGroupBuyTest {
 
         assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(otherUser, updateRequest, 1L))
                 .isInstanceOf(GroupBuyNotHostException.class)
-                .hasMessageContaining("공구 수정은 공구의 주최자만 요청 가능합니다.");
+                .hasMessageContaining(NOT_HOST);
     }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/UpdateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/UpdateGroupBuyTest.java
@@ -17,11 +17,10 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static com.moogsan.moongsan_backend.domain.groupbuy.message.GroupBuyResponseMessage.*;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/UpdateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/UpdateGroupBuyTest.java
@@ -1,5 +1,6 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.command;
 
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.CreateGroupBuyRequest;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.UpdateGroupBuyRequest;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
@@ -7,6 +8,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyN
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.UpdateGroupBuy;
+import com.moogsan.moongsan_backend.domain.image.entity.Image;
 import com.moogsan.moongsan_backend.domain.image.mapper.ImageMapper;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,14 +34,46 @@ class UpdateGroupBuyTest {
     @InjectMocks private UpdateGroupBuy updateGroupBuy;
 
     private User hostUser;
-    private GroupBuy before, after;
+    private Image image;
+    private GroupBuy gb;
+
     private UpdateGroupBuyRequest updateRequest;
+
+    private GroupBuy.GroupBuyBuilder defaultGroupBuy() {
+        return GroupBuy.builder()
+                .id(20L)
+                .title("라면 공구")
+                .name("진라면")
+                .url("https://example.com")
+                .price(10000)
+                .unitPrice(100)
+                .totalAmount(100)
+                .unitAmount(10)
+                .hostQuantity(1)
+                .description("라면 맛있어요")
+                .dueDate(LocalDateTime.now().plusDays(3))
+                .location("카카오테크 교육장")
+                .pickupDate(LocalDateTime.now().plusDays(4))
+                .images(List.of(image))
+                .user(hostUser);
+    }
 
     @BeforeEach
     void setup() {
         hostUser = User.builder().id(1L).build();
-        before = mock(GroupBuy.class);
-        after  = mock(GroupBuy.class);
+
+        image = Image.builder()
+                .id(2L)
+                .imageKey("images/1")
+                .imageSeqNo(0)
+                .thumbnail(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("공구 전체 수정 성공")
+    void updateGroupBuy_success() {
+        gb = defaultGroupBuy().build();
 
         updateRequest = UpdateGroupBuyRequest.builder()
                 .title("라면 공구")
@@ -51,24 +85,23 @@ class UpdateGroupBuyTest {
                 .dateModificationReason("배송이 늦네요...")
                 .imageKeys(List.of("images/image1.jpg"))
                 .build();
-    }
 
-    @Test
-    @DisplayName("공구 수정 성공")
-    void updateGroupBuy_success() {
-        when(groupBuyRepository.findById(1L))
-                .thenReturn(Optional.of(before));
-        when(before.getPostStatus()).thenReturn("OPEN");
-        when(before.getDueDate()).thenReturn(LocalDateTime.now().plusDays(1));
-        when(before.updateForm(eq(updateRequest))).thenReturn(after);
-        when(before.getUser()).thenReturn(hostUser);
+        when(groupBuyRepository.findById(20L))
+                .thenReturn(Optional.of(gb));
         when(groupBuyRepository.save(any(GroupBuy.class)))
-                .thenReturn(after);
-        when(after.getId()).thenReturn(1L);
+                .thenReturn(gb);
 
-        Long id = updateGroupBuy.updateGroupBuy(hostUser, updateRequest, 1L);
+        Long id = updateGroupBuy.updateGroupBuy(hostUser, updateRequest, 20L);
 
-        assertThat(id).isEqualTo(1L);
+        assertThat(id).isEqualTo(20L);
+        assertThat(gb.getTitle()).isEqualTo(updateRequest.getTitle());
+        assertThat(gb.getName()).isEqualTo(updateRequest.getName());
+        assertThat(gb.getHostQuantity()).isEqualTo(updateRequest.getHostQuantity());
+        assertThat(gb.getDescription()).isEqualTo(updateRequest.getDescription());
+        assertThat(gb.getDueDate()).isEqualTo(updateRequest.getDueDate());
+        assertThat(gb.getPickupDate()).isEqualTo(updateRequest.getPickupDate());
+        assertThat(gb.getDateModificationReason()).isEqualTo(updateRequest.getDateModificationReason());
+        ///  이미지 변경 여부도 확인 필요
         verify(groupBuyRepository).save(any(GroupBuy.class));
         verify(imageMapper).mapImagesToGroupBuy(
                 eq(updateRequest.getImageKeys()),
@@ -79,10 +112,10 @@ class UpdateGroupBuyTest {
     @Test
     @DisplayName("존재하지 않는 공구글 - 404 ")
     void updateGroupBuy_notFound() {
-        when(groupBuyRepository.findById(1L))
+        when(groupBuyRepository.findById(20L))
                 .thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(hostUser, updateRequest, 1L))
+        assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(hostUser, updateRequest, 20L))
                 .isInstanceOf(GroupBuyNotFoundException.class)
                 .hasMessageContaining(NOT_EXIST);
     }
@@ -90,11 +123,12 @@ class UpdateGroupBuyTest {
     @Test
     @DisplayName("공구글 status가 OPEN이 아님 - 409")
     void updateGroupBuy_postStatus_not_open() {
-        when(groupBuyRepository.findById(1L))
-                .thenReturn(Optional.of(before));
-        when(before.getPostStatus()).thenReturn("CLOSED");
-
-        assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(hostUser, updateRequest, 1L))
+        gb = defaultGroupBuy()
+                .postStatus("CLOSED")
+                .build();
+        when(groupBuyRepository.findById(20L))
+                .thenReturn(Optional.of(gb));
+        assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(hostUser, updateRequest, 20L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
                 .hasMessageContaining(NOT_OPEN);
     }
@@ -102,13 +136,13 @@ class UpdateGroupBuyTest {
     @Test
     @DisplayName("dueDate가 현재보다 과거 - 409")
     void updateGroupBuy_dueDate_past() {
-        when(groupBuyRepository.findById(1L))
-                .thenReturn(Optional.of(before));
-        when(before.getPostStatus()).thenReturn("OPEN");
-        when(before.getDueDate())
-                .thenReturn(LocalDateTime.now().minusDays(1));
+        gb = defaultGroupBuy()
+                .dueDate(LocalDateTime.now().minusDays(1))
+                .build();
+        when(groupBuyRepository.findById(20L))
+                .thenReturn(Optional.of(gb));
 
-        assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(hostUser, updateRequest, 1L))
+        assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(hostUser, updateRequest, 20L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
                 .hasMessageContaining(NOT_OPEN);
     }
@@ -116,13 +150,11 @@ class UpdateGroupBuyTest {
     @Test
     @DisplayName("공구글 주최자가 아님 - 403")
     void updateGroupBuy_notHost() {
+        gb = defaultGroupBuy().build();
         User otherUser = User.builder().id(2L).build();
-        when(groupBuyRepository.findById(1L)).thenReturn(Optional.of(before));
-        when(before.getPostStatus()).thenReturn("OPEN");
-        when(before.getDueDate()).thenReturn(LocalDateTime.now().plusDays(1));
-        when(before.getUser()).thenReturn(hostUser);
+        when(groupBuyRepository.findById(20L)).thenReturn(Optional.of(gb));
 
-        assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(otherUser, updateRequest, 1L))
+        assertThatThrownBy(() -> updateGroupBuy.updateGroupBuy(otherUser, updateRequest, 20L))
                 .isInstanceOf(GroupBuyNotHostException.class)
                 .hasMessageContaining(NOT_HOST);
     }


### PR DESCRIPTION
## 🔎 작업 개요
- `createGroupBuy` / `updateGroupBuy` 테스트 로직 개선  
- 에러 메시지 관리 방식을 `ErrorCode` enum → `ResponseMessage` / `ValidationMessage` 클래스로 분리  

---

## 🛠️ 주요 변경 사항
1. **Message 변수화**  
   - `groupBuy` command controller, service 및 query controller의 모든 하드코딩 응답 메시지를 `ResponseMessage` 상수로 이동  
   - 기존 도메인별 exception에서는 여전히 오버라이드된 메시지를 사용하되, `ErrorCode` enum에는 코드와 메시지 키만 유지  
   - DTO 검증 메시지는 `ValidationMessage` 클래스로 분리하여 관리  

2. **createGroupBuy 테스트 코드 수정**  
   - 공통으로 반복되던 빌더 초기화 로직을 `defaultBuilder()` 헬퍼 메서드로 분리  
   - 각 테스트에서 `build()` 호출하도록 변경하여 테스트 가독성 및 유지보수성 개선  

3. **updateGroupBuy 테스트 코드 추가 및 개선**  
   - `updateGroupBuy`가 `valid` 허용으로 모든 케이스가 통과하던 원인 분석  
   - `NotBlankIfPresentValidator` 커스텀 제약 작성 및 적용으로 “값이 있으면 blank 금지” 검증 추가  
   - DTO 검증 메시지를 `ResponseMessage`와 분리하여 `ValidationMessage`로 변수화  

---

## ✅ 검증 방법
- `./gradlew clean test` 실행하여 모든 유닛 테스트 통과 확인  
- Postman 으로 `/api/group-buys` 생성·수정 엔드포인트 정상 응답(성공/실패) 확인  

---

## 🔍 머지 전 확인사항
- `ResponseMessage` & `ValidationMessage`에 불필요한 메시지 중복 여부  
- `ErrorCode` enum과 메시지 키 일치 여부  
- 테스트 커버리지(특히 `updateGroupBuy`)가 유지되고 있는지  
- Postman 테스트 시 에러 메시지 포맷 및 HTTP 상태 코드 일관성  

---

## ➕ 이슈 링크
- [[Sub Task] BE - GroupBuy response message 상수 선언으로 변경](https://github.com/100-hours-a-week/14-YG-BE/issues/175)
- [[Sub Task] BE - GroupBuy validation message 상수 선언으로 변경](https://github.com/100-hours-a-week/14-YG-BE/issues/176)
- [[Sub Task] BE - UpdateGroupBuy DTO 유효성 테스트 추가](https://github.com/100-hours-a-week/14-YG-BE/issues/138)