### PR TITLE
feat(chatting): cursorJoinedAt 기반 채팅방 페이징 및 ChatRoomPagedResponse 반환

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacade.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacade.java
@@ -2,6 +2,7 @@ package com.moogsan.moongsan_backend.domain.chatting.Facade.query;
 
 import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatMessagePageResponse;
 import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatMessageResponse;
+import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatRoomPagedResponse;
 import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatRoomResponse;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import org.springframework.web.context.request.async.DeferredResult;
@@ -28,9 +29,9 @@ public interface ChattingQueryFacade {
             Long chatRoomId
     );
 
-    List<ChatRoomResponse> getChatRoomList (
+    ChatRoomPagedResponse getChatRoomList (
             Long userId,
             LocalDateTime cursorJoinedAt,
-            Long cursorId,
-            Integer limit);
+            Integer limit)
+    ;
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacadeImpl.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacadeImpl.java
@@ -2,6 +2,7 @@ package com.moogsan.moongsan_backend.domain.chatting.Facade.query;
 
 import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatMessagePageResponse;
 import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatMessageResponse;
+import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatRoomPagedResponse;
 import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatRoomResponse;
 import com.moogsan.moongsan_backend.domain.chatting.service.query.GetChatRoomList;
 import com.moogsan.moongsan_backend.domain.chatting.service.query.GetLatestMessageSse;
@@ -62,7 +63,7 @@ public class ChattingQueryFacadeImpl implements ChattingQueryFacade{
         // return getLatestMessagesSse.createEmitter(chatRoomId);
     }
 
