### PR TITLE
feat(image): 이미지 삭제·이동 전략 도입 및 마감임박 OPEN 필터 적용

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/response/DescriptionDto.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/response/DescriptionDto.java
@@ -1,12 +1,18 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.dto.command.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.time.LocalDateTime;
 
 public record DescriptionDto(
-        @JsonProperty("title") String title,
-        @JsonProperty("product_name") String productName,
+        @JsonProperty("upload_image_key") String imageKey,
+        String title,
+        @JsonProperty("product_name") String name,
         @JsonProperty("total_price") int totalPrice,
-        int count,
-        String summary
+        @JsonProperty("count") int unitAmount,
+        @JsonProperty("summary") String description,
+        @JsonProperty("due_date") LocalDateTime dueDate,
+        @JsonProperty("pickup_date") LocalDateTime pickupDate
 ) {}
-

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyCommandMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyCommandMapper.java
@@ -3,18 +3,23 @@ package com.moogsan.moongsan_backend.domain.groupbuy.mapper;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.CreateGroupBuyRequest;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.UpdateGroupBuyRequest;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.policy.DueSoonPolicy;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class GroupBuyCommandMapper {
+
+    private final DueSoonPolicy dueSoonPolicy;
 
     // 공구 게시글 생성 팩토리 메서드
     public GroupBuy create(CreateGroupBuyRequest req, User host) {
         int unitPrice = (int) Math.round((double) req.getPrice() / req.getTotalAmount());
         int leftAmount = req.getTotalAmount() - req.getHostQuantity();
 
-        return GroupBuy.builder()
+        GroupBuy gb = GroupBuy.builder()
                 .title(req.getTitle())
                 .name(req.getName())
                 .url(req.getUrl())
@@ -30,5 +35,7 @@ public class GroupBuyCommandMapper {
                 .pickupDate(req.getPickupDate())
                 .user(host)
                 .build();
+        gb.updateDueSoonStatus(dueSoonPolicy);
+        return gb;
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
@@ -11,6 +11,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepositor
 import com.moogsan.moongsan_backend.domain.groupbuy.util.FetchWishUtil;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -128,10 +129,14 @@ public class GetGroupBuyListByCursor {
 
     private Specification<GroupBuy> dueSoonOnlyEq(String orderBy) {
         return (root, query, cb) -> {
+            Predicate statusOpen = cb.equal(root.get("postStatus"), "OPEN");
             if (!"due_soon_only".equals(orderBy)) {
                 return cb.conjunction();
             }
-            return cb.isTrue(root.get("dueSoon"));
+            return cb.and(
+                    statusOpen,
+                    cb.isTrue(root.get("dueSoon"))
+            );
         };
     }
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/image/service/S3Service.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/image/service/S3Service.java
@@ -1,0 +1,96 @@
+package com.moogsan.moongsan_backend.domain.image.service;
+
+import com.moogsan.moongsan_backend.domain.image.dto.PresignResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+/**
+ * FileService: 이미지 업로드를 위한 Presigned URL 발급만 담당
+ */
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * S3에 업로드할 Presigned PUT URL 발급
+     * @return key, url 정보가 담긴 PresignResponse
+     */
+    public PresignResponse presign() {
+        // 1) S3 key 생성 (images/{UUID})
+        String key = "tmp/" + UUID.randomUUID();
+
+        // 2) Presign 요청 객체 생성
+        PutObjectRequest objReq = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        PutObjectPresignRequest preReq = PutObjectPresignRequest.builder()
+                .putObjectRequest(objReq)
+                .signatureDuration(Duration.ofMinutes(2))
+                .build();
+
+        // 3) URL 발급
+        String url = s3Presigner.presignPutObject(preReq)
+                .url().toString();
+
+        // 4) DTO 반환 (imageId 없이 key + url)
+        return new PresignResponse(key, url);
+    }
+
+    /**
+     * S3 객체 이동: copy → delete
+     */
+    public void moveImage(String srcKey, String destKey) {
+        try {
+            // 1) 복사
+            CopyObjectRequest copyReq = CopyObjectRequest.builder()
+                    .sourceBucket(bucket)
+                    .sourceKey(srcKey)
+                    .destinationBucket(bucket)
+                    .destinationKey(destKey)
+                    .build();
+            s3Client.copyObject(copyReq);
+
+            // 2) 원본 삭제
+            DeleteObjectRequest delReq = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(srcKey)
+                    .build();
+            s3Client.deleteObject(delReq);
+
+        } catch (S3Exception e) {
+            throw new RuntimeException("Failed to move image: " + e.awsErrorDetails().errorMessage(), e);
+        }
+    }
+
+    /**
+     * S3 객체 삭제
+     */
+    public void deleteImage(String key) {
+        try {
+            DeleteObjectRequest delReq = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+            s3Client.deleteObject(delReq);
+        } catch (S3Exception e) {
+            // TODO: 케이스별 예외처리 (존재하지 않을 때, 권한 부족 등)
+            throw new RuntimeException("Failed to delete image: " + e.awsErrorDetails().errorMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
## 🔎 작업 개요
- `DescriptionDto` 컬럼명 변경을 통해 AI API 응답 포맷 일관성 확보  
- 그룹공구 업데이트 시 S3 이미지 삭제 및 대상 폴더(`group-buys/`)로 이동 전략 추가  
- 마감임박(due soon) 리스트 조회 로직에서 `postStatus = OPEN` 필터 강제 적용  

## 🛠️ 주요 변경 사항
1. **DTO 응답 포맷 수정**  
   - `DescriptionDto`의 필드명을 snake_case에서 camelCase로 변경  
   - 프론트엔드 요구사항에 맞추어 JSON 구조 통일  
   - 관련 테스트 클래스 업데이트(필드명 검증 추가)  

2. **이미지 삭제·이동 전략 도입**  
   - `UpdateGroupBuyService` 로직 수정:  
     - 기존 이미지(`images/…`) 및 신규 임시 이미지(`tmp/…`) 모두 `group-buys/` 폴더로 이동  
     - S3 `deleteObject` 호출 후 `moveObject(tmp→group-buys)` 처리  
     - 예외 처리: 예상치 못한 키 포맷(`tmp/`, `images/` 외)에는 `IllegalArgumentException` 발생  
   - 단위 테스트 추가:  
     - `tmp/123.jpg` → `group-buys/123.jpg`  
     - `images/foo.png` → `group-buys/foo.png`  

3. **마감임박 리스트 조회 스펙 개선**  
   - `dueSoonOnlyEq` Specification:  
     - `orderBy = "due_soon_only"`인 경우 `postStatus = OPEN AND dueSoon = true`  
     - 기타 조회 시에도 `postStatus = OPEN` 필터 유지  
   - 통합 테스트 케이스 보강:  
     - 다양한 `orderBy` 파라미터 조합에 대한 반환 결과 검증  

## ✅ 검증 방법
- **이미지 업데이트 시나리오**  
  1. 신규 이미지 업로드 후 `UpdateGroupBuy` 호출 →  
     - S3 버킷에서 `tmp/{uuid}.jpg` 삭제 및 `group-buys/{uuid}.jpg` 이동 확인  
  2. 기존 이미지(`images/...`)만 있을 때 `UpdateGroupBuy` 호출 →  
     - 동일하게 `group-buys/{filename}` 으로 이동 확인  
  3. 잘못된 키 포맷(`foo/bar.jpg`) 입력 시 예외 발생 확인  
- **마감임박 리스트 필터링**  
  1. `GET /groupbuys?orderBy=due_soon_only` →  
     - 반환된 모든 항목 `postStatus == OPEN && dueSoon == true`  
  2. `GET /groupbuys` (orderBy 없음) →  
     - 반환된 모든 항목 `postStatus == OPEN`  

## 🔍 머지 전 확인사항
- [x] 프론트엔드 클라이언트와 변경된 DTO 포맷 호환성 검증  
- [x] 이미지 처리 로직 단위 테스트 및 통합 테스트 통과 여부  
- [x] due-soon 리스트 조회 로직 회귀 테스트 완료  
- [x] 코드 스타일(예외 메시지, 네이밍) 및 문서화(CI 스키마, API 문서) 반영  

## ➕ 이슈 링크
- [[Sprint #5] BE - v2 사전 배포 및 QA 진행](https://github.com/100-hours-a-week/14-YG-BE/issues/126)
- [#196 Sub Task – S3 이미지 삭제 및 객체 이동 전략 적용](https://github.com/100-hours-a-week/14-YG-BE/issues/196)  