### PR TITLE
test(group-buy): 고정 시간 적용, 호출 여부 검증

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CreateGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CreateGroupBuy.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+
 import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_DIVISOR;
 
 @Service
@@ -25,6 +27,7 @@ public class CreateGroupBuy {
     private final GroupBuyCommandMapper groupBuyCommandMapper;
     private final ChattingCommandFacade chattingCommandFacade;
     private final DuplicateRequestPreventer duplicateRequestPreventer;
+    private final Clock clock;
 
     /// 공구 게시글 작성
     public Long createGroupBuy(User currentUser, CreateGroupBuyRequest createGroupBuyRequest) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
@@ -20,6 +21,7 @@ import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessa
 public class EndGroupBuy {
 
     private final GroupBuyRepository groupBuyRepository;
+    private final Clock clock;
 
     /// 공구 게시글 공구 종료
     public void endGroupBuy(User currentUser, Long postId) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/LeaveGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/LeaveGroupBuy.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_OPEN;
@@ -28,6 +29,7 @@ public class LeaveGroupBuy {
     private final OrderRepository orderRepository;
     private final DueSoonPolicy dueSoonPolicy;
     private final ChattingCommandFacade chattingCommandFacade;
+    private final Clock clock;
 
     /// 공구 참여 취소
     public void leaveGroupBuy(User currentUser, Long postId) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/UpdateGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/UpdateGroupBuy.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
@@ -22,6 +23,7 @@ import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessa
 public class UpdateGroupBuy {
     private final GroupBuyRepository groupBuyRepository;
     private final ImageMapper imageMapper;
+    private final Clock clock;
 
     /// 공구 게시글 수정
     // TODO V2
@@ -33,7 +35,7 @@ public class UpdateGroupBuy {
 
         // 해당 공구의 status가 open인지 조회 -> 아니면 409
         if (!groupBuy.getPostStatus().equals("OPEN")
-                || groupBuy.getDueDate().isBefore(LocalDateTime.now())) {
+                || groupBuy.getDueDate().isBefore(LocalDateTime.now(clock))) {
             throw new GroupBuyInvalidStateException(NOT_OPEN);
         }
 

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/TimeConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/TimeConfig.java
@@ -1,0 +1,14 @@
+package com.moogsan.moongsan_backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfig {
+    @Bean
+    public Clock systemClock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/resources/db/migration/V10__rename_pickup_change_reason.sql
+++ b/src/main/resources/db/migration/V10__rename_pickup_change_reason.sql
@@ -1,0 +1,4 @@
+-- V10__rename_pickup_change_reason.sql
+
+ALTER TABLE group_buy
+RENAME COLUMN pickup_change_reason TO date_modification_reason;

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/CreateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/CreateGroupBuyTest.java
@@ -18,7 +18,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_DIVISOR;
@@ -44,16 +47,33 @@ public class CreateGroupBuyTest {
     @Mock
     private ChattingCommandFacade chattingCommandFacade;
 
-    @InjectMocks
     private CreateGroupBuy createGroupBuy;
 
     private CreateGroupBuyRequest request;
     private User user;
+    private Clock fixedClock;
+    private LocalDateTime now;
 
     @BeforeEach
     void setUp() {
         when(duplicateRequestPreventer.tryAcquireLock(anyString(), anyLong()))
                 .thenReturn(true);
+
+        fixedClock = Clock.fixed(
+                Instant.parse("2025-06-11T13:00:00Z"),
+                ZoneId.of("Asia/Seoul")
+        );
+
+        now = LocalDateTime.now(fixedClock);
+
+        createGroupBuy = new CreateGroupBuy(
+                groupBuyRepository,
+                imageMapper,
+                groupBuyCommandMapper,
+                chattingCommandFacade,
+                duplicateRequestPreventer,
+                fixedClock
+        );
 
         request = CreateGroupBuyRequest.builder()
                 .title("라면 공구")
@@ -64,9 +84,9 @@ public class CreateGroupBuyTest {
                 .unitAmount(10)
                 .hostQuantity(1)
                 .description("라면 맛있어요")
-                .dueDate(LocalDateTime.now().plusDays(3))
+                .dueDate(now.plusDays(3))
                 .location("카카오테크 교육장")
-                .pickupDate(LocalDateTime.now().plusDays(4))
+                .pickupDate(now.plusDays(4))
                 .imageKeys(List.of("images/image1.jpg"))
                 .build();
 
@@ -87,30 +107,46 @@ public class CreateGroupBuyTest {
         Long result = createGroupBuy.createGroupBuy(user, request);
 
         // then
-        verify(groupBuyCommandMapper).create(request, user);
-        verify(imageMapper).mapImagesToGroupBuy(request.getImageKeys(), mockGb);
-        verify(mockGb).increaseParticipantCount();
-        verify(groupBuyRepository).save(mockGb);
+        verify(groupBuyCommandMapper, times(1)).create(request, user);
+        verify(imageMapper, times(1)).mapImagesToGroupBuy(request.getImageKeys(), mockGb);
+        verify(mockGb, times(1)).increaseParticipantCount();
+        verify(groupBuyRepository, times(1)).save(mockGb);
+        verify(chattingCommandFacade, times(1)).joinChatRoom(user, mockGb.getId());
         assertThat(result).isEqualTo(42L);
     }
 
     @Test
     @DisplayName("공구 게시글 생성 실패 - 단위 수량은 0이 될 수 없음")
     void createGroupBuy_invalid_unitAmount_zero() {
+        GroupBuy mockGb = mock(GroupBuy.class);
         request.setUnitAmount(0);
 
         assertThatThrownBy(() -> createGroupBuy.createGroupBuy(user, request))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
                 .hasMessageContaining(NOT_DIVISOR);
+
+        verify(groupBuyCommandMapper, never()).create(request, user);
+        verify(imageMapper, never()).mapImagesToGroupBuy(request.getImageKeys(), mockGb);
+        verify(mockGb, never()).increaseParticipantCount();
+        verify(groupBuyRepository, never()).save(mockGb);
+        verify(chattingCommandFacade, never()).joinChatRoom(user, mockGb.getId());
+
     }
 
     @Test
     @DisplayName("공구 게시글 생성 실패 - 단위 수량은 총 상품 수량의 약수만 가능")
     void createGroupBuy_invalid_unitAmount() {
+        GroupBuy mockGb = mock(GroupBuy.class);
         request.setUnitAmount(7);
 
         assertThatThrownBy(() -> createGroupBuy.createGroupBuy(user, request))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
                 .hasMessageContaining(NOT_DIVISOR);
+
+        verify(groupBuyCommandMapper, never()).create(request, user);
+        verify(imageMapper, never()).mapImagesToGroupBuy(request.getImageKeys(), mockGb);
+        verify(mockGb, never()).increaseParticipantCount();
+        verify(groupBuyRepository, never()).save(mockGb);
+        verify(chattingCommandFacade, never()).joinChatRoom(user, mockGb.getId());
     }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/DeleteGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/DeleteGroupBuyTest.java
@@ -39,13 +39,12 @@ public class DeleteGroupBuyTest {
     private DeleteGroupBuy deleteGroupBuy;
 
     private User hostUser;
-    private GroupBuy before, after;
+    private GroupBuy before;
 
     @BeforeEach
     void setup() {
         hostUser = User.builder().id(1L).build();
         before = mock(GroupBuy.class);
-        after  = mock(GroupBuy.class);
     }
 
     @Test
@@ -62,7 +61,9 @@ public class DeleteGroupBuyTest {
 
         deleteGroupBuy.deleteGroupBuy(hostUser, 1L);
 
-        verify(groupBuyRepository).save(any(GroupBuy.class));
+        verify(groupBuyRepository, times(1)).findById(1L);
+        verify(orderRepository, times(1)).countByGroupBuyIdAndStatusNot(1L, "CANCELED");
+        verify(groupBuyRepository, times(1)).save(any(GroupBuy.class));
     }
 
     @Test
@@ -74,6 +75,10 @@ public class DeleteGroupBuyTest {
         assertThatThrownBy(() -> deleteGroupBuy.deleteGroupBuy(hostUser, 1L))
                 .isInstanceOf(GroupBuyNotFoundException.class)
                 .hasMessageContaining(NOT_EXIST);
+
+        verify(groupBuyRepository, times(1)).findById(1L);
+        verify(orderRepository, never()).countByGroupBuyIdAndStatusNot(1L, "CANCELED");
+        verify(groupBuyRepository, never()).save(any(GroupBuy.class));
     }
 
     @Test
@@ -86,6 +91,10 @@ public class DeleteGroupBuyTest {
         assertThatThrownBy(() -> deleteGroupBuy.deleteGroupBuy(hostUser, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
                 .hasMessageContaining(NOT_OPEN);
+
+        verify(groupBuyRepository, times(1)).findById(1L);
+        verify(orderRepository, never()).countByGroupBuyIdAndStatusNot(1L, "CANCELED");
+        verify(groupBuyRepository, never()).save(any(GroupBuy.class));
     }
 
     @Test
@@ -100,6 +109,10 @@ public class DeleteGroupBuyTest {
         assertThatThrownBy(() -> deleteGroupBuy.deleteGroupBuy(hostUser, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
                 .hasMessageContaining(NOT_OPEN);
+
+        verify(groupBuyRepository, times(1)).findById(1L);
+        verify(orderRepository, never()).countByGroupBuyIdAndStatusNot(1L, "CANCELED");
+        verify(groupBuyRepository, never()).save(any(GroupBuy.class));
     }
 
     @Test
@@ -116,10 +129,14 @@ public class DeleteGroupBuyTest {
         assertThatThrownBy(() -> deleteGroupBuy.deleteGroupBuy(hostUser, 1L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
                 .hasMessageContaining(EXIST_PARTICIPANT);
+
+        verify(groupBuyRepository, times(1)).findById(1L);
+        verify(orderRepository, times(1)).countByGroupBuyIdAndStatusNot(1L, "CANCELED");
+        verify(groupBuyRepository, never()).save(any(GroupBuy.class));
     }
 
     @Test
-    @DisplayName("공구글 작성자가 아님 - 403 예외")
+    @DisplayName("공구글 작성자가 아님 - 403 예외") // 이 로직을 두번째 상단으로 리팩토링할 필요 있음
     void deleteGroupBuy_notHost() {
         User otherUser = User.builder().id(2L).build();
         when(groupBuyRepository.findById(1L))
@@ -134,5 +151,9 @@ public class DeleteGroupBuyTest {
         assertThatThrownBy(() -> deleteGroupBuy.deleteGroupBuy(otherUser, 1L))
                 .isInstanceOf(GroupBuyNotHostException.class)
                 .hasMessageContaining(NOT_HOST);
+
+        verify(groupBuyRepository, times(1)).findById(1L);
+        verify(orderRepository, times(1)).countByGroupBuyIdAndStatusNot(1L, "CANCELED");
+        verify(groupBuyRepository, never()).save(any(GroupBuy.class));
     }
 }


### PR DESCRIPTION
## 🔎 작업 개요
- 공구글 테스트 코드의 시간 관련 로직을 안정적으로 테스트할 수 있도록 `Clock`을 도입하고, 테스트 환경에서만 고정된 시간을 사용할 수 있도록 설정했습니다.
- 또한 가독성을 높이기 위해 `pickup_change_reason` 컬럼명을 `date_modification_reason`으로 수정했습니다.
- 각 테스트 케이스에 `@BeforeEach` 및 `times(n)` 기반의 호출 검증을 명시하여 테스트 신뢰도를 높였습니다.

---

## 🛠️ 주요 변경 사항

1. **고정 시간 사용을 위한 환경 구성**
   - `Clock` 및 `TestClockConfig` 생성
   - 테스트 코드에서 `Clock.fixed()`를 활용해 시간 관련 테스트를 안정화

2. **DB 컬럼명 수정**
   - `group_buy.pickup_change_reason` → `date_modification_reason`으로 변경 (Flyway V10 적용)

3. **테스트 리팩토링**
   - `@BeforeEach`를 활용해 테스트마다 공통 세팅 적용
   - `verify(..., times(n))` 및 `verify(..., never())` 등 명시적 호출 검증 추가

---

## ✅ 검증 방법
- 모든 관련 테스트가 고정 시간 기준으로 일관된 결과를 반환하는지 확인
- Flyway 마이그레이션이 정상적으로 동작하는지 확인 (`V10__rename_column.sql`)
- 실패 케이스에서 `verify(..., never())`가 적절히 적용되었는지 확인

---

## 🔍 머지 전 확인사항
- [x] 새로운 `Clock` 사용 방식이 프로덕션 코드에 영향이 없는지 검토
- [x] 컬럼명 변경이 API 응답, 프론트 요청 등과 충돌하지 않는지 확인
- [x] Flyway 마이그레이션 이후 기존 데이터에 영향이 없는지 확인

---

## ➕ 관련 이슈
- [[Sub Task] BE - 서비스단에서 times(n)을 통한 호출 여부 검증 추가](https://github.com/100-hours-a-week/14-YG-BE/issues/140)
- [[Sub Task] BE - 테스트 코드에서의 고정 시간 사용](https://github.com/100-hours-a-week/14-YG-BE/issues/141)