-    public List<ChatRoomResponse> getChatRoomList (Long userId, LocalDateTime cursorJoinedAt, Long cursorId, Integer limit) {
-        return getChatRoomList.getChatRoomList(userId, cursorJoinedAt, cursorId, limit);
+    public ChatRoomPagedResponse getChatRoomList (Long userId, LocalDateTime cursorJoinedAt, Integer limit) {
+        return getChatRoomList.getChatRoomList(userId, cursorJoinedAt, limit);
     };
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetChatRoomListController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetChatRoomListController.java
@@ -2,6 +2,7 @@ package com.moogsan.moongsan_backend.domain.chatting.controller.query;
 
 import com.moogsan.moongsan_backend.domain.WrapperResponse;
 import com.moogsan.moongsan_backend.domain.chatting.Facade.query.ChattingQueryFacade;
+import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatRoomPagedResponse;
 import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatRoomResponse;
 import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
 import com.moogsan.moongsan_backend.global.exception.specific.UnauthenticatedAccessException;
@@ -24,18 +25,17 @@ public class GetChatRoomListController {
     private final ChattingQueryFacade chattingQueryFacade;
 
     @GetMapping("/users/me/participant")
-    public ResponseEntity<WrapperResponse<List<ChatRoomResponse>>> getChatRoomList (
+    public ResponseEntity<WrapperResponse<ChatRoomPagedResponse>> getChatRoomList (
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(value = "cursorJoinedAt", required = false) LocalDateTime cursorJoinedAt,
-            @RequestParam(value = "cursorId", required = false) Long cursorId,
             @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit
     ) {
         if (userDetails == null) throw new UnauthenticatedAccessException("로그인이 필요합니다.");
 
-        List<ChatRoomResponse> chatRoomResponse = chattingQueryFacade
-                .getChatRoomList(userDetails.getUser().getId(), cursorJoinedAt, cursorId, limit);
+        ChatRoomPagedResponse chatRoomResponse = chattingQueryFacade
+                .getChatRoomList(userDetails.getUser().getId(), cursorJoinedAt, limit);
         return ResponseEntity.ok(
-                WrapperResponse.<List<ChatRoomResponse>>builder()
+                WrapperResponse.<ChatRoomPagedResponse>builder()
                         .message("참여자 채팅방을 성공적으로 조회했습니다")
                         .data(chatRoomResponse)
                         .build());

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/dto/query/ChatRoomPagedResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/dto/query/ChatRoomPagedResponse.java
@@ -1,0 +1,17 @@
+package com.moogsan.moongsan_backend.domain.chatting.dto.query;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatRoomPagedResponse {
+
+    private List<ChatRoomResponse> chatRooms;                // 채팅 게시글 리스트
+    private LocalDateTime nextCursorJoinedAt;           // 다음 페이지용 postId
+    private boolean hasMore;              // 다음 페이지 존재 여부
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetChatRoomList.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetChatRoomList.java
@@ -1,15 +1,15 @@
 package com.moogsan.moongsan_backend.domain.chatting.service.query;
 
+import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatRoomPagedResponse;
 import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatRoomResponse;
-import com.moogsan.moongsan_backend.domain.chatting.entity.ChatMessageDocument;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatParticipant;
 import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
 import com.moogsan.moongsan_backend.domain.chatting.mapper.ChatMessageQueryMapper;
-import com.moogsan.moongsan_backend.domain.chatting.repository.ChatMessageRepository;
 import com.moogsan.moongsan_backend.domain.chatting.repository.ChatParticipantRepository;
-import com.moogsan.moongsan_backend.domain.image.entity.Image;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -22,23 +22,44 @@ public class GetChatRoomList {
     private final ChatParticipantRepository chatParticipantRepository;
     private final ChatMessageQueryMapper chatMessageQueryMapper;
 
-    public List<ChatRoomResponse> getChatRoomList (Long userId, LocalDateTime cursorJoinedAt, Long cursorId, Integer limit) {
+    public ChatRoomPagedResponse getChatRoomList (Long userId, LocalDateTime cursorJoinedAt, Integer limit) {
 
         // 결과 조회 -> 없으면 빈 리스트 리턴
-        Pageable pageable = PageRequest.of(0, limit);
+        Pageable page = PageRequest.of(0,
+                limit + 1,
+                Sort.by("joinedAt").descending()
+                        .and(Sort.by("id").descending())
+        );
 
-        List<ChatRoom> rooms;
-        if (cursorJoinedAt == null || cursorId == null) {
-            rooms = chatParticipantRepository.findInitialChatRooms(userId, pageable);
+        List<ChatParticipant> participants;
+        if (cursorJoinedAt == null) {
+            participants = chatParticipantRepository.findInitialParticipants(userId, page);
         } else {
-            rooms = chatParticipantRepository.findActiveParticipantChatRoomsByUserIdWithCursor(
-                    userId,
-                    cursorJoinedAt,
-                    cursorId == null ? Long.MAX_VALUE : cursorId,
-                    pageable
-            );
+            participants = chatParticipantRepository.findParticipantsAfter(userId, cursorJoinedAt, page);
         }
 
-        return chatMessageQueryMapper.toChatRoomList(rooms);
+        List<ChatParticipant> pageOf = participants.size() > limit
+                ? participants.subList(0, limit)
+                : participants;
+
+        LocalDateTime nextJoinedAt = null;
+        if (!pageOf.isEmpty()) {
+            ChatParticipant last = pageOf.getLast();
+            nextJoinedAt = last.getJoinedAt();
+        }
+
+        boolean hasMore = participants.size() > limit;
+
+        List<ChatRoom> rooms = pageOf.stream()
+                .map(ChatParticipant::getChatRoom)
+                .toList();
+
+        List<ChatRoomResponse> results = chatMessageQueryMapper.toChatRoomList(rooms);
+
+        return ChatRoomPagedResponse.builder()
+                .chatRooms(results)
+                .nextCursorJoinedAt(nextJoinedAt)
+                .hasMore(hasMore)
+                .build();
     }
 }


### PR DESCRIPTION
## 🔎 작업 개요  
ChatRoom 리스트 조회 서비스에 `cursorJoinedAt` 기반 커서 페이징을 적용하고, 반환 DTO를 기존 `ChatRoomResponse` 리스트가 아닌 `ChatRoomPagedResponse` 형태로 변경합니다.

## 🛠️ 주요 변경 사항  
- **`ChatParticipantRepository`**  
  - `findInitialParticipants` / `findParticipantsAfter` 쿼리 추가:  
    - `joinedAt DESC, id DESC` 정렬  
    - `p.joinedAt < :cursorJoinedAt` 조건으로 다음 페이지 페이징  
- **`GetChatRoomList` 서비스**  
  - `ChatParticipant` 조회 → `joinedAt` 기준으로 커서 페이징  
  - 잘라낸 참가자 리스트에서 `ChatRoom`만 추출하여 기존 매퍼에 전달  
  - `ChatRoomPagedResponse`에 `chats`, `nextCursorJoinedAt`, `hasMore` 필드 설정  
- **`ChatRoomPagedResponse` DTO** 추가  
- **컨트롤러 & Facade** 호출부: 페이징 파라미터(`cursorJoinedAt`, `limit`) 전달 및 반환 타입 변경  

## ✅ 검증 방법  
- `cursorJoinedAt = null` 시 최신 방 1페이지(limit 개수) 정상 반환  
- 반환된 `nextCursorJoinedAt`를 전달했을 때 이어지는 방(다음 페이지) 정상 반환  
- 전체 결과가 `limit+1` 이상일 때 `hasMore=true`, 아닐 때 `false`  
- 동시간대(`joinedAt` 동일) 다수 참가자 발생 시 중복·누락 없이 순차 페이징  

## 🔍 머지 전 확인사항  
- 쿼리 실행 계획(EXPLAIN)으로 성능 이슈 없는지 검토  
- API 스펙(프론트 계약)과 리턴 필드 정확히 일치하는지 확인  
- 기존 `ChatRoomResponse` 매핑 로직 변화 없음  

## ➕ 이슈 링크  
- [[Sprint #5] BE - 실시간 참여자 채팅 서버 구축](https://github.com/100-hours-a-week/14-YG-BE/issues/93)