### PR TITLE
test(chatting): 채팅 서비스 테스트 코드 작성

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/exception/specific/AlreadyJoinedException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/exception/specific/AlreadyJoinedException.java
@@ -3,9 +3,11 @@ package com.moogsan.moongsan_backend.domain.chatting.exception.specific;
 import com.moogsan.moongsan_backend.domain.chatting.exception.base.ChattingException;
 import com.moogsan.moongsan_backend.domain.chatting.exception.code.ChattingErrorCode;
 
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.ALREADEY_JOINED;
+
 public class AlreadyJoinedException extends ChattingException {
     public AlreadyJoinedException() {
-        super(ChattingErrorCode.ALREADY_JOINED, "중복된 참여 요청입니다.");
+        super(ChattingErrorCode.ALREADY_JOINED, ALREADEY_JOINED);
     }
 
     public AlreadyJoinedException(String message) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/exception/specific/ChatRoomInvalidStateException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/exception/specific/ChatRoomInvalidStateException.java
@@ -3,9 +3,11 @@ package com.moogsan.moongsan_backend.domain.chatting.exception.specific;
 import com.moogsan.moongsan_backend.domain.chatting.exception.base.ChattingException;
 import com.moogsan.moongsan_backend.domain.chatting.exception.code.ChattingErrorCode;
 
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.CHAT_ROOM_INVALID_STATE;
+
 public class ChatRoomInvalidStateException extends ChattingException {
     public ChatRoomInvalidStateException() {
-        super(ChattingErrorCode.CHAT_ROOM_INVALID_STATE, "채팅방 상태가 유효하지 않아 요청을 처리할 수 없습니다.");
+        super(ChattingErrorCode.CHAT_ROOM_INVALID_STATE, CHAT_ROOM_INVALID_STATE);
     }
 
     public ChatRoomInvalidStateException(String message) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/exception/specific/ChatRoomNotFoundException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/exception/specific/ChatRoomNotFoundException.java
@@ -5,9 +5,11 @@ import com.moogsan.moongsan_backend.domain.chatting.exception.code.ChattingError
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.base.GroupBuyException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
 
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.CHAT_ROOM_NOT_FOUND;
+
 public class ChatRoomNotFoundException extends ChattingException {
     public ChatRoomNotFoundException() {
-        super(ChattingErrorCode.CHAT_ROOM_NOT_FOUND, "존재하지 않는 채팅방입니다.");
+        super(ChattingErrorCode.CHAT_ROOM_NOT_FOUND, CHAT_ROOM_NOT_FOUND);
     }
 
     public ChatRoomNotFoundException(String message) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/exception/specific/NotParticipantException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/exception/specific/NotParticipantException.java
@@ -3,9 +3,11 @@ package com.moogsan.moongsan_backend.domain.chatting.exception.specific;
 import com.moogsan.moongsan_backend.domain.chatting.exception.base.ChattingException;
 import com.moogsan.moongsan_backend.domain.chatting.exception.code.ChattingErrorCode;
 
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.NOT_PARTICIPANT;
+
 public class NotParticipantException extends ChattingException {
     public NotParticipantException() {
-        super(ChattingErrorCode.NOT_PARTICIPANT, "참여자만 요청가능합니다.");
+        super(ChattingErrorCode.NOT_PARTICIPANT, NOT_PARTICIPANT);
     }
 
     public NotParticipantException(String message) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/message/ResponseMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/message/ResponseMessage.java
@@ -1,0 +1,31 @@
+package com.moogsan.moongsan_backend.domain.chatting.message;
+
+public class ResponseMessage {
+
+    /// SUCCESS
+
+    public static final String CREATE_SUCCESS =
+            "공구 게시글이 성공적으로 업로드되었습니다.";
+
+
+    ///  FAIL
+
+    public static final String CHAT_ROOM_NOT_FOUND =
+            "존재하지 않는 채팅방입니다.";
+
+    public static final String DELETED_CHAT_ROOM =
+            "삭제된 채팅방에는 메세지를 보낼 수 없습니다.";
+
+    public static final String NOT_PARTICIPANT =
+            "채팅방의 참여자만 요청 가능합니다.";
+
+    public static final String ALREADEY_JOINED =
+            "이미 참여한 채팅방입니다.";
+
+    public static final String CHAT_ROOM_INVALID_STATE =
+            "채팅방 상태가 유효하지 않아 요청을 처리할 수 없습니다.";
+
+    public static final String ORDER_NOT_FOUND =
+            "공구의 참여자만 채팅방에 참가할 수 있습니다.";
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/JoinChatRoom.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/JoinChatRoom.java
@@ -20,6 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.ALREADEY_JOINED;
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.ORDER_NOT_FOUND;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -41,9 +44,8 @@ public class JoinChatRoom {
         if (!isHost) {
             // 해당 공구의 주문 테이블에 해당 유저의 주문이 존재하는지 조회 -> 아니면 404
             Order order = orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(currentUser.getId(), groupBuy.getId(), "CANCELED")
-                    .orElseThrow(() -> new OrderNotFoundException("공구의 참여자만 참가 가능합니다."));
+                    .orElseThrow(() -> new OrderNotFoundException(ORDER_NOT_FOUND));
         }
-
 
         // 해당 공구의 참여자 채팅방이 존재하는지 조회
         ChatRoom chatRoom = chatRoomRepository
@@ -62,7 +64,7 @@ public class JoinChatRoom {
                 .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), currentUser.getId());
 
         if (alreadyJoined) {
-            throw new AlreadyJoinedException("이미 참여한 채팅방입니다.");
+            throw new AlreadyJoinedException(ALREADEY_JOINED);
         } else {
             // 호스트를 참여자로 등록
             ChatParticipant participant = ChatParticipant.builder()

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/LeaveChatRoom.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/LeaveChatRoom.java
@@ -23,6 +23,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.CHAT_ROOM_NOT_FOUND;
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.ORDER_NOT_FOUND;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_PARTICIPANT;
+
 @Slf4j
 @Service
 @Transactional
@@ -38,17 +42,17 @@ public class LeaveChatRoom {
 
         // 해당 공구의 주문 테이블에 해당 유저의 주문이 존재하는지 조회 -> 아니면 404
         Order order = orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(currentUser.getId(), groupBuyId, "CANCELED")
-                .orElseThrow(() -> new OrderNotFoundException("공구의 참여자만 나갈 수 있습니다: ORDER."));
+                .orElseThrow(() -> new OrderNotFoundException(ORDER_NOT_FOUND));
 
         // 해당 공구의 참여자 채팅방이 존재하는지 조회
         ChatRoom chatRoom = chatRoomRepository
                 .findByGroupBuy_IdAndType(groupBuyId, "PARTICIPANT")
-                .orElseThrow(() -> new ChatRoomNotFoundException("존재하는 채팅방만 나갈 수 있습니다."));
+                .orElseThrow(() -> new ChatRoomNotFoundException(CHAT_ROOM_NOT_FOUND));
 
         // 참여자인지 조회 -> 아니면 403
         ChatParticipant chatParticipant = chatParticipantRepository
                 .findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), currentUser.getId())
-                .orElseThrow(() -> new NotParticipantException("공구의 참여자만 나갈 수 있습니다: CHATPARTICIPANT"));
+                .orElseThrow(() -> new NotParticipantException(NOT_PARTICIPANT));
 
         chatRoom.decrementParticipants();
         chatRoomRepository.save(chatRoom);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetChatRoomList.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetChatRoomList.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -50,7 +51,7 @@ public class GetChatRoomList {
 
         boolean hasMore = participants.size() > limit;
 
-        List<ChatRoom> rooms = pageOf.stream()
+         List<ChatRoom> rooms = pageOf.stream()
                 .map(ChatParticipant::getChatRoom)
                 .toList();
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessageSse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessageSse.java
@@ -24,11 +24,12 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.NOT_PARTICIPANT;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class GetLatestMessageSse {
-    private static final long TIMEOUT_MILLIS = 5000L;
 
     private final ChatParticipantRepository chatParticipantRepository;
     private final ChatRoomRepository chatRoomRepository;
@@ -48,7 +49,7 @@ public class GetLatestMessageSse {
         boolean isParticipant = chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoomId, currentUser.getId());
 
         if(!isParticipant) {
-            throw new NotParticipantException("참여자만 메세지를 조회할 수 있습니다.");
+            throw new NotParticipantException(NOT_PARTICIPANT);
         }
 
         // SseEmitter 생성

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessages.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetLatestMessages.java
@@ -22,6 +22,8 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.NOT_PARTICIPANT;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -47,7 +49,7 @@ public class GetLatestMessages {
         boolean isParticipant = chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoomId, currentUser.getId());
 
         if(!isParticipant) {
-            throw new NotParticipantException("참여자만 메세지를 조회할 수 있습니다.");
+            throw new NotParticipantException(NOT_PARTICIPANT);
         }
 
         // 마지막 메세지 이후 새로운 메세지 존재 여부 확인
@@ -84,8 +86,6 @@ public class GetLatestMessages {
         Long chatRoomId = newMessage.getChatRoomId();
         List<DeferredResult<List<ChatMessageResponse>>> results = listeners.getOrDefault(chatRoomId, new ArrayList<>());
 
-        // log.info("🔔 notifyNewMessage 호출됨: chatRoomId={}, messageId={}", chatRoomId, newMessage.getId());
-        // log.info("🧍‍♂️ 응답 대기 중인 클라이언트 수: {}", results.size());
         ChatMessageResponse response = chatMessageQueryMapper.toMessageResponse(newMessage, nickname, imageKey);
         for (DeferredResult<List<ChatMessageResponse>> r : results) {
             Runnable task = () -> {
@@ -98,14 +98,5 @@ public class GetLatestMessages {
         }
 
         results.clear();
-    }
-
-    private DeferredResult<List<ChatMessageResponse>> wrapResult(List<ChatMessageDocument> messages) {
-        List<ChatMessageResponse> responses = messages.stream()
-                .map(doc -> chatMessageQueryMapper.toMessageResponse(doc, "알수없음", null)) // 빠른 반환이라 간략화
-                .collect(Collectors.toList());
-        DeferredResult<List<ChatMessageResponse>> result = new DeferredResult<>();
-        result.setResult(responses);
-        return result;
     }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/command/CreateChatMessageTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/command/CreateChatMessageTest.java
@@ -1,0 +1,13 @@
+package com.moogsan.moongsan_backend.unit.chatting.controller.command;
+
+import com.moogsan.moongsan_backend.domain.chatting.controller.command.CreateChatMessageController;
+import com.moogsan.moongsan_backend.domain.groupbuy.controller.command.CreateGroupBuyController;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(controllers = CreateChatMessageController.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+public class CreateChatMessageTest {
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/command/JoinChatRoomTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/command/JoinChatRoomTest.java
@@ -1,0 +1,13 @@
+package com.moogsan.moongsan_backend.unit.chatting.controller.command;
+
+import com.moogsan.moongsan_backend.domain.chatting.controller.command.CreateChatMessageController;
+import com.moogsan.moongsan_backend.domain.chatting.controller.command.JoinChatRoomController;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(controllers = JoinChatRoomController.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+public class JoinChatRoomTest {
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/command/LeaveChatRoomTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/command/LeaveChatRoomTest.java
@@ -1,0 +1,13 @@
+package com.moogsan.moongsan_backend.unit.chatting.controller.command;
+
+import com.moogsan.moongsan_backend.domain.chatting.controller.command.JoinChatRoomController;
+import com.moogsan.moongsan_backend.domain.chatting.controller.command.LeaveChatRoomController;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(controllers = LeaveChatRoomController.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+public class LeaveChatRoomTest {
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/query/GetChatRoomListTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/query/GetChatRoomListTest.java
@@ -1,0 +1,13 @@
+package com.moogsan.moongsan_backend.unit.chatting.controller.query;
+
+import com.moogsan.moongsan_backend.domain.chatting.controller.command.LeaveChatRoomController;
+import com.moogsan.moongsan_backend.domain.chatting.controller.query.GetChatRoomListController;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(controllers = GetChatRoomListController.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+public class GetChatRoomListTest {
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/query/GetLatestMessagesSseTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/query/GetLatestMessagesSseTest.java
@@ -1,0 +1,12 @@
+package com.moogsan.moongsan_backend.unit.chatting.controller.query;
+
+import com.moogsan.moongsan_backend.domain.chatting.controller.query.GetLatestMessagesSseController;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(controllers = GetLatestMessagesSseController.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+public class GetLatestMessagesSseTest {
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/query/GetLatestMessagesTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/query/GetLatestMessagesTest.java
@@ -1,0 +1,13 @@
+package com.moogsan.moongsan_backend.unit.chatting.controller.query;
+
+import com.moogsan.moongsan_backend.domain.chatting.controller.query.GetLatestMessagesController;
+import com.moogsan.moongsan_backend.domain.chatting.controller.query.GetLatestMessagesSseController;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(controllers = GetLatestMessagesController.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+public class GetLatestMessagesTest {
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/query/GetPastMessagesTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/controller/query/GetPastMessagesTest.java
@@ -1,0 +1,12 @@
+package com.moogsan.moongsan_backend.unit.chatting.controller.query;
+
+import com.moogsan.moongsan_backend.domain.chatting.controller.query.GetPastMessagesController;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(controllers = GetPastMessagesController.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+public class GetPastMessagesTest {
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/command/CreateChatMessageTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/command/CreateChatMessageTest.java
@@ -1,0 +1,195 @@
+package com.moogsan.moongsan_backend.unit.chatting.service.command;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.domain.chatting.Facade.command.ChattingCommandFacade;
+import com.moogsan.moongsan_backend.domain.chatting.controller.command.CreateChatMessageController;
+import com.moogsan.moongsan_backend.domain.chatting.dto.command.request.CreateChatMessageRequest;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatMessageDocument;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatParticipant;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
+import com.moogsan.moongsan_backend.domain.chatting.exception.specific.ChatRoomInvalidStateException;
+import com.moogsan.moongsan_backend.domain.chatting.exception.specific.ChatRoomNotFoundException;
+import com.moogsan.moongsan_backend.domain.chatting.exception.specific.NotParticipantException;
+import com.moogsan.moongsan_backend.domain.chatting.mapper.ChatMessageCommandMapper;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatMessageRepository;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatParticipantRepository;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
+import com.moogsan.moongsan_backend.domain.chatting.service.command.CreateChatMessage;
+import com.moogsan.moongsan_backend.domain.chatting.service.query.GetLatestMessageSse;
+import com.moogsan.moongsan_backend.domain.chatting.service.query.GetLatestMessages;
+import com.moogsan.moongsan_backend.domain.chatting.util.MessageSequenceGenerator;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.time.*;
+import java.util.Optional;
+
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.CHAT_ROOM_NOT_FOUND;
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.DELETED_CHAT_ROOM;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_DIVISOR;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_PARTICIPANT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CreateChatMessageTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatParticipantRepository chatParticipantRepository;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    private MessageSequenceGenerator messageSequenceGenerator;
+
+    @Mock
+    private ChatMessageCommandMapper chatMessageCommandMapper;
+
+    @Mock
+    private GetLatestMessages getLatestMessages;
+
+    @Mock
+    private GetLatestMessageSse getLatestMessageSse;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private ZSetOperations<String, String> zSetOperations;
+
+    private CreateChatMessage createChatMessage;
+    private ChatRoom chatRoom;
+    private User participantUser;
+    private User normalUser;
+    private ChatParticipant chatParticipant;
+    private ChatMessageDocument chatMessageDocument;
+    private String json;
+    private CreateChatMessageRequest request;
+    private Clock fixedClock;
+    private LocalDateTime now;
+
+    @BeforeEach
+    void setUp() {
+
+        chatRoom = spy(ChatRoom.builder().id(20L).build());
+        participantUser = User.builder().id(1L).build();
+        normalUser = User.builder().id(2L).build();
+        chatParticipant = ChatParticipant.builder().id(3L).user(participantUser).build();
+        request = CreateChatMessageRequest.builder().messageContent("안녕하세요!").build();
+        chatMessageDocument = mock(ChatMessageDocument.class);
+
+        fixedClock = Clock.fixed(
+                Instant.parse("2025-06-11T13:00:00Z"),
+                ZoneId.of("Asia/Seoul")
+        );
+
+        now = LocalDateTime.now(fixedClock);
+
+        createChatMessage = new CreateChatMessage(
+                chatRoomRepository,
+                chatParticipantRepository,
+                chatMessageRepository,
+                messageSequenceGenerator,
+                chatMessageCommandMapper,
+                getLatestMessages,
+                getLatestMessageSse,
+                redisTemplate,
+                objectMapper,
+                fixedClock
+        );
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 메세지 작성 성공")
+    void createChatMessage_success() throws JsonProcessingException{
+        when(chatRoomRepository.findById(20L)).thenReturn(Optional.of(chatRoom));
+        when(chatParticipantRepository.findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId()))
+                .thenReturn(Optional.ofNullable(chatParticipant));
+        when(messageSequenceGenerator.getNextMessageSeq(chatRoom.getId())).thenReturn(2L);
+        when(chatMessageCommandMapper.toMessageDocument(chatRoom, chatParticipant.getId(), request, 2L))
+                .thenReturn(chatMessageDocument);
+        when(chatMessageDocument.getId()).thenReturn("64df8cfa34fded0a178ed289");
+        json = "{\"id\":\"64df8cfa34fded0a178ed289\",\"content\":\"안녕하세요!\"}";
+        when(objectMapper.writeValueAsString(chatMessageDocument)).thenReturn(json);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(zSetOperations.add(anyString(), anyString(), anyDouble())).thenReturn(true);
+
+        createChatMessage.createChatMessage(participantUser, request, chatRoom.getId());
+
+        verify(chatRoomRepository, times(1)).findById(20L);
+        verify(chatParticipantRepository, times(1))
+                .findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+        verify(messageSequenceGenerator, times(1)).getNextMessageSeq(chatRoom.getId());
+        verify(chatMessageCommandMapper, times(1)).toMessageDocument(chatRoom, chatParticipant.getId(), request, 2L);
+        verify(redisTemplate.opsForZSet(), times(1)).add(anyString(), anyString(), anyDouble());
+        verify(redisTemplate, times(1)).expire(anyString(), eq(Duration.ofHours(24)));
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 메세지 작성 실패 - 존재하지 않는 채팅방")
+    void createChatMessage_fail_chat_room_not_exist() {
+        when(chatRoomRepository.findById(20L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> createChatMessage.createChatMessage(participantUser, request, 20L))
+                .isInstanceOf(ChatRoomNotFoundException.class)
+                .hasMessageContaining(CHAT_ROOM_NOT_FOUND);
+
+        verify(chatRoomRepository, times(1)).findById(20L);
+        verify(chatParticipantRepository, never())
+                .findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+        verify(messageSequenceGenerator, never()).getNextMessageSeq(chatRoom.getId());
+        verify(chatMessageCommandMapper, never()).toMessageDocument(chatRoom, chatParticipant.getId(), request, 2L);
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 메세지 작성 실패 - 채팅방 삭제됨")
+    void createChatMessage_fail_delete_chat_room() {
+        when(chatRoomRepository.findById(20L)).thenReturn(Optional.of(chatRoom));
+        when(chatRoom.getDeletedAt()).thenReturn(now.minusDays(2));
+
+        assertThatThrownBy(() -> createChatMessage.createChatMessage(participantUser, request, 20L))
+                .isInstanceOf(ChatRoomInvalidStateException.class)
+                .hasMessageContaining(DELETED_CHAT_ROOM);
+
+        verify(chatRoomRepository, times(1)).findById(20L);
+        verify(chatParticipantRepository, never())
+                .findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+        verify(messageSequenceGenerator, never()).getNextMessageSeq(chatRoom.getId());
+        verify(chatMessageCommandMapper, never()).toMessageDocument(chatRoom, chatParticipant.getId(), request, 2L);
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 메세지 작성 실패 - 참여자가 아님")
+    void createChatMessage_fail_not_participant() {
+        when(chatRoomRepository.findById(20L)).thenReturn(Optional.of(chatRoom));
+        when(chatParticipantRepository.findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> createChatMessage.createChatMessage(participantUser, request, 20L))
+                .isInstanceOf(NotParticipantException.class)
+                .hasMessageContaining(NOT_PARTICIPANT);
+
+        verify(chatRoomRepository, times(1)).findById(20L);
+        verify(chatParticipantRepository, times(1))
+                .findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+        verify(messageSequenceGenerator, never()).getNextMessageSeq(chatRoom.getId());
+        verify(chatMessageCommandMapper, never()).toMessageDocument(chatRoom, chatParticipant.getId(), request, 2L);
+    }
+
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/command/JoinChatRoomTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/command/JoinChatRoomTest.java
@@ -1,0 +1,161 @@
+package com.moogsan.moongsan_backend.unit.chatting.service.command;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
+import com.moogsan.moongsan_backend.domain.chatting.exception.specific.AlreadyJoinedException;
+import com.moogsan.moongsan_backend.domain.chatting.exception.specific.ChatRoomNotFoundException;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatParticipantRepository;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
+import com.moogsan.moongsan_backend.domain.chatting.service.command.JoinChatRoom;
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
+import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.order.entity.Order;
+import com.moogsan.moongsan_backend.domain.order.exception.specific.OrderNotFoundException;
+import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.*;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_EXIST;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class JoinChatRoomTest {
+
+    @Mock
+    private GroupBuyRepository groupBuyRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatParticipantRepository chatParticipantRepository;
+
+    private JoinChatRoom joinChatRoom;
+    private GroupBuy groupBuy;
+    private User hostUser;
+    private User participantUser;
+    private Order order;
+    private ChatRoom chatRoom;
+
+    @BeforeEach
+    void setUp() {
+
+        hostUser = User.builder().id(1L).build();
+        participantUser = User.builder().id(2L).build();
+        groupBuy = GroupBuy.builder().id(20L).user(hostUser).build();
+        order = Order.builder().id(30L).user(participantUser).build();
+        chatRoom = ChatRoom.builder().id(18L).type("PARTICIPANT").build();
+
+        joinChatRoom = new JoinChatRoom(
+                groupBuyRepository,
+                orderRepository,
+                chatRoomRepository,
+                chatParticipantRepository
+        );
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 참여 성공 - 주최자")
+    void joinChatRoom_success_host() {
+        when(groupBuyRepository.findById(20L)).thenReturn(Optional.of(groupBuy));
+        when(chatRoomRepository.findByGroupBuy_IdAndType(20L, "PARTICIPANT")).thenReturn(Optional.of(chatRoom));
+        when(chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), hostUser.getId()))
+                .thenReturn(false);
+
+        joinChatRoom.joinChatRoom(hostUser, 20L);
+
+        verify(groupBuyRepository, times(1)).findById(20L);
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdAndType(20L, "PARTICIPANT");
+        verify(chatParticipantRepository, times(1))
+                .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), hostUser.getId());
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 참여 성공 - 참가자")
+    void joinChatRoom_success_participant() {
+        when(groupBuyRepository.findById(20L)).thenReturn(Optional.of(groupBuy));
+        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED"))
+                .thenReturn(Optional.of(order));
+        when(chatRoomRepository.findByGroupBuy_IdAndType(20L, "PARTICIPANT")).thenReturn(Optional.of(chatRoom));
+        when(chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId()))
+                .thenReturn(false);
+
+        joinChatRoom.joinChatRoom(participantUser, 20L);
+
+        verify(groupBuyRepository, times(1)).findById(20L);
+        verify(orderRepository, times(1)).findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdAndType(20L, "PARTICIPANT");
+        verify(chatParticipantRepository, times(1))
+                .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 참여 실패 - 존재하지 않는 공구")
+    void joinChatRoom_success_group_buy_not_found() {
+        when(groupBuyRepository.findById(20L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> joinChatRoom.joinChatRoom(participantUser, 20L))
+                .isInstanceOf(GroupBuyNotFoundException.class)
+                .hasMessageContaining(NOT_EXIST);
+
+        verify(groupBuyRepository, times(1)).findById(20L);
+        verify(orderRepository, never()).findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(chatRoomRepository, never()).findByGroupBuy_IdAndType(20L, "PARTICIPANT");
+        verify(chatParticipantRepository, never())
+                .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 참여 실패 - 참여자가 아님")
+    void joinChatRoom_success_group_buy_not_participant() {
+        when(groupBuyRepository.findById(20L)).thenReturn(Optional.of(groupBuy));
+        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> joinChatRoom.joinChatRoom(participantUser, 20L))
+                .isInstanceOf(OrderNotFoundException.class)
+                .hasMessageContaining(ORDER_NOT_FOUND);
+
+        verify(groupBuyRepository, times(1)).findById(20L);
+        verify(orderRepository, times(1)).findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(chatRoomRepository, never()).findByGroupBuy_IdAndType(20L, "PARTICIPANT");
+        verify(chatParticipantRepository, never())
+                .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 참여 실패 - 이미 참여한 채팅방")
+    void joinChatRoom_success_group_buy_already_joined() {
+        when(groupBuyRepository.findById(20L)).thenReturn(Optional.of(groupBuy));
+        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED"))
+                .thenReturn(Optional.of(order));
+        when(chatRoomRepository.findByGroupBuy_IdAndType(20L, "PARTICIPANT")).thenReturn(Optional.of(chatRoom));
+        when(chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId()))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> joinChatRoom.joinChatRoom(participantUser, 20L))
+                .isInstanceOf(AlreadyJoinedException.class)
+                .hasMessageContaining(ALREADEY_JOINED);
+
+        verify(groupBuyRepository, times(1)).findById(20L);
+        verify(orderRepository, times(1)).findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdAndType(20L, "PARTICIPANT");
+        verify(chatParticipantRepository, times(1))
+                .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+    }
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/command/LeaveChatRoomTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/command/LeaveChatRoomTest.java
@@ -1,0 +1,144 @@
+package com.moogsan.moongsan_backend.unit.chatting.service.command;
+
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatParticipant;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
+import com.moogsan.moongsan_backend.domain.chatting.exception.specific.ChatRoomNotFoundException;
+import com.moogsan.moongsan_backend.domain.chatting.exception.specific.NotParticipantException;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatParticipantRepository;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
+import com.moogsan.moongsan_backend.domain.chatting.service.command.LeaveChatRoom;
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
+import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.order.entity.Order;
+import com.moogsan.moongsan_backend.domain.order.exception.specific.OrderNotFoundException;
+import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.CHAT_ROOM_NOT_FOUND;
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.ORDER_NOT_FOUND;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_EXIST;
+import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.NOT_PARTICIPANT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class LeaveChatRoomTest {
+
+    @Mock
+    private GroupBuyRepository groupBuyRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatParticipantRepository chatParticipantRepository;
+
+    private LeaveChatRoom leaveChatRoom;
+    private User participantUser;
+    private GroupBuy groupBuy;
+    private User normalUser;
+    private Order order;
+    private ChatRoom chatRoom;
+    private ChatParticipant chatParticipant;
+
+    @BeforeEach
+    void setUp() {
+        participantUser = User.builder().id(1L).build();
+        groupBuy = GroupBuy.builder().id(3L).build();
+        normalUser = User.builder().id(2L).build();
+        order = Order.builder().id(5L).user(participantUser).build();
+        chatRoom = ChatRoom.builder().id(20L).type("PARTICIPANT").build();
+        chatParticipant = ChatParticipant.builder().id(34L).build();
+
+        leaveChatRoom = new LeaveChatRoom(
+                groupBuyRepository,
+                orderRepository,
+                chatRoomRepository,
+                chatParticipantRepository
+        );
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 나가기 성공 - 참여자")
+    void leaveChatRoom_success_host() {
+        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED"))
+                .thenReturn(Optional.of(order));
+        when(chatRoomRepository.findByGroupBuy_IdAndType(groupBuy.getId(), "PARTICIPANT"))
+                .thenReturn(Optional.of(chatRoom));
+        when(chatParticipantRepository.findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId()))
+                .thenReturn(Optional.of(chatParticipant));
+
+        leaveChatRoom.leaveChatRoom(participantUser, 3L);
+
+        verify(orderRepository, times(1)).findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdAndType(groupBuy.getId(), "PARTICIPANT");
+        verify(chatParticipantRepository, times(1)).findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 나가기 실패 - 공구 참여자가 아님")
+    void leaveChatRoom_success_not_group_buy_participant() {
+        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(normalUser.getId(), groupBuy.getId(), "CANCELED"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> leaveChatRoom.leaveChatRoom(normalUser, 3L))
+                .isInstanceOf(OrderNotFoundException.class)
+                .hasMessageContaining(ORDER_NOT_FOUND);
+
+        verify(orderRepository, times(1)).findByUserIdAndGroupBuyIdAndStatusNot(normalUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(chatRoomRepository, never()).findByGroupBuy_IdAndType(groupBuy.getId(), "PARTICIPANT");
+        verify(chatParticipantRepository, never()).findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), normalUser.getId());
+
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 나가기 실패 - 존재하지 않는 참여자 채팅방")
+    void leaveChatRoom_success_not_exist_chat_room() {
+        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED"))
+                .thenReturn(Optional.of(order));
+        when(chatRoomRepository.findByGroupBuy_IdAndType(groupBuy.getId(), "PARTICIPANT"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> leaveChatRoom.leaveChatRoom(participantUser, 3L))
+                .isInstanceOf(ChatRoomNotFoundException.class)
+                .hasMessageContaining(CHAT_ROOM_NOT_FOUND);
+
+        verify(orderRepository, times(1)).findByUserIdAndGroupBuyIdAndStatusNot(participantUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdAndType(groupBuy.getId(), "PARTICIPANT");
+        verify(chatParticipantRepository, never()).findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 나가기 실패 - 채팅 참여자가 아님")
+    void leaveChatRoom_success_not_chat_room_participant() {
+        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(normalUser.getId(), groupBuy.getId(), "CANCELED"))
+                .thenReturn(Optional.of(order));
+        when(chatRoomRepository.findByGroupBuy_IdAndType(groupBuy.getId(), "PARTICIPANT"))
+                .thenReturn(Optional.of(chatRoom));
+        when(chatParticipantRepository.findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), normalUser.getId()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> leaveChatRoom.leaveChatRoom(normalUser, 3L))
+                .isInstanceOf(NotParticipantException.class)
+                .hasMessageContaining(NOT_PARTICIPANT);
+
+        verify(orderRepository, times(1)).findByUserIdAndGroupBuyIdAndStatusNot(normalUser.getId(), groupBuy.getId(), "CANCELED");
+        verify(chatRoomRepository, times(1)).findByGroupBuy_IdAndType(groupBuy.getId(), "PARTICIPANT");
+        verify(chatParticipantRepository, times(1)).findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), normalUser.getId());
+
+    }
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/query/GetChatRoomListTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/query/GetChatRoomListTest.java
@@ -1,0 +1,224 @@
+package com.moogsan.moongsan_backend.unit.chatting.service.query;
+
+import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatRoomPagedResponse;
+import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatRoomResponse;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatParticipant;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
+import com.moogsan.moongsan_backend.domain.chatting.mapper.ChatMessageQueryMapper;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatParticipantRepository;
+import com.moogsan.moongsan_backend.domain.chatting.service.query.GetChatRoomList;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class GetChatRoomListTest {
+
+    @Mock
+    private ChatParticipantRepository chatParticipantRepository;
+
+    @Mock
+    private ChatMessageQueryMapper chatMessageQueryMapper;
+
+    private GetChatRoomList getChatRoomList;
+    private User loginedUser;
+    private Pageable expectedPageable;
+    private LocalDateTime cursorJoinedAt;
+    private int limit;
+    private ChatRoom chatRoom;
+    private ChatParticipant participant1;
+    private ChatParticipant participant2;
+    private ChatParticipant participant3;
+
+    @BeforeEach
+    void setUp() {
+        loginedUser = User.builder().id(1L).build();
+        chatRoom = ChatRoom.builder().id(29L).build();
+
+        participant1 = ChatParticipant.builder()
+                .id(1L)
+                .chatRoom(chatRoom)
+                .joinedAt(LocalDateTime.of(2025, 1, 1, 10, 0))
+                .build();
+        participant2 = ChatParticipant.builder()
+                .id(2L)
+                .chatRoom(chatRoom)
+                .joinedAt(LocalDateTime.of(2025, 1, 1, 9, 0))
+                .build();
+        participant3 = ChatParticipant.builder()
+                .id(3L)
+                .chatRoom(chatRoom)
+                .joinedAt(LocalDateTime.of(2025, 1, 1, 8, 0))
+                .build();
+
+        getChatRoomList = new GetChatRoomList(
+                chatParticipantRepository,
+                chatMessageQueryMapper
+        );
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 리스트 조회 성공 - 로그인한 유저, 커서 존재, 다음 요소 있음")
+    void getChatRoomList_success_user_cursor_has_next() {
+        // Given
+        cursorJoinedAt = LocalDateTime.of(2025, 1, 1, 9, 30);
+        limit = 2;
+        List<ChatParticipant> participants = List.of(participant1, participant2, participant3);
+        expectedPageable = PageRequest.of(0, limit + 1,
+                Sort.by("joinedAt").descending()
+                        .and(Sort.by("id").descending())
+        );
+        List<ChatParticipant> pageOf = participants.subList(0, limit);
+        List<ChatRoom> rooms = pageOf.stream()
+                .map(ChatParticipant::getChatRoom)
+                .toList();
+        ChatRoomResponse response1 = ChatRoomResponse.builder().build();
+        ChatRoomResponse response2 = ChatRoomResponse.builder().build();
+        List<ChatRoomResponse> mappedResponses = List.of(response1, response2);
+        LocalDateTime lastJoinedAt = pageOf.getLast().getJoinedAt();
+        boolean hasMore = participants.size() > limit;
+
+        when(chatParticipantRepository.findParticipantsAfter(loginedUser.getId(), cursorJoinedAt, expectedPageable))
+                .thenReturn(participants);
+        when(chatMessageQueryMapper.toChatRoomList(rooms))
+                .thenReturn(mappedResponses);
+
+        ChatRoomPagedResponse result = getChatRoomList.getChatRoomList(
+                loginedUser.getId(),
+                cursorJoinedAt,
+                limit
+        );
+
+        verify(chatParticipantRepository, times(1))
+                .findParticipantsAfter(loginedUser.getId(), cursorJoinedAt, expectedPageable);
+        verify(chatMessageQueryMapper, times(1)).toChatRoomList(rooms);
+        assertThat(result.getChatRooms()).hasSize(limit);
+        assertThat(result.getNextCursorJoinedAt()).isEqualTo(lastJoinedAt);
+        assertThat(result.isHasMore()).isEqualTo(hasMore);
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 리스트 조회 성공 - 로그인한 유저, 커서 없음, 다음 요소 있음")
+    void getChatRoomList_success_user_noCursor_has_next() {
+
+        cursorJoinedAt = null;
+        limit = 2;
+        List<ChatParticipant> participants = List.of(participant1, participant2, participant3);
+        expectedPageable = PageRequest.of(0, limit + 1,
+                Sort.by("joinedAt").descending()
+                        .and(Sort.by("id").descending())
+        );
+        List<ChatParticipant> pageOf = participants.subList(0, limit);
+        List<ChatRoom> rooms = pageOf.stream()
+                .map(ChatParticipant::getChatRoom)
+                .toList();
+        ChatRoomResponse response1 = ChatRoomResponse.builder().build();
+        ChatRoomResponse response2 = ChatRoomResponse.builder().build();
+        List<ChatRoomResponse> mappedResponses = List.of(response1, response2);
+        LocalDateTime lastJoinedAt = pageOf.getLast().getJoinedAt();
+        boolean hasMore = participants.size() > limit;
+
+        when(chatParticipantRepository.findInitialParticipants(loginedUser.getId(), expectedPageable))
+                .thenReturn(participants);
+        when(chatMessageQueryMapper.toChatRoomList(rooms))
+                .thenReturn(mappedResponses);
+
+        ChatRoomPagedResponse result = getChatRoomList.getChatRoomList(
+                loginedUser.getId(),
+                null,
+                limit
+        );
+
+        verify(chatParticipantRepository, times(1))
+                .findInitialParticipants(loginedUser.getId(), expectedPageable);
+        verify(chatMessageQueryMapper, times(1)).toChatRoomList(rooms);
+        assertThat(result.getChatRooms()).hasSize(limit);
+        assertThat(result.getNextCursorJoinedAt()).isEqualTo(lastJoinedAt);
+        assertThat(result.isHasMore()).isEqualTo(hasMore);
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 리스트 조회 성공 - 로그인한 유저, 커서 있음, 다음 요소 없음")
+    void getChatRoomList_success_user_cursor_no_next() {
+        cursorJoinedAt = LocalDateTime.of(2025, 1, 1, 9, 30);
+        limit = 2;
+        List<ChatParticipant> participants = List.of(participant1, participant2); // size == limit
+        expectedPageable = PageRequest.of(0, limit + 1,
+                Sort.by("joinedAt").descending()
+                        .and(Sort.by("id").descending())
+        );
+        List<ChatRoom> rooms = participants.stream()
+                .map(ChatParticipant::getChatRoom)
+                .toList();
+        ChatRoomResponse response1 = ChatRoomResponse.builder().build();
+        ChatRoomResponse response2 = ChatRoomResponse.builder().build();
+        List<ChatRoomResponse> mappedResponses = List.of(response1, response2);
+        LocalDateTime lastJoinedAt = participants.getLast().getJoinedAt();
+        boolean hasMore = false; // participants.size() == limit
+
+        when(chatParticipantRepository.findParticipantsAfter(loginedUser.getId(), cursorJoinedAt, expectedPageable))
+                .thenReturn(participants);
+        when(chatMessageQueryMapper.toChatRoomList(rooms))
+                .thenReturn(mappedResponses);
+
+        ChatRoomPagedResponse result = getChatRoomList.getChatRoomList(
+                loginedUser.getId(),
+                cursorJoinedAt,
+                limit
+        );
+
+        verify(chatParticipantRepository, times(1))
+                .findParticipantsAfter(loginedUser.getId(), cursorJoinedAt, expectedPageable);
+        verify(chatMessageQueryMapper, times(1)).toChatRoomList(rooms);
+        assertThat(result.getChatRooms()).hasSize(limit);
+        assertThat(result.getNextCursorJoinedAt()).isEqualTo(lastJoinedAt);
+        assertThat(result.isHasMore()).isFalse();
+    }
+
+    @Test
+    @DisplayName("참여자 채팅방 리스트 조회 성공 - 로그인한 유저, 결과 없음")
+    void getChatRoomList_success_user_empty() {
+
+        cursorJoinedAt = null;
+        limit = 5;
+        List<ChatParticipant> participants = Collections.emptyList();
+        expectedPageable = PageRequest.of(0, limit + 1,
+                Sort.by("joinedAt").descending()
+                        .and(Sort.by("id").descending())
+        );
+        List<ChatRoom> rooms = Collections.emptyList();
+        List<ChatRoomResponse> mappedResponses = Collections.emptyList();
+
+        when(chatParticipantRepository.findInitialParticipants(loginedUser.getId(), expectedPageable))
+                .thenReturn(participants);
+        when(chatMessageQueryMapper.toChatRoomList(rooms))
+                .thenReturn(mappedResponses);
+
+        ChatRoomPagedResponse result = getChatRoomList.getChatRoomList(
+                loginedUser.getId(),
+                null,
+                limit
+        );
+
+        verify(chatParticipantRepository, times(1))
+                .findInitialParticipants(loginedUser.getId(), expectedPageable);
+        verify(chatMessageQueryMapper, times(1)).toChatRoomList(rooms);
+        assertThat(result.getChatRooms()).isEmpty();
+        assertThat(result.getNextCursorJoinedAt()).isNull();
+        assertThat(result.isHasMore()).isFalse();
+    }
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/query/GetLatestMessagesSseTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/query/GetLatestMessagesSseTest.java
@@ -1,0 +1,236 @@
+package com.moogsan.moongsan_backend.unit.chatting.service.query;
+
+import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatMessageResponse;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatMessageDocument;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
+import com.moogsan.moongsan_backend.domain.chatting.exception.specific.ChatRoomNotFoundException;
+import com.moogsan.moongsan_backend.domain.chatting.exception.specific.NotParticipantException;
+import com.moogsan.moongsan_backend.domain.chatting.mapper.ChatMessageQueryMapper;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatMessageRepository;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatParticipantRepository;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
+import com.moogsan.moongsan_backend.domain.chatting.service.query.GetLatestMessageSse;
+import com.moogsan.moongsan_backend.domain.chatting.service.query.GetLatestMessages;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import org.assertj.core.api.AssertionsForInterfaceTypes;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.async.DeferredResult;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.CHAT_ROOM_NOT_FOUND;
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.NOT_PARTICIPANT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class GetLatestMessagesSseTest {
+
+    @Mock
+    private ChatParticipantRepository chatParticipantRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatMessageQueryMapper chatMessageQueryMapper;
+
+    // FOR getLatestMessagesSse
+    private GetLatestMessageSse service;
+    private User participantUser;
+    private User normalUser;
+    private User authorUser;
+    private ChatMessageDocument message1;
+    private ChatRoom chatRoom;
+
+    // FOR createLongPollingResult - 단순 매핑이기 때문에 테스트하지 않기로 결정 -
+
+    // FOR notifyNewMessageSse
+    private SecurityContext context;
+    private SseEmitter emitter1;
+    private SseEmitter emitter2;
+    private List<SseEmitter> list;
+    private ChatMessageResponse response;
+
+
+    @BeforeEach
+    void setUp() {
+
+        participantUser = User.builder().id(1L).build();
+        normalUser = User.builder().id(2L).build();
+        authorUser = User.builder().id(3L).nickname("lucy").imageKey("images/image1").build();
+        chatRoom = ChatRoom.builder().id(20L).type("PARTICIPANT").build();
+        message1 = ChatMessageDocument.builder().id("64a6f2c21f9b8e4d3a9b1234").chatRoomId(chatRoom.getId()).build();
+
+        emitter1 = spy(new SseEmitter(0L));
+        emitter2 = spy(new SseEmitter(0L));
+
+        service = new GetLatestMessageSse(
+                chatParticipantRepository,
+                chatRoomRepository,
+                chatMessageQueryMapper
+        );
+
+        context = mock(SecurityContext.class);
+
+        when(chatMessageQueryMapper.toMessageResponse(message1, authorUser.getNickname(), authorUser.getImageKey()))
+                .thenReturn(response);
+
+        service.notifyNewMessageSse(
+                message1,
+                authorUser.getNickname(),
+                authorUser.getImageKey(),
+                context
+        );
+
+    }
+
+    @Nested
+    @DisplayName("Describe GetLatestMessages SSE")
+    class DescribeGetLatestMessagesSSE {
+
+        @Test
+        @DisplayName("최신 메세지 조회 성공 (SSE) - 참여자")
+        void get_lastest_message_sse_success_participant() {
+            when(chatRoomRepository.findById(20L)).thenReturn(Optional.of(chatRoom));
+            when(chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId()))
+                    .thenReturn(true);
+
+            service.getLatestMessagesSse(participantUser, 20L);
+
+            verify(chatRoomRepository, times(1)).findById(20L);
+            verify(chatParticipantRepository, times(1)).existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+
+        }
+
+        @Test
+        @DisplayName("최신 메세지 조회 실패 (SSE) - 존재하지 않는 채팅방")
+        void get_lastest_message_sse_fail_chat_room_not_exist() {
+            when(chatRoomRepository.findById(20L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getLatestMessagesSse(normalUser, 20L))
+                    .isInstanceOf(ChatRoomNotFoundException.class)
+                    .hasMessageContaining(CHAT_ROOM_NOT_FOUND);
+
+            verify(chatRoomRepository, times(1)).findById(20L);
+        }
+
+        @Test
+        @DisplayName("최신 메세지 조회 실패 (SSE) - 참여자가 아님")
+        void get_lastest_message_sse_fail_normal_user() {
+            when(chatRoomRepository.findById(20L)).thenReturn(Optional.of(chatRoom));
+            when(chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), normalUser.getId()))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> service.getLatestMessagesSse(normalUser, 20L))
+                    .isInstanceOf(NotParticipantException.class)
+                    .hasMessageContaining(NOT_PARTICIPANT);
+
+            verify(chatRoomRepository, times(1)).findById(20L);
+            verify(chatParticipantRepository, times(1)).existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), normalUser.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Describe NotifyNewMessage SSE")
+    class DescribeNotifyNewMessageSSE {
+        ///  비동기 awaitility
+
+        @Test
+        @DisplayName("새로운 메세지 발행 성공 - 단일 emitter 존재")
+        void notify_new_messages_sse_success_single_listener() {
+
+            ReflectionTestUtils.invokeMethod(service, "registerEmitter", chatRoom.getId(), emitter1);
+
+            ArgumentCaptor<SseEmitter.SseEventBuilder> captor = ArgumentCaptor.forClass(SseEmitter.SseEventBuilder.class);
+
+            service.notifyNewMessageSse(message1, participantUser.getNickname(), participantUser.getImageKey(), context);
+
+            Awaitility.await()
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> {
+                        verify(emitter1, atLeastOnce()).send(captor.capture());
+                    });
+
+            List<SseEmitter.SseEventBuilder> sentEvents = captor.getAllValues();
+            assertThat(sentEvents).hasSizeGreaterThanOrEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("새로운 메세지 발행 성공 - 다중 emitter 존재")
+        void notify_new_messages_sse_success_multi_listener() {
+
+            ReflectionTestUtils.invokeMethod(service, "registerEmitter", chatRoom.getId(), emitter1);
+            ReflectionTestUtils.invokeMethod(service, "registerEmitter", chatRoom.getId(), emitter2);
+
+            ArgumentCaptor<SseEmitter.SseEventBuilder> captor = ArgumentCaptor.forClass(SseEmitter.SseEventBuilder.class);
+
+            service.notifyNewMessageSse(message1, participantUser.getNickname(), participantUser.getImageKey(), context);
+
+            Awaitility.await()
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> {
+                        verify(emitter1, atLeastOnce()).send(captor.capture());
+
+                        verify(emitter2, atLeastOnce()).send(captor.capture());
+                    });
+
+            List<SseEmitter.SseEventBuilder> sentEvents = captor.getAllValues();
+            assertThat(sentEvents).hasSizeGreaterThanOrEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("새로운 메세지 발행 성공 - emitter 존재하지 않음")
+        void notify_new_messages_sse_success_no_listener() {
+
+            assertDoesNotThrow(() ->
+                service.notifyNewMessageSse(
+                    message1,
+                    authorUser.getNickname(),
+                    authorUser.getImageKey(),
+                    context
+                )
+            );
+
+            service.notifyNewMessageSse(message1, participantUser.getNickname(), participantUser.getImageKey(), context);
+
+            @SuppressWarnings("unchecked")
+            Map<Long,List<SseEmitter>> emitters =
+                    (Map<Long,List<SseEmitter>>) ReflectionTestUtils.getField(service, "emitters");
+            assertThat(emitters).doesNotContainKey(chatRoom.getId());
+        }
+    }
+
+    @Test
+    @DisplayName("send 실패 시 completeWithError 호출")
+    void notify_new_message_sse_sendError() throws Exception {
+        doThrow(new IOException("fail")).when(emitter1).send(any(SseEmitter.SseEventBuilder.class));
+        ReflectionTestUtils.invokeMethod(service, "registerEmitter", chatRoom.getId(), emitter1);
+
+        service.notifyNewMessageSse(message1, participantUser.getNickname(), participantUser.getImageKey(), context);
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .untilAsserted(() ->
+                        verify(emitter1).completeWithError(any(IOException.class))
+                );
+    }
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/query/GetLatestMessagesTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/query/GetLatestMessagesTest.java
@@ -1,0 +1,227 @@
+package com.moogsan.moongsan_backend.unit.chatting.service.query;
+
+import com.moogsan.moongsan_backend.domain.chatting.dto.query.ChatMessageResponse;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatMessageDocument;
+import com.moogsan.moongsan_backend.domain.chatting.entity.ChatRoom;
+import com.moogsan.moongsan_backend.domain.chatting.exception.specific.ChatRoomNotFoundException;
+import com.moogsan.moongsan_backend.domain.chatting.exception.specific.NotParticipantException;
+import com.moogsan.moongsan_backend.domain.chatting.mapper.ChatMessageQueryMapper;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatMessageRepository;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatParticipantRepository;
+import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
+import com.moogsan.moongsan_backend.domain.chatting.service.query.GetLatestMessages;
+import com.moogsan.moongsan_backend.domain.order.exception.specific.OrderNotFoundException;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.time.Duration;
+import java.util.*;
+
+import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class GetLatestMessagesTest {
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    private ChatParticipantRepository chatParticipantRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatMessageQueryMapper chatMessageQueryMapper;
+
+    // FOR getLatestMessages
+    private GetLatestMessages service;
+    private User participantUser;
+    private User normalUser;
+    private User authorUser;
+    private ChatRoom chatRoom;
+    private String lastMessageId;
+    private ChatMessageDocument message1;
+    private ChatMessageDocument message2;
+    private List<ChatMessageDocument> newMessages;
+
+    // FOR createLongPollingResult - 단순 매핑이기 때문에 테스트하지 않기로 결정 -
+
+    // FOR notifyNewMessage
+    private SecurityContext context;
+    private DeferredResult<List<ChatMessageResponse>> result1;
+    private DeferredResult<List<ChatMessageResponse>> result2;
+    private ChatMessageResponse response;
+
+
+    @BeforeEach
+    void setUp() {
+
+        participantUser = User.builder().id(1L).build();
+        normalUser = User.builder().id(2L).build();
+        authorUser =  User.builder().id(3L).nickname("lucy").imageKey("images/image1").build();
+        chatRoom = ChatRoom.builder().id(20L).type("PARTICIPANT").build();
+        lastMessageId = "64a6f2c21f9b8e4d3a9b1233";
+        message1 = ChatMessageDocument.builder().id("64a6f2c21f9b8e4d3a9b1234").chatRoomId(chatRoom.getId()).build();
+        message2 = ChatMessageDocument.builder().id("64a6f2c21f9b8e4d3a9b1235").chatRoomId(chatRoom.getId()).build();
+        newMessages = List.of(message1, message2);
+        service = new GetLatestMessages(
+                chatMessageRepository,
+                chatParticipantRepository,
+                chatRoomRepository,
+                chatMessageQueryMapper
+        );
+
+        result1 = service.createLongPollingResult(chatRoom.getId());
+        result2 = service.createLongPollingResult(chatRoom.getId());
+        response = ChatMessageResponse.builder().build();
+        context = mock(SecurityContext.class);
+    }
+
+    @Nested
+    @DisplayName("Describe GetLatestMessages")
+    class DescribeGetLatestMessages {
+
+        @Test
+        @DisplayName("최신 메세지 조회 성공 (롱폴링) - 참여자")
+        void get_lastest_message_success_participant () {
+            when(chatRoomRepository.findById(20L)).thenReturn(Optional.of(chatRoom));
+            when(chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId()))
+                    .thenReturn(true);
+            when(chatMessageRepository.findMessagesAfter(chatRoom.getId(), lastMessageId))
+                    .thenReturn(newMessages);
+
+            service.getLatestMessages(participantUser, 20L, lastMessageId);
+
+            verify(chatRoomRepository, times(1)).findById(20L);
+            verify(chatParticipantRepository, times(1)).existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+            verify(chatMessageRepository, times(1)).findMessagesAfter(chatRoom.getId(), lastMessageId);
+
+        }
+
+        @Test
+        @DisplayName("최신 메세지 조회 실패 (롱폴링) - 존재하지 않는 채팅방")
+        void get_lastest_message_fail_chat_room_not_exist () {
+            when(chatRoomRepository.findById(20L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getLatestMessages(normalUser, 20L, lastMessageId))
+                    .isInstanceOf(ChatRoomNotFoundException.class)
+                    .hasMessageContaining(CHAT_ROOM_NOT_FOUND);
+
+            verify(chatRoomRepository, times(1)).findById(20L);
+        }
+
+        @Test
+        @DisplayName("최신 메세지 조회 실패 (롱폴링) - 참여자가 아님")
+        void get_lastest_message_fail_normal_user() {
+            when(chatRoomRepository.findById(20L)).thenReturn(Optional.of(chatRoom));
+            when(chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), normalUser.getId()))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> service.getLatestMessages(normalUser, 20L, lastMessageId))
+                    .isInstanceOf(NotParticipantException.class)
+                    .hasMessageContaining(NOT_PARTICIPANT);
+
+            verify(chatRoomRepository, times(1)).findById(20L);
+            verify(chatParticipantRepository, times(1)).existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), normalUser.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Describe NotifyNewMessage")
+    class DescribeNotifyNewMessage {  ///  비동기 awaitility
+
+        @Test
+        @DisplayName("새로운 메세지 발행 성공 - 단일 리스너, 큐 비우기 확인")
+        void notify_new_messages_success_single_listener () {
+            when(chatMessageQueryMapper.toMessageResponse(message1, authorUser.getNickname(), authorUser.getImageKey()))
+                    .thenReturn(response);
+
+            service.notifyNewMessage(
+                    message1,
+                    authorUser.getNickname(),
+                    authorUser.getImageKey(),
+                    context
+            );
+
+            Awaitility.await()
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> {
+                        List<ChatMessageResponse> actual = (List<ChatMessageResponse>) result1.getResult();
+                        assertThat(actual).containsExactly(response);
+                    });
+
+            @SuppressWarnings("unchecked")
+            Map<Long, List<DeferredResult<List<ChatMessageResponse>>>> map =
+                    (Map<Long, List<DeferredResult<List<ChatMessageResponse>>>>) ReflectionTestUtils.getField(service, "listeners");
+            assertThat(Objects.requireNonNull(map).get(chatRoom.getId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("새로운 메세지 발행 성공 - 다중 리스너, 큐 비우기 확인")
+        void notify_new_messages_success_multi_listener () {
+            when(chatMessageQueryMapper.toMessageResponse(message1, authorUser.getNickname(), authorUser.getImageKey()))
+                    .thenReturn(response);
+
+            service.notifyNewMessage(
+                    message1,
+                    authorUser.getNickname(),
+                    authorUser.getImageKey(),
+                    context
+            );
+
+            Awaitility.await()
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> {
+                        List<ChatMessageResponse> actual1 = (List<ChatMessageResponse>) result1.getResult();
+                        assertThat(actual1).containsExactly(response);
+                        List<ChatMessageResponse> actual2 = (List<ChatMessageResponse>) result2.getResult();
+                        assertThat(actual2).containsExactly(response);
+                    });
+
+            @SuppressWarnings("unchecked")
+            Map<Long, List<DeferredResult<List<ChatMessageResponse>>>> map =
+                    (Map<Long, List<DeferredResult<List<ChatMessageResponse>>>>) ReflectionTestUtils.getField(service, "listeners");
+            assertThat(Objects.requireNonNull(map).get(chatRoom.getId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("새로운 메세지 발행 성공 - 리스너 없음, 큐 비우기 확인")
+        void notify_new_messages_success_no_listener () {
+            when(chatMessageQueryMapper.toMessageResponse(message1, authorUser.getNickname(), authorUser.getImageKey()))
+                    .thenReturn(response);
+
+            service.notifyNewMessage(
+                    message1,
+                    authorUser.getNickname(),
+                    authorUser.getImageKey(),
+                    context
+            );
+
+            Awaitility.await()
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> {
+                        ///  리스너 없음
+                    });
+
+            @SuppressWarnings("unchecked")
+            Map<Long, List<DeferredResult<List<ChatMessageResponse>>>> map =
+                    (Map<Long, List<DeferredResult<List<ChatMessageResponse>>>>) ReflectionTestUtils.getField(service, "listeners");
+            assertThat(Objects.requireNonNull(map).get(chatRoom.getId())).isEmpty();
+        }
+
+    }
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/query/GetPastMessagesTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/query/GetPastMessagesTest.java
@@ -1,0 +1,8 @@
+package com.moogsan.moongsan_backend.unit.chatting.service.query;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class GetPastMessagesTest {
+}


### PR DESCRIPTION
## 🔎 작업 개요
- 채팅 서비스 커맨드 및 쿼리 로직에 대한 단위 테스트 작성  
- `CreateChatMessage`, `JoinChatRoom`, `LeaveChatRoom` 커맨드 서비스 유닛 테스트  
- `GetChatRoomList`, `GetLatestMessages`, `GetLatestMessageSse` 쿼리 서비스 유닛 테스트  
- 고정 `Clock` 주입 검증 및 예외 시나리오 검증  
- 모든 테스트 클래스(`CreateChatMessageTest`, `JoinChatRoomTest`, `LeaveChatRoomTest`, `GetChatRoomListTest`, `GetLatestMessagesTest`, `GetLatestMessageSseTest`) 작성 완료 및 통과 확인  

---

## 🛠️ 주요 변경 사항
- **커맨드 서비스 테스트**  
  - `CreateChatMessageTest`  
    - 채팅방 존재 여부, 삭제 여부, 참여자 여부 예외 검증  
    - 메시지 시퀀스 생성, Redis ZSET 캐싱 동작 검증  
  - `JoinChatRoomTest`  
    - 주최자/참가자 정상 참여 경로 테스트  
    - 공구 미존재, 미참여, 중복 참여 예외 검증  
  - `LeaveChatRoomTest`  
    - 참여자 정상 나가기 경로 테스트  
    - 미참여, 채팅방 미존재, 비참여 예외 검증  
- **쿼리 서비스 테스트**  
  - `GetChatRoomListTest`  
    - 커서 기반 페이징(limit+1, nextCursor, hasMore) 정상 및 빈 결과 검증  
  - `GetLatestMessagesTest`  
    - 롱폴링: 참여자 여부, 채팅방 존재 여부, 새 메시지 조회 로직 검증  
    - DeferredResult 리스너 등록 및 큐 비우기 검증  
  - `GetLatestMessageSseTest`  
    - SSE: 참여자 여부, 채팅방 존재 여부 예외 검증  
    - 단일·다중·없음 리스너 시나리오 발행 검증  
    - 전송 실패 시 `completeWithError` 호출 검증  
- **테스트 공통**  
  - 모든 테스트에 고정 `Clock` 주입 및 객체 매핑 검증  
  - Mockito 기반 mock 설정 및 `@ExtendWith(MockitoExtension.class)` 적용  

---

## ✅ 검증 방법
1. `./gradlew test` 수행  
2. `CreateChatMessageTest`, `JoinChatRoomTest`, `LeaveChatRoomTest`,  
   `GetChatRoomListTest`, `GetLatestMessagesTest`, `GetLatestMessageSseTest` 모두 **green** 확인  

---

## 🔍 머지 전 확인사항
- 기존 테스트 코드와 네임스페이스 충돌 여부  
- Mockito 설정 중복 또는 정적 import 충돌 확인  
- DeferredResult/SseEmitter 리스너 맵 초기화 상태  

---

## ➕ 관련 이슈
- [[Sub Task] BE - 테스트 코드 작성](https://github.com/100-hours-a-week/14-YG-BE/issues/95)
- [[Sub Task] BE - Chatting response message 상수 선언으로 변경 ](https://github.com/100-hours-a-week/14-YG-BE/issues/181)
- [[Sub Task] BE - ArgumentCaptor 적용](https://github.com/100-hours-a-week/14-YG-BE/issues/142)
