### PR TITLE
test(group-buy): Clock 주입 및 GroupBuy query service단 테스트 코드 작성

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyEditController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyEditController.java
@@ -27,7 +27,7 @@ public class GroupBuyEditController {
         if (userDetails == null) {
             throw new UnauthenticatedAccessException("로그인이 필요합니다.");
         }
-        GroupBuyForUpdateResponse groupBuyForUpdate = queryFacade.getGroupBuyEditInfo(postId);
+        GroupBuyForUpdateResponse groupBuyForUpdate = queryFacade.getGroupBuyEditInfo(userDetails.getUser().getId(), postId);
         return ResponseEntity.ok(
                 WrapperResponse.<GroupBuyForUpdateResponse>builder()
                         .message(GET_UPDATE_SUCCESS)

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/facade/query/GroupBuyQueryFacade.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/facade/query/GroupBuyQueryFacade.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 public interface GroupBuyQueryFacade {
 
     // 공구 수정 화면용 단건 조회
-    GroupBuyForUpdateResponse getGroupBuyEditInfo(Long postId);
+    GroupBuyForUpdateResponse getGroupBuyEditInfo(Long userId, Long postId);
 
     // 상세·계좌
     DetailResponse        getGroupBuyDetailInfo(Long userId, Long postId);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/facade/query/GroupBuyQueryFacadeImpl.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/facade/query/GroupBuyQueryFacadeImpl.java
@@ -30,8 +30,8 @@ public class GroupBuyQueryFacadeImpl implements GroupBuyQueryFacade {
     private final GetGroupBuyParticipantsInfo    participantsInfoSvc;
 
     @Override
-    public GroupBuyForUpdateResponse getGroupBuyEditInfo(Long postId) {
-        return editInfoSvc.getGroupBuyEditInfo(postId);
+    public GroupBuyForUpdateResponse getGroupBuyEditInfo(Long userId, Long postId) {
+        return editInfoSvc.getGroupBuyEditInfo(userId, postId);
     }
 
     @Override

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/DeleteGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/DeleteGroupBuy.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
@@ -22,6 +23,7 @@ public class DeleteGroupBuy {
 
     private final GroupBuyRepository groupBuyRepository;
     private final OrderRepository orderRepository;
+    private final Clock clock;
 
     /// 공구 게시글 삭제: 참여자가 아무도 없는, 주문 레코드가 없는 경우이므로 하드 삭제
     // TODO V2
@@ -33,7 +35,7 @@ public class DeleteGroupBuy {
 
         // 해당 공구의 status가 open인지 조회 -> 아니면 409
         if (!groupBuy.getPostStatus().equals("OPEN")
-                || groupBuy.getDueDate().isBefore(LocalDateTime.now())) {
+                || groupBuy.getDueDate().isBefore(LocalDateTime.now(clock))) {
             throw new GroupBuyInvalidStateException(NOT_OPEN);
         }
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
@@ -41,12 +41,12 @@ public class EndGroupBuy {
         }
 
         // dueDate 이후인지 조회 -> 아니면 409
-        if (groupBuy.getDueDate().isAfter(LocalDateTime.now())) {
+        if (groupBuy.getDueDate().isAfter(LocalDateTime.now(clock))) {
             throw new GroupBuyInvalidStateException(BEFORE_CLOSED);
         }
 
         // pickupDate 이후인지 조회 -> 아니면 409
-        if (groupBuy.getPickupDate().isAfter(LocalDateTime.now())) {
+        if (groupBuy.getPickupDate().isAfter(LocalDateTime.now(clock))) {
             throw new GroupBuyInvalidStateException(BEFORE_PICKUP_DATE);
         }
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/LeaveGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/LeaveGroupBuy.java
@@ -40,7 +40,7 @@ public class LeaveGroupBuy {
 
         // 해당 공구가 OPEN인지 조회, dueDate가 현재 이후인지 조회 -> 아니면 409
         if (!groupBuy.getPostStatus().equals("OPEN")
-                || groupBuy.getDueDate().isBefore(LocalDateTime.now())) {
+                || groupBuy.getDueDate().isBefore(LocalDateTime.now(clock))) {
             throw new GroupBuyInvalidStateException(NOT_OPEN);
         }
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyDetailInfo.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyDetailInfo.java
@@ -13,6 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.AFTER_DELETED;
@@ -27,6 +29,7 @@ public class GetGroupBuyDetailInfo {
     private final OrderRepository orderRepository;
     private final GroupBuyQueryMapper groupBuyQueryMapper;
     private final WishRepository wishRepository;
+    private final Clock now;
 
     /// 공구 게시글 상세 조회
     public DetailResponse getGroupBuyDetailInfo(Long userId, Long postId) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyEditInfo.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyEditInfo.java
@@ -2,13 +2,21 @@ package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryServic
 
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyUpdate.GroupBuyForUpdateResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
 import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyQueryMapper;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_HOST;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_OPEN;
 
 @Slf4j
 @Service
@@ -18,12 +26,22 @@ public class GetGroupBuyEditInfo {
 
     private final GroupBuyRepository groupBuyRepository;
     private final GroupBuyQueryMapper groupBuyQueryMapper;
+    private final Clock clock;
 
     /// 공구 게시글 수정 전 정보 조회
-    /// TODO V2
-    public GroupBuyForUpdateResponse getGroupBuyEditInfo(Long postId) {
+    public GroupBuyForUpdateResponse getGroupBuyEditInfo(Long userId, Long postId) {
         GroupBuy groupBuy = groupBuyRepository.findWithImagesById(postId)
                 .orElseThrow(GroupBuyNotFoundException::new);
+
+        if (!groupBuy.getUser().getId().equals(userId)) {
+            throw new GroupBuyNotHostException(NOT_HOST);
+        }
+
+        // 해당 공구의 status가 open인지 조회 -> 아니면 409
+        if (!groupBuy.getPostStatus().equals("OPEN")
+                || groupBuy.getDueDate().isBefore(LocalDateTime.now(clock))) {
+            throw new GroupBuyInvalidStateException(NOT_OPEN);
+        }
 
         return groupBuyQueryMapper.toUpdateResponse(groupBuy);
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyHostAccountInfo.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyHostAccountInfo.java
@@ -25,7 +25,6 @@ public class GetGroupBuyHostAccountInfo {
     private final GroupBuyRepository groupBuyRepository;
     private final OrderRepository orderRepository;
     private final GroupBuyQueryMapper groupBuyQueryMapper;
-    private final WishRepository wishRepository;
 
     /// 주최자 계좌 정보 조회
     public UserAccountResponse getGroupBuyHostAccountInfo(Long userId, Long postId) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyHostedList.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyHostedList.java
@@ -40,7 +40,7 @@ public class GetGroupBuyHostedList {
 
         String status = postStatus.toUpperCase();
 
-        Pageable page = PageRequest.of(0, limit, Sort.by("id").descending());
+        Pageable page = PageRequest.of(0, limit + 1, Sort.by("id").descending());
 
         // cursorId가 없으면 cursor 조건 제외
         List<GroupBuy> groupBuys;
@@ -74,15 +74,19 @@ public class GetGroupBuyHostedList {
         List<HostedListResponse> posts = groupBuyQueryMapper
                 .toHostedListWishResponses(groupBuys, wishMap, chatRooms);
 
+        List<HostedListResponse> hostedGroupBuys = posts.size() > limit
+                ? posts.subList(0, limit)
+                : posts;
+
         // 다음 커서 및 더보기 여부
-        Long nextCursor = posts.isEmpty()
+        Long nextCursor = hostedGroupBuys.isEmpty()
                 ? null
-                : posts.getLast().getPostId();
-        boolean hasMore = posts.size() == limit;
+                : hostedGroupBuys.getLast().getPostId();
+        boolean hasMore = posts.size() > limit;
 
         return PagedResponse.<HostedListResponse>builder()
-                .count(posts.size())
-                .posts(posts)
+                .count(hostedGroupBuys.size())
+                .posts(hostedGroupBuys)
                 .nextCursor(nextCursor != null ? nextCursor.intValue() : null)
                 .hasMore(hasMore)
                 .build();

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyParticipantsInfo.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyParticipantsInfo.java
@@ -40,7 +40,7 @@ public class GetGroupBuyParticipantsInfo {
             throw new GroupBuyNotHostException(NOT_HOST);
         }
 
-        List<Order> orders = orderRepository.findByGroupBuyIdAndStatusNot(postId, "canceled");
+        List<Order> orders = orderRepository.findByGroupBuyIdAndStatusNot(postId, "CANCELED");
 
         List<ParticipantResponse> participantList = orders.stream()
                 .map(groupBuyQueryMapper::toParticipantResponse)

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyParticipatedList.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyParticipatedList.java
@@ -2,6 +2,7 @@ package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryServic
 
 import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
 import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.HostedList.HostedListResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.PagedResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipatedList.ParticipatedListResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
@@ -45,7 +46,7 @@ public class GetGroupBuyParticipatedList {
 
         Pageable page = PageRequest.of(
                 0,
-                limit,
+                limit + 1,
                 Sort.by("createdAt").descending()
                         .and(Sort.by("id").descending())
         );
@@ -88,15 +89,19 @@ public class GetGroupBuyParticipatedList {
         List<ParticipatedListResponse> posts = groupBuyQueryMapper
                 .toParticipatedListWishResponse(orders, wishMap, chatRooms);
 
+        List<ParticipatedListResponse> participatedGroupBuys = posts.size() > limit
+                ? posts.subList(0, limit)
+                : posts;
+
         // 다음 커서 및 더보기 여부
-        Long nextCursor = posts.isEmpty()
+        Long nextCursor = participatedGroupBuys.isEmpty()
                 ? null
-                : posts.getLast().getPostId();
-        boolean hasMore = posts.size() == limit;
+                : participatedGroupBuys.getLast().getPostId();
+        boolean hasMore = posts.size() > limit;
 
         return PagedResponse.<ParticipatedListResponse>builder()
-                .count(posts.size())
-                .posts(posts)
+                .count(participatedGroupBuys.size())
+                .posts(participatedGroupBuys)
                 .nextCursor(nextCursor != null ? nextCursor.intValue() : null)
                 .hasMore(hasMore)
                 .build();

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyEditInfoTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyEditInfoTest.java
@@ -52,6 +52,7 @@ public class GetGroupBuyEditInfoTest {
                 .build();
 
         Mockito.when(queryFacade.getGroupBuyEditInfo(
+                eq(1L),
                 eq(20L)
         )).thenReturn(item);
 
@@ -60,7 +61,7 @@ public class GetGroupBuyEditInfoTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value(GET_UPDATE_SUCCESS));
 
-        Mockito.verify(queryFacade).getGroupBuyEditInfo(eq(20L));
+        Mockito.verify(queryFacade).getGroupBuyEditInfo(eq(1L), eq(20L));
     }
 
     @Test

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/CreateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/CreateGroupBuyTest.java
@@ -48,7 +48,6 @@ public class CreateGroupBuyTest {
     private ChattingCommandFacade chattingCommandFacade;
 
     private CreateGroupBuy createGroupBuy;
-
     private CreateGroupBuyRequest request;
     private User user;
     private Clock fixedClock;

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyDetailInfoTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyDetailInfoTest.java
@@ -1,4 +1,162 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.query;
 
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyDetail.DetailResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyQueryMapper;
+import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryService.GetGroupBuyDetailInfo;
+import com.moogsan.moongsan_backend.domain.image.entity.Image;
+import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import com.moogsan.moongsan_backend.domain.user.repository.WishRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 public class GetGroupBuyDetailInfoTest {
+
+    @Mock
+    private GroupBuyRepository groupBuyRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private GroupBuyQueryMapper groupBuyQueryMapper;
+
+    @Mock
+    private WishRepository wishRepository;
+
+    private GetGroupBuyDetailInfo getGroupBuyDetailInfo;
+    private User hostUser;
+    private User participantUser;
+    private User normalUser;
+    private GroupBuy groupBuy;
+    private Image image;
+    private Clock fixedClock;
+    private LocalDateTime now;
+
+    @BeforeEach
+    void setUp() {
+        hostUser = User.builder().id(1L).build();
+        participantUser = User.builder().id(2L).build();
+        normalUser = User.builder().id(3L).build();
+
+        fixedClock = Clock.fixed(
+                Instant.parse("2025-06-11T13:00:00Z"),
+                ZoneId.of("Asia/Seoul")
+        );
+
+        now = LocalDateTime.now(fixedClock);
+
+        getGroupBuyDetailInfo = new GetGroupBuyDetailInfo(
+                groupBuyRepository,
+                orderRepository,
+                groupBuyQueryMapper,
+                wishRepository,
+                fixedClock
+        );
+
+        image = Image.builder()
+                .id(2L)
+                .imageKey("images/1")
+                .imageSeqNo(0)
+                .thumbnail(true)
+                .build();
+
+        groupBuy = GroupBuy.builder()
+                .id(20L)
+                .title("라면 공구")
+                .name("진라면")
+                .url("https://example.com")
+                .price(10000)
+                .unitPrice(100)
+                .totalAmount(100)
+                .unitAmount(10)
+                .hostQuantity(1)
+                .description("라면 맛있어요")
+                .dueDate(now.plusDays(5))
+                .location("카카오테크 교육장")
+                .pickupDate(now.plusDays(7))
+                .images(List.of(image))
+                .user(hostUser)
+                .build();
+    }
+
+    @Test
+    @DisplayName("공구 게시글 상세 조회 성공 - 주최자")
+    void getGroupBuyDetail_success_host() {
+        DetailResponse detailResponse = mock(DetailResponse.class);
+
+        when(groupBuyRepository.findWithImagesById(20L)).thenReturn(Optional.ofNullable(groupBuy));
+        when(orderRepository.existsParticipant(hostUser.getId(), groupBuy.getId(), "CANCELED")).thenReturn(false);
+        when(wishRepository.existsByUserIdAndGroupBuyId(hostUser.getId(), groupBuy.getId())).thenReturn(false);
+        when(groupBuyQueryMapper.toDetailResponse(groupBuy, true, false, false))
+                .thenReturn(detailResponse);
+
+        DetailResponse result = getGroupBuyDetailInfo.getGroupBuyDetailInfo(hostUser.getId(), 20L);
+
+        verify(groupBuyRepository, times(1)).findWithImagesById(20L);
+        verify(orderRepository, times(1)).existsParticipant(hostUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(wishRepository, times(1)).existsByUserIdAndGroupBuyId(hostUser.getId(), groupBuy.getId());
+        verify(groupBuyQueryMapper, times(1))
+                .toDetailResponse(groupBuy, true, false, false);
+        assertThat(result).isInstanceOf(DetailResponse.class);
+    }
+
+    @Test
+    @DisplayName("공구 게시글 상세 조회 성공 - 참가자")
+    void getGroupBuyDetail_success_participant() {
+        DetailResponse detailResponse = mock(DetailResponse.class);
+
+        when(groupBuyRepository.findWithImagesById(20L)).thenReturn(Optional.ofNullable(groupBuy));
+        when(orderRepository.existsParticipant(participantUser.getId(), groupBuy.getId(), "CANCELED")).thenReturn(true);
+        when(wishRepository.existsByUserIdAndGroupBuyId(participantUser.getId(), groupBuy.getId())).thenReturn(true);
+        when(groupBuyQueryMapper.toDetailResponse(groupBuy, false, true, true))
+                .thenReturn(detailResponse);
+
+        DetailResponse result = getGroupBuyDetailInfo.getGroupBuyDetailInfo(participantUser.getId(), 20L);
+
+        verify(groupBuyRepository, times(1)).findWithImagesById(20L);
+        verify(orderRepository, times(1)).existsParticipant(participantUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(wishRepository, times(1)).existsByUserIdAndGroupBuyId(participantUser.getId(), groupBuy.getId());
+        verify(groupBuyQueryMapper, times(1))
+                .toDetailResponse(groupBuy, false, true, true);
+        assertThat(result).isInstanceOf(DetailResponse.class);
+    }
+
+    @Test
+    @DisplayName("공구 게시글 상세 조회 성공 - 비참가자")
+    void getGroupBuyDetail_success_user() {
+        DetailResponse detailResponse = mock(DetailResponse.class);
+
+        when(groupBuyRepository.findWithImagesById(20L)).thenReturn(Optional.ofNullable(groupBuy));
+        when(orderRepository.existsParticipant(normalUser.getId(), groupBuy.getId(), "CANCELED")).thenReturn(false);
+        when(wishRepository.existsByUserIdAndGroupBuyId(normalUser.getId(), groupBuy.getId())).thenReturn(false);
+        when(groupBuyQueryMapper.toDetailResponse(groupBuy, false, false, false))
+                .thenReturn(detailResponse);
+
+        DetailResponse result = getGroupBuyDetailInfo.getGroupBuyDetailInfo(normalUser.getId(), 20L);
+
+        verify(groupBuyRepository, times(1)).findWithImagesById(20L);
+        verify(orderRepository, times(1)).existsParticipant(normalUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(wishRepository, times(1)).existsByUserIdAndGroupBuyId(normalUser.getId(), groupBuy.getId());
+        verify(groupBuyQueryMapper, times(1))
+                .toDetailResponse(groupBuy, false, false, false);
+        assertThat(result).isInstanceOf(DetailResponse.class);
+    }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyEditInfoTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyEditInfoTest.java
@@ -1,4 +1,152 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.query;
 
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyDetail.DetailResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyUpdate.GroupBuyForUpdateResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
+import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyQueryMapper;
+import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryService.GetGroupBuyEditInfo;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_OPEN;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 public class GetGroupBuyEditInfoTest {
+
+    @Mock
+    private GroupBuyRepository groupBuyRepository;
+
+    @Mock
+    private GroupBuyQueryMapper groupBuyQueryMapper;
+
+    @Mock
+    private Clock fixedClock;
+
+    private GetGroupBuyEditInfo getGroupBuyEditInfo;
+    private User hostUser;
+    private User normalUser;
+    private LocalDateTime now;
+    private GroupBuy groupBuy;
+    private GroupBuyForUpdateResponse groupBuyForUpdateResponse;
+
+    @BeforeEach
+    void setUp() {
+        hostUser = User.builder().id(1L).build();
+        normalUser = User.builder().id(2L).build();
+
+        fixedClock = Clock.fixed(
+                Instant.parse("2025-06-11T13:00:00Z"),
+                ZoneId.of("Asia/Seoul")
+        );
+
+        now = LocalDateTime.now(fixedClock);
+
+        getGroupBuyEditInfo = new GetGroupBuyEditInfo(
+                groupBuyRepository,
+                groupBuyQueryMapper,
+                fixedClock
+        );
+
+        groupBuy = mock(GroupBuy.class);
+        groupBuyForUpdateResponse = mock(GroupBuyForUpdateResponse.class);
+    }
+
+    @Test
+    @DisplayName("공구 게시글 수정용 조회 성공 - 주최자")
+    void getGetGroupBuyEditInfo_success_host() {
+        when(groupBuyRepository.findWithImagesById(20L)).thenReturn(Optional.ofNullable(groupBuy));
+        when(groupBuy.getPostStatus()).thenReturn("OPEN");
+        when(groupBuy.getDueDate()).thenReturn(now.plusDays(3));
+        when(groupBuy.getUser()).thenReturn(hostUser);
+        when(groupBuyQueryMapper.toUpdateResponse(groupBuy))
+                .thenReturn(groupBuyForUpdateResponse);
+
+        // when
+        GroupBuyForUpdateResponse result = getGroupBuyEditInfo.getGroupBuyEditInfo(hostUser.getId(), 20L);
+
+        // then
+        verify(groupBuyRepository, times(1)).findWithImagesById(20L);
+        verify(groupBuyQueryMapper, times(1))
+                .toUpdateResponse(groupBuy);
+        assertThat(result).isInstanceOf(GroupBuyForUpdateResponse.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 공구글 - 404 예외")
+    void deleteGroupBuy_notFound() {
+        when(groupBuyRepository.findWithImagesById(20L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> getGroupBuyEditInfo.getGroupBuyEditInfo(hostUser.getId(), 20L))
+                .isInstanceOf(GroupBuyNotFoundException.class)
+                .hasMessageContaining(NOT_EXIST);
+
+        verify(groupBuyRepository, times(1)).findWithImagesById(20L);
+        verify(groupBuyQueryMapper, never()).toUpdateResponse(groupBuy);
+    }
+
+    @Test
+    @DisplayName("공구 게시글 수정용 조회 실패 - 주최자가 아님")
+    void getGetGroupBuyEditInfo_fail_not_host() {
+        when(groupBuyRepository.findWithImagesById(20L)).thenReturn(Optional.ofNullable(groupBuy));
+        when(groupBuy.getUser()).thenReturn(hostUser);
+
+        assertThatThrownBy(() -> getGroupBuyEditInfo.getGroupBuyEditInfo(normalUser.getId(), 20L))
+                .isInstanceOf(GroupBuyNotHostException.class)
+                .hasMessageContaining(NOT_HOST);
+
+        verify(groupBuyRepository, times(1)).findWithImagesById(20L);
+        verify(groupBuyQueryMapper, never()).toUpdateResponse(groupBuy);
+    }
+
+    @Test
+    @DisplayName("공구글 status가 OPEN이 아님 - 409 예외")
+    void deleteGroupBuy_postStatus_not_open() {
+        when(groupBuyRepository.findWithImagesById(20L)).thenReturn(Optional.ofNullable(groupBuy));
+        when(groupBuy.getUser()).thenReturn(hostUser);
+        when(groupBuy.getPostStatus()).thenReturn("CLOSED");
+
+        assertThatThrownBy(() -> getGroupBuyEditInfo.getGroupBuyEditInfo(hostUser.getId(), 20L))
+                .isInstanceOf(GroupBuyInvalidStateException.class)
+                .hasMessageContaining(NOT_OPEN);
+
+        verify(groupBuyRepository, times(1)).findWithImagesById(20L);
+        verify(groupBuyQueryMapper, never()).toUpdateResponse(groupBuy);
+    }
+
+    @Test
+    @DisplayName("dueDate가 현재보다 과거 - 409 예외")
+    void deleteGroupBuy_dueDate_past() {
+        when(groupBuyRepository.findWithImagesById(20L)).thenReturn(Optional.ofNullable(groupBuy));
+        when(groupBuy.getUser()).thenReturn(hostUser);
+        when(groupBuy.getPostStatus()).thenReturn("OPEN");
+        when(groupBuy.getDueDate()).thenReturn(now.minusDays(3));
+
+        assertThatThrownBy(() -> getGroupBuyEditInfo.getGroupBuyEditInfo(hostUser.getId(), 20L))
+                .isInstanceOf(GroupBuyInvalidStateException.class)
+                .hasMessageContaining(NOT_OPEN);
+
+        verify(groupBuyRepository, times(1)).findWithImagesById(20L);
+        verify(groupBuyQueryMapper, never()).toUpdateResponse(groupBuy);
+    }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyHostAccountInfoTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyHostAccountInfoTest.java
@@ -1,4 +1,124 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.query;
 
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyDetail.UserAccountResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyUpdate.GroupBuyForUpdateResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotParticipantException;
+import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyQueryMapper;
+import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryService.GetGroupBuyHostAccountInfo;
+import com.moogsan.moongsan_backend.domain.order.entity.Order;
+import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_HOST;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_PARTICIPANT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 public class GetGroupBuyHostAccountInfoTest {
+
+    @Mock
+    private GroupBuyRepository groupBuyRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private GroupBuyQueryMapper groupBuyQueryMapper;
+
+    private GetGroupBuyHostAccountInfo getGroupBuyHostAccountInfo;
+    private UserAccountResponse userAccountResponse;
+    private GroupBuy groupBuy;
+    private Order order;
+    private User hostUser;
+    private User participantUser;
+    private User normalUser;
+
+    @BeforeEach
+    void setUp() {
+
+        groupBuy = mock(GroupBuy.class);
+        order = mock(Order.class);
+        userAccountResponse = mock(UserAccountResponse.class);
+
+        hostUser = User.builder().id(1L).build();
+        participantUser = User.builder().id(2L).build();
+        normalUser = User.builder().id(3L).build();
+
+        getGroupBuyHostAccountInfo = new GetGroupBuyHostAccountInfo(
+                groupBuyRepository,
+                orderRepository,
+                groupBuyQueryMapper
+        );
+
+    }
+
+    @Test
+    @DisplayName("공구 게시글 주최자 계좌 정보 조회 성공 - 주최자")
+    void getGroupBuyHostAccountInfo_success_host() {
+        when(groupBuyRepository.findById(20L)).thenReturn(Optional.ofNullable(groupBuy));
+        when(groupBuy.getUser()).thenReturn(hostUser);
+        when(groupBuyQueryMapper.toHostAccount(groupBuy))
+                .thenReturn(userAccountResponse);
+
+        // when
+        UserAccountResponse result = getGroupBuyHostAccountInfo.getGroupBuyHostAccountInfo(hostUser.getId(), 20L);
+
+        // then
+        verify(groupBuyRepository, times(1)).findById(20L);
+        verify(groupBuyQueryMapper, times(1))
+                .toHostAccount(groupBuy);
+        assertThat(result).isInstanceOf(UserAccountResponse.class);
+    }
+
+    @Test
+    @DisplayName("공구 게시글 주최자 계좌 정보 조회 성공 - 참여자")
+    void getGroupBuyHostAccountInfo_success_participant() {
+        when(groupBuyRepository.findById(20L)).thenReturn(Optional.ofNullable(groupBuy));
+        when(groupBuy.getUser()).thenReturn(hostUser);
+        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED"))
+                .thenReturn(Optional.ofNullable(order));
+        when(groupBuyQueryMapper.toHostAccount(groupBuy))
+                .thenReturn(userAccountResponse);
+
+        UserAccountResponse result = getGroupBuyHostAccountInfo.getGroupBuyHostAccountInfo(participantUser.getId(), 20L);
+
+        verify(groupBuyRepository, times(1)).findById(20L);
+        verify(orderRepository, times(1))
+                .findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED");
+        assertThat(result).isInstanceOf(UserAccountResponse.class);
+        verify(groupBuyQueryMapper, times(1))
+                .toHostAccount(groupBuy);
+    }
+
+    @Test
+    @DisplayName("공구 게시글 주최자 계좌 정보 조회 실패 - 일반 유저")
+    void getGroupBuyHostAccountInfo_fail_normal_user() {
+        when(groupBuyRepository.findById(20L)).thenReturn(Optional.ofNullable(groupBuy));
+        when(groupBuy.getUser()).thenReturn(hostUser);
+        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(normalUser.getId(), groupBuy.getId(), "CANCELED"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> getGroupBuyHostAccountInfo.getGroupBuyHostAccountInfo(normalUser.getId(), 20L))
+                .isInstanceOf(GroupBuyNotParticipantException.class)
+                .hasMessageContaining(NOT_PARTICIPANT);
+
+        verify(groupBuyRepository, times(1)).findById(20L);
+        verify(orderRepository, times(1))
+                .findByUserIdAndGroupBuyIdAndStatusNot(normalUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(groupBuyQueryMapper, never())
+                .toHostAccount(groupBuy);
+    }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyHostedListTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyHostedListTest.java
@@ -1,5 +1,179 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.query;
 
+import com.google.common.reflect.TypeToken;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyDetail.UserAccountResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.HostedList.HostedListResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.PagedResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyQueryMapper;
+import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryService.GetGroupBuyHostedList;
+import com.moogsan.moongsan_backend.domain.groupbuy.util.FetchWishUtil;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 public class GetGroupBuyHostedListTest {
 
+    @Mock
+    private GroupBuyRepository groupBuyRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private GroupBuyQueryMapper groupBuyQueryMapper;
+
+    @Mock
+    private FetchWishUtil fetchWishUtil;
+
+    private GetGroupBuyHostedList getGroupBuyHostedList;
+    private User loginedUser;
+    private Pageable expectedPageable;
+    private Long cursorId;
+    private String postStatus;
+    private int limit;
+    private GroupBuy groupBuy1;
+    private GroupBuy groupBuy2;
+    private List<GroupBuy> groupBuys;
+    private Map<Long, Boolean> wishMap;
+    private List<Long> groupBuyIds;
+    private List<ChatRoom> chatRooms;
+    private List<HostedListResponse> posts;
+    private HostedListResponse post1;
+    private HostedListResponse post2;
+
+    @BeforeEach
+    void setUp() {
+        loginedUser = User.builder().id(1L).build();
+        postStatus = "OPEN";
+
+        groupBuy1 = GroupBuy.builder().id(1L).user(loginedUser).build();
+        groupBuy2 = GroupBuy.builder().id(2L).user(loginedUser).build();
+        groupBuys = List.of(groupBuy1, groupBuy2);
+        wishMap = mock(Map.class);
+        groupBuyIds = List.of(1L, 2L);
+        chatRooms = mock(List.class);
+        post1 = HostedListResponse.builder().postId(1L).build();
+        post2 = HostedListResponse.builder().postId(2L).build();
+        posts = List.of(post2, post1);
+
+        getGroupBuyHostedList = new GetGroupBuyHostedList(
+                groupBuyRepository,
+                chatRoomRepository,
+                groupBuyQueryMapper,
+                fetchWishUtil
+        );
+    }
+
+    @Test
+    @DisplayName("주최 공구 리스트 조회 성공 - 로그인한 유저, 커서 존재, 다음 요소 있음")
+    void getGroupBuyHostedList_success_logined_user_cursor_has_next() {
+        cursorId = 2L;
+        limit = 1;
+        expectedPageable = PageRequest.of(0, limit + 1, Sort.by("id").descending());
+
+        when(groupBuyRepository.findByUser_IdAndPostStatusAndIdLessThan(loginedUser.getId(), postStatus, cursorId, expectedPageable))
+                .thenReturn(groupBuys);
+        when(fetchWishUtil.fetchWishMap(loginedUser.getId(), groupBuys)).thenReturn(wishMap);
+        when(chatRoomRepository.findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT")).thenReturn(chatRooms);
+        when(groupBuyQueryMapper.toHostedListWishResponses(groupBuys, wishMap, chatRooms)).thenReturn(posts);
+
+        PagedResponse<HostedListResponse> result = getGroupBuyHostedList.getGroupBuyHostedList(loginedUser.getId(), postStatus, cursorId, limit);
+
+        verify(groupBuyRepository, times(1)).findByUser_IdAndPostStatusAndIdLessThan(loginedUser.getId(), postStatus, cursorId, expectedPageable);
+        verify(fetchWishUtil, times(1)).fetchWishMap(loginedUser.getId(), groupBuys);
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT");
+        verify(groupBuyQueryMapper, times(1)).toHostedListWishResponses(groupBuys, wishMap, chatRooms);
+        assertThat(result.getPosts()).hasSize(1);
+        assertThat(result.getNextCursor()).isEqualTo(2L);
+        assertThat(result.isHasMore()).isTrue();
+    }
+
+    @Test
+    @DisplayName("주최 공구 리스트 조회 성공 - 로그인한 유저, 커서 존재, 다음 요소 없음")
+    void getGroupBuyHostedList_success_logined_user_cursor() {
+        cursorId = 2L;
+        limit = 2;
+        expectedPageable = PageRequest.of(0, limit + 1, Sort.by("id").descending());
+
+        when(groupBuyRepository.findByUser_IdAndPostStatusAndIdLessThan(loginedUser.getId(), postStatus, cursorId, expectedPageable))
+                .thenReturn(groupBuys);
+        when(fetchWishUtil.fetchWishMap(loginedUser.getId(), groupBuys)).thenReturn(wishMap);
+        when(chatRoomRepository.findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT")).thenReturn(chatRooms);
+        when(groupBuyQueryMapper.toHostedListWishResponses(groupBuys, wishMap, chatRooms)).thenReturn(posts);
+
+        PagedResponse<HostedListResponse> result = getGroupBuyHostedList.getGroupBuyHostedList(loginedUser.getId(), postStatus, cursorId, limit);
+
+        verify(groupBuyRepository, times(1)).findByUser_IdAndPostStatusAndIdLessThan(loginedUser.getId(), postStatus, cursorId, expectedPageable);
+        verify(fetchWishUtil, times(1)).fetchWishMap(loginedUser.getId(), groupBuys);
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT");
+        verify(groupBuyQueryMapper, times(1)).toHostedListWishResponses(groupBuys, wishMap, chatRooms);
+        assertThat(result.getPosts()).hasSize(2);
+        assertThat(result.getNextCursor()).isEqualTo(1L);
+        assertThat(result.isHasMore()).isFalse();
+    }
+
+    @Test
+    @DisplayName("주최 공구 리스트 조회 성공 - 로그인한 유저, 커서 미존재, 다음 요소 있음")
+    void getGroupBuyHostedList_success_logined_user_has_next() {
+        limit = 1;
+        cursorId = null;
+        expectedPageable = PageRequest.of(0, limit + 1, Sort.by("id").descending());
+
+        when(groupBuyRepository.findByUser_IdAndPostStatus(loginedUser.getId(), postStatus, expectedPageable))
+                .thenReturn(groupBuys);
+        when(fetchWishUtil.fetchWishMap(loginedUser.getId(), groupBuys)).thenReturn(wishMap);
+        when(chatRoomRepository.findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT")).thenReturn(chatRooms);
+        when(groupBuyQueryMapper.toHostedListWishResponses(groupBuys, wishMap, chatRooms)).thenReturn(posts);
+
+        PagedResponse<HostedListResponse> result = getGroupBuyHostedList.getGroupBuyHostedList(loginedUser.getId(), postStatus, cursorId, limit);
+
+        verify(groupBuyRepository, times(1)).findByUser_IdAndPostStatus(loginedUser.getId(), postStatus, expectedPageable);
+        verify(fetchWishUtil, times(1)).fetchWishMap(loginedUser.getId(), groupBuys);
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT");
+        verify(groupBuyQueryMapper, times(1)).toHostedListWishResponses(groupBuys, wishMap, chatRooms);
+        assertThat(result.getPosts()).hasSize(1);
+        assertThat(result.getNextCursor()).isEqualTo(2L);
+        assertThat(result.isHasMore()).isTrue();
+    }
+
+    @Test
+    @DisplayName("주최 공구 리스트 조회 성공 - 로그인한 유저, 커서 미존재, 다음 요소 없음")
+    void getGroupBuyHostedList_success_logined_user() {
+        limit = 3;
+        cursorId = null;
+        expectedPageable = PageRequest.of(0, limit + 1, Sort.by("id").descending());
+
+        when(groupBuyRepository.findByUser_IdAndPostStatus(loginedUser.getId(), postStatus, expectedPageable))
+                .thenReturn(groupBuys);
+        when(fetchWishUtil.fetchWishMap(loginedUser.getId(), groupBuys)).thenReturn(wishMap);
+        when(chatRoomRepository.findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT")).thenReturn(chatRooms);
+        when(groupBuyQueryMapper.toHostedListWishResponses(groupBuys, wishMap, chatRooms)).thenReturn(posts);
+
+        PagedResponse<HostedListResponse> result = getGroupBuyHostedList.getGroupBuyHostedList(loginedUser.getId(), postStatus, cursorId, limit);
+
+        verify(groupBuyRepository, times(1)).findByUser_IdAndPostStatus(loginedUser.getId(), postStatus, expectedPageable);
+        verify(fetchWishUtil, times(1)).fetchWishMap(loginedUser.getId(), groupBuys);
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT");
+        verify(groupBuyQueryMapper, times(1)).toHostedListWishResponses(groupBuys, wishMap, chatRooms);
+        assertThat(result.getPosts()).hasSize(2);
+        assertThat(result.isHasMore()).isFalse();
+    }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyListByCursorTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyListByCursorTest.java
@@ -1,4 +1,8 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.query;
 
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 public class GetGroupBuyListByCursorTest {
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyParticipantsInfoTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyParticipantsInfoTest.java
@@ -1,4 +1,114 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.query;
 
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyDetail.DetailResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipantList.ParticipantListResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipantList.ParticipantResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotParticipantException;
+import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyQueryMapper;
+import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryService.GetGroupBuyParticipantsInfo;
+import com.moogsan.moongsan_backend.domain.order.entity.Order;
+import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
 public class GetGroupBuyParticipantsInfoTest {
+
+    @Mock
+    private GroupBuyRepository groupBuyRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private GroupBuyQueryMapper groupBuyQueryMapper;
+
+    private GetGroupBuyParticipantsInfo getGroupBuyParticipantsInfo;
+    private User hostUser;
+    private User normalUser1;
+    private User normalUser2;
+    private GroupBuy groupBuy;
+    private Order order1;
+    private Order order2;
+    private List<Order> orders;
+
+    @BeforeEach
+    void setUp() {
+
+        hostUser = User.builder().id(1L).build();
+        normalUser1 = User.builder().id(2L).build();
+        normalUser2 = User.builder().id(3L).build();
+        groupBuy = GroupBuy.builder().id(1L).user(hostUser).build();
+        order1 = Order.builder().id(2L).user(normalUser1).build();
+        order2 = Order.builder().id(3L).user(normalUser2).build();
+        orders = List.of(order1, order2);
+
+        getGroupBuyParticipantsInfo = new GetGroupBuyParticipantsInfo(
+                groupBuyRepository,
+                orderRepository,
+                groupBuyQueryMapper
+        );
+    }
+
+    @Test
+    @DisplayName("공구 참여자 목록 조회 성공 - 주최자")
+    void getGroupBuyDetail_success_host() {
+        ParticipantResponse respA = mock(ParticipantResponse.class);
+        ParticipantResponse respB = mock(ParticipantResponse.class);
+
+        when(groupBuyRepository.findById(1L)).thenReturn(Optional.ofNullable(groupBuy));
+        when(orderRepository.findByGroupBuyIdAndStatusNot(hostUser.getId(), "CANCELED")).thenReturn(orders);
+        when(groupBuyQueryMapper.toParticipantResponse(order1)).thenReturn(respA);
+        when(groupBuyQueryMapper.toParticipantResponse(order2)).thenReturn(respB);
+
+        ParticipantListResponse result = getGroupBuyParticipantsInfo.getGroupBuyParticipantsInfo(hostUser.getId(), 1L);
+
+        verify(groupBuyRepository, times(1)).findById(1L);
+        verify(orderRepository, times(1)).findByGroupBuyIdAndStatusNot(hostUser.getId(), "CANCELED");
+        verify(groupBuyQueryMapper, times(1)).toParticipantResponse(order1);
+        verify(groupBuyQueryMapper, times(1)).toParticipantResponse(order2);
+        assertThat(result).isInstanceOf(ParticipantListResponse.class);
+    }
+
+    @Test
+    @DisplayName("공구 참여자 목록 조회 실패 - 공구글 없음")
+    void getGroupBuyDetail_success_not_found() {
+        when(groupBuyRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> getGroupBuyParticipantsInfo.getGroupBuyParticipantsInfo(hostUser.getId(), 1L))
+                .isInstanceOf(GroupBuyNotFoundException.class)
+                .hasMessageContaining(NOT_EXIST);
+
+        verify(groupBuyRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("공구 참여자 목록 조회 실패 - 주최자 아님")
+    void getGroupBuyDetail_success_not_host() {
+        when(groupBuyRepository.findById(1L)).thenReturn(Optional.ofNullable(groupBuy));
+
+        assertThatThrownBy(() -> getGroupBuyParticipantsInfo.getGroupBuyParticipantsInfo(normalUser1.getId(), 1L))
+                .isInstanceOf(GroupBuyNotHostException.class)
+                .hasMessageContaining(NOT_HOST);
+
+        verify(groupBuyRepository, times(1)).findById(1L);
+    }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyParticipatedListTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyParticipatedListTest.java
@@ -1,4 +1,213 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.query;
 
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.HostedList.HostedListResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.PagedResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.ParticipatedList.ParticipatedListResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyQueryMapper;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryService.GetGroupBuyHostedList;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryService.GetGroupBuyParticipatedList;
+import com.moogsan.moongsan_backend.domain.groupbuy.util.FetchWishUtil;
+import com.moogsan.moongsan_backend.domain.order.entity.Order;
+import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
 public class GetGroupBuyParticipatedListTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private GroupBuyQueryMapper groupBuyQueryMapper;
+
+    @Mock
+    private FetchWishUtil fetchWishUtil;
+
+    private GetGroupBuyParticipatedList getGroupBuyParticipatedList;
+    private Pageable expectedPageable;
+    private User loginedUser;
+    private Long cursorId;
+    private LocalDateTime cursorCreatedAt;
+    private String postStatus;
+    private int limit;
+    private Order order1;
+    private Order order2;
+    private List<Order> orders;
+    private GroupBuy groupBuy1;
+    private GroupBuy groupBuy2;
+    private List<GroupBuy> groupBuys;
+    private Map<Long, Boolean> wishMap;
+    private List<Long> groupBuyIds;
+    private List<ChatRoom> chatRooms;
+    private List<ParticipatedListResponse> posts;
+    private ParticipatedListResponse post1;
+    private ParticipatedListResponse post2;
+
+    @BeforeEach
+    void setUp(){
+        loginedUser = User.builder().id(1L).build();
+        postStatus = "OPEN";
+        groupBuy1 = GroupBuy.builder().id(1L).user(loginedUser).build();
+        groupBuy2 = GroupBuy.builder().id(2L).user(loginedUser).build();
+        groupBuys = List.of(groupBuy2, groupBuy1);
+        order1 = Order.builder().id(1L).groupBuy(groupBuy1).user(loginedUser).build();
+        order2 = Order.builder().id(2L).groupBuy(groupBuy2).user(loginedUser).build();
+        orders = List.of(order2, order1);
+        wishMap = mock(Map.class);
+        groupBuyIds = List.of(2L, 1L);
+        chatRooms = mock(List.class);
+        post1 = ParticipatedListResponse.builder().postId(1L).build();
+        post2 = ParticipatedListResponse.builder().postId(2L).build();
+        posts = List.of(post2, post1);
+
+        getGroupBuyParticipatedList = new GetGroupBuyParticipatedList(
+                orderRepository,
+                chatRoomRepository,
+                groupBuyQueryMapper,
+                fetchWishUtil
+        );
+    }
+
+    @Test
+    @DisplayName("참여 공구 리스트 조회 성공 - 로그인한 유저, 커서 존재, 다음 요소 있음")
+    void getGroupBuyParticipatedList_success_logined_user_cursor_has_next() {
+        cursorId = 2L;
+        cursorCreatedAt = LocalDateTime.of(2025, 6, 12, 3, 14);
+        limit = 1;
+        expectedPageable = PageRequest.of(
+                0,
+                limit + 1,
+                Sort.by("createdAt").descending()
+                        .and(Sort.by("id").descending())
+        );
+
+        when(orderRepository.findByUserAndPostStatusAndNotCanceledBeforeCursor(loginedUser.getId(), postStatus, cursorCreatedAt, cursorId, expectedPageable))
+                .thenReturn(orders);
+        when(fetchWishUtil.fetchWishMap(loginedUser.getId(), groupBuys)).thenReturn(wishMap);
+        when(chatRoomRepository.findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT")).thenReturn(chatRooms);
+        when(groupBuyQueryMapper.toParticipatedListWishResponse(orders, wishMap, chatRooms)).thenReturn(posts);
+
+        PagedResponse<ParticipatedListResponse> result = getGroupBuyParticipatedList.getGroupBuyParticipatedList(loginedUser.getId(), postStatus, cursorCreatedAt, cursorId, limit);
+
+        verify(orderRepository, times(1)).findByUserAndPostStatusAndNotCanceledBeforeCursor(loginedUser.getId(), postStatus, cursorCreatedAt, cursorId, expectedPageable);
+        verify(fetchWishUtil, times(1)).fetchWishMap(loginedUser.getId(), groupBuys);
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT");
+        verify(groupBuyQueryMapper, times(1)).toParticipatedListWishResponse(orders, wishMap, chatRooms);
+        assertThat(result.getPosts()).hasSize(1);
+        assertThat(result.getNextCursor()).isEqualTo(2L);
+        assertThat(result.isHasMore()).isTrue();
+    }
+
+    @Test
+    @DisplayName("참여 공구 리스트 조회 성공 - 로그인한 유저, 커서 존재, 다음 요소 없음")
+    void getGroupBuyParticipatedList_success_logined_user_cursor() {
+        cursorId = 2L;
+        cursorCreatedAt = LocalDateTime.of(2025, 6, 12, 3, 14);
+        limit = 2;
+        expectedPageable = PageRequest.of(
+                0,
+                limit + 1,
+                Sort.by("createdAt").descending()
+                        .and(Sort.by("id").descending())
+        );
+
+        when(orderRepository.findByUserAndPostStatusAndNotCanceledBeforeCursor(loginedUser.getId(), postStatus, cursorCreatedAt, cursorId, expectedPageable))
+                .thenReturn(orders);
+        when(fetchWishUtil.fetchWishMap(loginedUser.getId(), groupBuys)).thenReturn(wishMap);
+        when(chatRoomRepository.findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT")).thenReturn(chatRooms);
+        when(groupBuyQueryMapper.toParticipatedListWishResponse(orders, wishMap, chatRooms)).thenReturn(posts);
+
+        PagedResponse<ParticipatedListResponse> result = getGroupBuyParticipatedList.getGroupBuyParticipatedList(loginedUser.getId(), postStatus, cursorCreatedAt, cursorId, limit);
+
+        verify(orderRepository, times(1)).findByUserAndPostStatusAndNotCanceledBeforeCursor(loginedUser.getId(), postStatus, cursorCreatedAt, cursorId, expectedPageable);
+        verify(fetchWishUtil, times(1)).fetchWishMap(loginedUser.getId(), groupBuys);
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT");
+        verify(groupBuyQueryMapper, times(1)).toParticipatedListWishResponse(orders, wishMap, chatRooms);
+        assertThat(result.getPosts()).hasSize(2);
+        assertThat(result.getNextCursor()).isEqualTo(1L);
+        assertThat(result.isHasMore()).isFalse();
+    }
+
+    @Test
+    @DisplayName("참여 공구 리스트 조회 성공 - 로그인한 유저, 커서 미존재, 다음 요소 있음")
+    void getGroupBuyParticipatedList_success_logined_user_has_next() {
+        cursorId = null;
+        cursorCreatedAt = null;
+        limit = 1;
+        expectedPageable = PageRequest.of(
+                0,
+                limit + 1,
+                Sort.by("createdAt").descending()
+                        .and(Sort.by("id").descending())
+        );
+
+        when(orderRepository.findByUserAndPostStatusAndNotCanceled(loginedUser.getId(), postStatus, expectedPageable))
+                .thenReturn(orders);
+        when(fetchWishUtil.fetchWishMap(loginedUser.getId(), groupBuys)).thenReturn(wishMap);
+        when(chatRoomRepository.findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT")).thenReturn(chatRooms);
+        when(groupBuyQueryMapper.toParticipatedListWishResponse(orders, wishMap, chatRooms)).thenReturn(posts);
+
+        PagedResponse<ParticipatedListResponse> result = getGroupBuyParticipatedList.getGroupBuyParticipatedList(loginedUser.getId(), postStatus, cursorCreatedAt, cursorId, limit);
+
+        verify(orderRepository, times(1)).findByUserAndPostStatusAndNotCanceled(loginedUser.getId(), postStatus, expectedPageable);
+        verify(fetchWishUtil, times(1)).fetchWishMap(loginedUser.getId(), groupBuys);
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT");
+        verify(groupBuyQueryMapper, times(1)).toParticipatedListWishResponse(orders, wishMap, chatRooms);
+        assertThat(result.getPosts()).hasSize(1);
+        assertThat(result.getNextCursor()).isEqualTo(2L);
+        assertThat(result.isHasMore()).isTrue();
+    }
+
+    @Test
+    @DisplayName("참여 공구 리스트 조회 성공 - 로그인한 유저, 커서 미존재, 다음 요소 없음")
+    void getGroupBuyParticipatedList_success_logined_user() {
+        cursorId = null;
+        cursorCreatedAt = null;
+        limit = 3;
+        expectedPageable = PageRequest.of(
+                0,
+                limit + 1,
+                Sort.by("createdAt").descending()
+                        .and(Sort.by("id").descending())
+        );
+
+        when(orderRepository.findByUserAndPostStatusAndNotCanceled(loginedUser.getId(), postStatus, expectedPageable))
+                .thenReturn(orders);
+        when(fetchWishUtil.fetchWishMap(loginedUser.getId(), groupBuys)).thenReturn(wishMap);
+        when(chatRoomRepository.findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT")).thenReturn(chatRooms);
+        when(groupBuyQueryMapper.toParticipatedListWishResponse(orders, wishMap, chatRooms)).thenReturn(posts);
+
+        PagedResponse<ParticipatedListResponse> result = getGroupBuyParticipatedList.getGroupBuyParticipatedList(loginedUser.getId(), postStatus, cursorCreatedAt, cursorId, limit);
+
+        verify(orderRepository, times(1)).findByUserAndPostStatusAndNotCanceled(loginedUser.getId(), postStatus, expectedPageable);
+        verify(fetchWishUtil, times(1)).fetchWishMap(loginedUser.getId(), groupBuys);
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdInAndType(groupBuyIds, "PARTICIPANT");
+        verify(groupBuyQueryMapper, times(1)).toParticipatedListWishResponse(orders, wishMap, chatRooms);
+        assertThat(result.getPosts()).hasSize(2);
+        assertThat(result.getNextCursor()).isEqualTo(1L);
+        assertThat(result.isHasMore()).isFalse();
+    }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyWishListTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/query/GetGroupBuyWishListTest.java
@@ -1,4 +1,168 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.query;
 
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.PagedResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.WishList.WishListResponse;
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyQueryMapper;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryService.GetGroupBuyWishList;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import com.moogsan.moongsan_backend.domain.user.repository.WishRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 public class GetGroupBuyWishListTest {
+
+    @Mock
+    private WishRepository wishRepository;
+
+    @Mock
+    private GroupBuyQueryMapper groupBuyQueryMapper;
+
+    private GetGroupBuyWishList getGroupBuyWishList;
+
+    // 공통 테스트 데이터
+    private final User user = User.builder().id(7L).build();
+    private final String postStatus = "OPEN";
+
+    private GroupBuy groupBuy1;
+    private GroupBuy groupBuy2;
+    private WishListResponse res1;
+    private WishListResponse res2;
+    private List<GroupBuy> groupBuys;
+    private List<WishListResponse> mapped;
+
+    @BeforeEach
+    void setUp() {
+        groupBuy1 = GroupBuy.builder().id(1L).user(user).build();
+        groupBuy2 = GroupBuy.builder().id(2L).user(user).build();
+        groupBuys = List.of(groupBuy2, groupBuy1);
+
+        res1 = WishListResponse.builder().postId(1L).build();
+        res2 = WishListResponse.builder().postId(2L).build();
+        mapped = List.of(res2, res1);
+
+        getGroupBuyWishList = new GetGroupBuyWishList(groupBuyQueryMapper, wishRepository);
+    }
+
+    @Test
+    @DisplayName("관심 공구 리스트 조회 - 커서 존재 & 다음 페이지 존재")
+    void getWishList_cursor_hasNext() {
+        int limit = 1;
+        long cursorId = 2L;
+        LocalDateTime cursorAt = LocalDateTime.of(2025, 6, 12, 13, 40);
+
+        Pageable pageable = PageRequest.of(
+                0, limit + 1,
+                Sort.by("createdAt").descending().and(Sort.by("id").descending())
+        );
+
+        when(wishRepository.findGroupBuysByUserAndPostStatusBeforeCursor(
+                user.getId(), postStatus, cursorAt, cursorId, pageable)
+        ).thenReturn(groupBuys);
+
+        when(groupBuyQueryMapper.toWishListResponse(groupBuy2)).thenReturn(res2);
+        when(groupBuyQueryMapper.toWishListResponse(groupBuy1)).thenReturn(res1);
+
+        PagedResponse<WishListResponse> result = getGroupBuyWishList.getGroupBuyWishList(
+                user.getId(), postStatus, cursorAt, cursorId, limit);
+
+        verify(wishRepository).findGroupBuysByUserAndPostStatusBeforeCursor(
+                user.getId(), postStatus, cursorAt, cursorId, pageable);
+        verify(groupBuyQueryMapper, times(2)).toWishListResponse(any(GroupBuy.class));
+
+        assertThat(result.getPosts()).hasSize(1)
+                .extracting(WishListResponse::getPostId)
+                .containsExactly(2L);
+        assertThat(result.getNextCursor()).isEqualTo(2L);
+        assertThat(result.isHasMore()).isTrue();
+    }
+
+    @Test
+    @DisplayName("관심 공구 리스트 조회 - 커서 존재 & 다음 페이지 없음")
+    void getWishList_cursor_noNext() {
+        int   limit      = 2;
+        long  cursorId   = 2L;
+        LocalDateTime at = LocalDateTime.of(2025, 6, 12, 13, 40);
+
+        Pageable pageable = PageRequest.of(
+                0, limit + 1,
+                Sort.by("createdAt").descending().and(Sort.by("id").descending())
+        );
+
+        when(wishRepository.findGroupBuysByUserAndPostStatusBeforeCursor(
+                user.getId(), postStatus, at, cursorId, pageable)
+        ).thenReturn(groupBuys);
+        when(groupBuyQueryMapper.toWishListResponse(groupBuy2)).thenReturn(res2);
+        when(groupBuyQueryMapper.toWishListResponse(groupBuy1)).thenReturn(res1);
+
+        PagedResponse<WishListResponse> result = getGroupBuyWishList.getGroupBuyWishList(
+                user.getId(), postStatus, at, cursorId, limit);
+
+        assertThat(result.getPosts()).hasSize(2);
+        assertThat(result.getNextCursor()).isEqualTo(1L);
+        assertThat(result.isHasMore()).isFalse();
+    }
+
+    @Test
+    @DisplayName("관심 공구 리스트 조회 - 커서 없음 & 다음 페이지 존재")
+    void getWishList_noCursor_hasNext() {
+        int limit = 1;
+        Pageable pageable = PageRequest.of(
+                0, limit + 1,
+                Sort.by("createdAt").descending().and(Sort.by("id").descending())
+        );
+
+        when(wishRepository.findGroupBuysByUserAndPostStatus(
+                user.getId(), postStatus, pageable)
+        ).thenReturn(groupBuys);
+        when(groupBuyQueryMapper.toWishListResponse(groupBuy2)).thenReturn(res2);
+        when(groupBuyQueryMapper.toWishListResponse(groupBuy1)).thenReturn(res1);
+
+        PagedResponse<WishListResponse> result = getGroupBuyWishList.getGroupBuyWishList(
+                user.getId(), postStatus, null, null, limit);
+
+        assertThat(result.getPosts()).hasSize(1)
+                .extracting(WishListResponse::getPostId)
+                .containsExactly(2L);
+        assertThat(result.getNextCursor()).isEqualTo(2L);
+        assertThat(result.isHasMore()).isTrue();
+    }
+
+    @Test
+    @DisplayName("관심 공구 리스트 조회 - 커서 없음 & 다음 페이지 없음")
+    void getWishList_noCursor_noNext() {
+        int limit = 3;
+        Pageable pageable = PageRequest.of(
+                0, limit + 1,
+                Sort.by("createdAt").descending().and(Sort.by("id").descending())
+        );
+
+        when(wishRepository.findGroupBuysByUserAndPostStatus(
+                user.getId(), postStatus, pageable)
+        ).thenReturn(groupBuys);
+        when(groupBuyQueryMapper.toWishListResponse(groupBuy2)).thenReturn(res2);
+        when(groupBuyQueryMapper.toWishListResponse(groupBuy1)).thenReturn(res1);
+
+        PagedResponse<WishListResponse> result = getGroupBuyWishList.getGroupBuyWishList(
+                user.getId(), postStatus, null, null, limit);
+
+        assertThat(result.getPosts()).hasSize(2);
+        assertThat(result.getNextCursor()).isEqualTo(1L);
+        assertThat(result.isHasMore()).isFalse();
+    }
 }


### PR DESCRIPTION
## 🔎 작업 개요
- `Clock` 컴포넌트를 기존에 도입된 Delete/End/LeaveGroupBuy 커맨드 서비스에 추가 주입  
- 마감임박(`dueSoon=true`) 조회 시 `postStatus = POSTED` 필터 적용  
- `getGroupBuyEditInfo`에 `userId` 파라미터 오버로드 및 비호스트 접근 예외 처리 강화  
- **Hosted/Participated/Wish List** 서비스에서 커서 기반 페이징 로직(`limit + 1`, `nextCursor`, `hasMore`) 전반 개선  
- 커서 기반 페이징 시나리오에 대한 **단위 테스트** (`GetGroupBuyHostedListTest`, `GetGroupBuyParticipatedListTest`, `GetGroupBuyWishListTest`) 작성

---

## 🛠️ 주요 변경 사항
- **커맨드 서비스**  
  - `DeleteGroupBuy`, `EndGroupBuy`, `LeaveGroupBuy` → `LocalDateTime.now(clock)` 사용하도록 변경  
- **쿼리 서비스**  
  - `GetGroupBuyDetailInfo`, `GetGroupBuyEditInfo`, `GetGroupBuyHostAccountInfo` → `Clock` 주입 및 시간 검증 보강  
  - `GetGroupBuyEditInfo` → `getGroupBuyEditInfo(Long userId, Long postId)` 오버로드, 권한 체크 강화  
- **리스트 서비스 커서 페이징**  
  - `GetGroupBuyHostedList`, `GetGroupBuyParticipatedList`, `GetGroupBuyWishList`  
    - `limit + 1` 페이지 요청  
    - `nextCursor`, `hasMore` 계산 버그 수정  
    - `postStatus` 필터링 (`HostedList`만)  
- **테스트**  
  - 고정 `Clock` 주입 검증 추가 (Command/Detail/Edit/HostAccount)  
  - **커서 페이징 시나리오** (limit 초과/미초과, cursor 유/무) 단위 테스트 3종 추가

---

## ✅ 검증 방법
1. `./gradlew test` → 모든 유닛 테스트 통과  
2. `GET /api/group-buys?dueSoon=true` → POSTED 상태의 게시글만 반환  
3. `GET /api/group-buys/{id}/edit` → 호스트는 200, 비호스트는 예외 발생  
4. Hosted/Participated/Wish List API → 커서 기반 페이징(limit, nextCursor, hasMore) 정확성 확인

---

## 🔍 머지 전 확인사항
- 기존 테스트 코드와 충돌나지 않는지

---

## ➕ 관련 이슈
 - [[Sub Task] BE - 테스트 코드 작성](https://github.com/100-hours-a-week/14-YG-BE/issues/95)
 - [[Sub Task] BE - 테스트 코드에서의 고정 시간 사용](https://github.com/100-hours-a-week/14-YG-BE/issues/141)
