### PR TITLE
fix(group-buy, chatting, test.yaml): 롱폴링 중복 응답, 공구 커서 누락, 마감 스케줄러, test.yml 오류 수정

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacadeImpl.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/Facade/query/ChattingQueryFacadeImpl.java
@@ -49,7 +49,7 @@ public class ChattingQueryFacadeImpl implements ChattingQueryFacade{
         }
 
         // 2) 롱폴링 대기 (노 트랜잭션)
-        return getLatestMessages.createLongPollingResult(chatRoomId);
+        return getLatestMessages.createLongPollingResult(user, chatRoomId);
     }
 
     @Override

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/repository/GroupBuyRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/repository/GroupBuyRepository.java
@@ -20,7 +20,7 @@ public interface GroupBuyRepository extends JpaRepository<GroupBuy, Long>, JpaSp
     List<GroupBuy> findByPostStatusAndDueDateBefore(String postStatus, LocalDateTime now);
 
     // 공구 종료 조건 기반 조회 (백그라운드 API용)
-    List<GroupBuy> findByPostStatusAndPickupDateBefore(String postStatus, LocalDateTime now);
+    List<GroupBuy> findByPostStatusAndPickupDateLessThanEqual(String postStatus, LocalDateTime now);
 
     // 공구 주최 리스트 첫 조회
     List<GroupBuy> findByUser_IdAndPostStatus(Long userId, String postStatus, Pageable pageable);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/scheduler/GroupBuyScheduler.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/scheduler/GroupBuyScheduler.java
@@ -24,15 +24,15 @@ public class GroupBuyScheduler {
         closePastDueGroupBuys.closePastDueGroupBuys(now);
     }
 
-    // 공구 게시글 pickupDate 기반 자동 공구 종료 스케줄러 (매 정각(0분)과 31분에 작동)
-    @Scheduled(cron = "0 0/31 * * * *")
+    // 공구 게시글 pickupDate 기반 자동 공구 종료 스케줄러 (매 정각(1분)과 31분에 작동)
+    @Scheduled(cron = "0 1/31 * * * *")
     public void endPastPickupGroupBuys() {
         LocalDateTime now = LocalDateTime.now();
         endPastPickupGroupBuys.endPastPickupGroupBuys(now);
     }
 
     // 공구 참여 자동 취소 스케줄러 (매 정각 1분10분)과 40분에 작동)
-    @Scheduled(cron = "0 1/40 * * * *")
+    @Scheduled(cron = "0 10/40 * * * *")
     public void runAutoCancellation() {
         cancelGroupBuyParticipant.cancelUnconfirmedOrders();
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndPastPickupGroupBuys.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndPastPickupGroupBuys.java
@@ -19,7 +19,7 @@ public class EndPastPickupGroupBuys {
     /// 공구 종료 (백그라운드 API)
     public void endPastPickupGroupBuys(LocalDateTime now) {
         List<GroupBuy> toEnd = groupBuyRepository
-                .findByPostStatusAndPickupDateBefore("CLOSED", now);
+                .findByPostStatusAndPickupDateLessThanEqual("CLOSED", now);
 
         for (GroupBuy gb : toEnd) {
             gb.changePostStatus("ENDED");

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/query/GetLatestMessagesTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/service/query/GetLatestMessagesTest.java
@@ -10,7 +10,6 @@ import com.moogsan.moongsan_backend.domain.chatting.repository.ChatMessageReposi
 import com.moogsan.moongsan_backend.domain.chatting.repository.ChatParticipantRepository;
 import com.moogsan.moongsan_backend.domain.chatting.repository.ChatRoomRepository;
 import com.moogsan.moongsan_backend.domain.chatting.service.query.GetLatestMessages;
-import com.moogsan.moongsan_backend.domain.order.exception.specific.OrderNotFoundException;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,29 +24,24 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.request.async.DeferredResult;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import static com.moogsan.moongsan_backend.domain.chatting.message.ResponseMessage.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class GetLatestMessagesTest {
 
-    @Mock
-    private ChatMessageRepository chatMessageRepository;
+    @Mock private ChatMessageRepository chatMessageRepository;
+    @Mock private ChatParticipantRepository chatParticipantRepository;
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private ChatMessageQueryMapper chatMessageQueryMapper;
 
-    @Mock
-    private ChatParticipantRepository chatParticipantRepository;
-
-    @Mock
-    private ChatRoomRepository chatRoomRepository;
-
-    @Mock
-    private ChatMessageQueryMapper chatMessageQueryMapper;
-
-    // FOR getLatestMessages
     private GetLatestMessages service;
     private User participantUser;
     private User normalUser;
@@ -58,26 +52,22 @@ public class GetLatestMessagesTest {
     private ChatMessageDocument message2;
     private List<ChatMessageDocument> newMessages;
 
-    // FOR createLongPollingResult - 단순 매핑이기 때문에 테스트하지 않기로 결정 -
-
-    // FOR notifyNewMessage
     private SecurityContext context;
     private DeferredResult<List<ChatMessageResponse>> result1;
     private DeferredResult<List<ChatMessageResponse>> result2;
     private ChatMessageResponse response;
 
-
     @BeforeEach
     void setUp() {
-
         participantUser = User.builder().id(1L).build();
-        normalUser = User.builder().id(2L).build();
-        authorUser =  User.builder().id(3L).nickname("lucy").imageKey("images/image1").build();
-        chatRoom = ChatRoom.builder().id(20L).type("PARTICIPANT").build();
+        normalUser    = User.builder().id(2L).build();
+        authorUser    = User.builder().id(3L).nickname("lucy").imageKey("images/image1").build();
+        chatRoom      = ChatRoom.builder().id(20L).type("PARTICIPANT").build();
         lastMessageId = "64a6f2c21f9b8e4d3a9b1233";
-        message1 = ChatMessageDocument.builder().id("64a6f2c21f9b8e4d3a9b1234").chatRoomId(chatRoom.getId()).build();
-        message2 = ChatMessageDocument.builder().id("64a6f2c21f9b8e4d3a9b1235").chatRoomId(chatRoom.getId()).build();
-        newMessages = List.of(message1, message2);
+        message1      = ChatMessageDocument.builder().id("64a6f2c21f9b8e4d3a9b1234").chatRoomId(20L).build();
+        message2      = ChatMessageDocument.builder().id("64a6f2c21f9b8e4d3a9b1235").chatRoomId(20L).build();
+        newMessages   = List.of(message1, message2);
+
         service = new GetLatestMessages(
                 chatMessageRepository,
                 chatParticipantRepository,
@@ -85,143 +75,125 @@ public class GetLatestMessagesTest {
                 chatMessageQueryMapper
         );
 
-        result1 = service.createLongPollingResult(chatRoom.getId());
-        result2 = service.createLongPollingResult(chatRoom.getId());
+        result1 = service.createLongPollingResult(participantUser, chatRoom.getId());
+        result2 = service.createLongPollingResult(normalUser,   chatRoom.getId());
+
         response = ChatMessageResponse.builder().build();
-        context = mock(SecurityContext.class);
+        context  = mock(SecurityContext.class);
     }
 
     @Nested
     @DisplayName("Describe GetLatestMessages")
     class DescribeGetLatestMessages {
-
-        @Test
-        @DisplayName("최신 메세지 조회 성공 (롱폴링) - 참여자")
+        @Test @DisplayName("최신 메세지 조회 성공 (롱폴링) - 참여자")
         void get_lastest_message_success_participant () {
-            when(chatRoomRepository.findById(20L)).thenReturn(Optional.of(chatRoom));
-            when(chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId()))
+            when(chatRoomRepository.findById(20L)).thenReturn(java.util.Optional.of(chatRoom));
+            when(chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(20L, 1L))
                     .thenReturn(true);
-            when(chatMessageRepository.findMessagesAfter(chatRoom.getId(), lastMessageId))
+            when(chatMessageRepository.findMessagesAfter(20L, lastMessageId))
                     .thenReturn(newMessages);
 
             service.getLatestMessages(participantUser, 20L, lastMessageId);
 
             verify(chatRoomRepository, times(1)).findById(20L);
-            verify(chatParticipantRepository, times(1)).existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
-            verify(chatMessageRepository, times(1)).findMessagesAfter(chatRoom.getId(), lastMessageId);
-
+            verify(chatParticipantRepository, times(1))
+                    .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(20L, 1L);
+            verify(chatMessageRepository, times(1))
+                    .findMessagesAfter(20L, lastMessageId);
         }
 
-        @Test
-        @DisplayName("최신 메세지 조회 실패 (롱폴링) - 존재하지 않는 채팅방")
+        @Test @DisplayName("최신 메세지 조회 실패 - 채팅방 없음")
         void get_lastest_message_fail_chat_room_not_exist () {
-            when(chatRoomRepository.findById(20L)).thenReturn(Optional.empty());
+            when(chatRoomRepository.findById(20L)).thenReturn(java.util.Optional.empty());
 
-            assertThatThrownBy(() -> service.getLatestMessages(normalUser, 20L, lastMessageId))
-                    .isInstanceOf(ChatRoomNotFoundException.class)
+            assertThatThrownBy(() ->
+                    service.getLatestMessages(normalUser, 20L, lastMessageId)
+            ).isInstanceOf(ChatRoomNotFoundException.class)
                     .hasMessageContaining(CHAT_ROOM_NOT_FOUND);
 
             verify(chatRoomRepository, times(1)).findById(20L);
         }
 
-        @Test
-        @DisplayName("최신 메세지 조회 실패 (롱폴링) - 참여자가 아님")
+        @Test @DisplayName("최신 메세지 조회 실패 - 참여자 아님")
         void get_lastest_message_fail_normal_user() {
-            when(chatRoomRepository.findById(20L)).thenReturn(Optional.of(chatRoom));
-            when(chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), normalUser.getId()))
+            when(chatRoomRepository.findById(20L)).thenReturn(java.util.Optional.of(chatRoom));
+            when(chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(20L, 2L))
                     .thenReturn(false);
 
-            assertThatThrownBy(() -> service.getLatestMessages(normalUser, 20L, lastMessageId))
-                    .isInstanceOf(NotParticipantException.class)
+            assertThatThrownBy(() ->
+                    service.getLatestMessages(normalUser, 20L, lastMessageId)
+            ).isInstanceOf(NotParticipantException.class)
                     .hasMessageContaining(NOT_PARTICIPANT);
 
-            verify(chatRoomRepository, times(1)).findById(20L);
-            verify(chatParticipantRepository, times(1)).existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), normalUser.getId());
+            verify(chatParticipantRepository, times(1))
+                    .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(20L, 2L);
         }
     }
 
     @Nested
     @DisplayName("Describe NotifyNewMessage")
-    class DescribeNotifyNewMessage {  ///  비동기 awaitility
+    class DescribeNotifyNewMessage {
 
         @Test
-        @DisplayName("새로운 메세지 발행 성공 - 단일 리스너, 큐 비우기 확인")
+        @DisplayName("단일 리스너에만 정상 전달 후 제거")
         void notify_new_messages_success_single_listener () {
             when(chatMessageQueryMapper.toMessageResponse(message1, authorUser.getNickname(), authorUser.getImageKey()))
                     .thenReturn(response);
 
-            service.notifyNewMessage(
-                    message1,
-                    authorUser.getNickname(),
-                    authorUser.getImageKey(),
-                    context
-            );
-
-            Awaitility.await()
-                    .atMost(Duration.ofSeconds(5))
-                    .untilAsserted(() -> {
-                        List<ChatMessageResponse> actual = (List<ChatMessageResponse>) result1.getResult();
-                        assertThat(actual).containsExactly(response);
-                    });
-
             @SuppressWarnings("unchecked")
-            Map<Long, List<DeferredResult<List<ChatMessageResponse>>>> map =
-                    (Map<Long, List<DeferredResult<List<ChatMessageResponse>>>>) ReflectionTestUtils.getField(service, "listeners");
-            assertThat(Objects.requireNonNull(map).get(chatRoom.getId())).isEmpty();
+            Map<Long, Map<Long, DeferredResult<List<ChatMessageResponse>>>> listeners =
+                (Map<Long, Map<Long, DeferredResult<List<ChatMessageResponse>>>>) ReflectionTestUtils.getField(service, "listeners");
+            listeners.get(chatRoom.getId()).remove(normalUser.getId());
+
+            service.notifyNewMessage(message1, authorUser.getNickname(), authorUser.getImageKey(), context);
+
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                // 먼저 null이 아님을 확인
+                assertThat(result1.getResult()).isNotNull();
+                assertThat((List<ChatMessageResponse>) result1.getResult())
+                                .containsExactly(response);
+                // 두 번째 리스너는 메시지를 받지 않음
+                assertThat(result2.getResult()).isNull();
+            });
         }
 
         @Test
-        @DisplayName("새로운 메세지 발행 성공 - 다중 리스너, 큐 비우기 확인")
+        @DisplayName("다중 리스너에 정상 전달 후 제거")
         void notify_new_messages_success_multi_listener () {
+            // 두 개의 리스너를 전부 active 상태로 두었기 때문에
+            // 둘 다 메시지를 받아야 함
             when(chatMessageQueryMapper.toMessageResponse(message1, authorUser.getNickname(), authorUser.getImageKey()))
                     .thenReturn(response);
 
-            service.notifyNewMessage(
-                    message1,
-                    authorUser.getNickname(),
-                    authorUser.getImageKey(),
-                    context
-            );
+            service.notifyNewMessage(message1, authorUser.getNickname(), authorUser.getImageKey(), context);
 
-            Awaitility.await()
-                    .atMost(Duration.ofSeconds(5))
-                    .untilAsserted(() -> {
-                        List<ChatMessageResponse> actual1 = (List<ChatMessageResponse>) result1.getResult();
-                        assertThat(actual1).containsExactly(response);
-                        List<ChatMessageResponse> actual2 = (List<ChatMessageResponse>) result2.getResult();
-                        assertThat(actual2).containsExactly(response);
-                    });
-
-            @SuppressWarnings("unchecked")
-            Map<Long, List<DeferredResult<List<ChatMessageResponse>>>> map =
-                    (Map<Long, List<DeferredResult<List<ChatMessageResponse>>>>) ReflectionTestUtils.getField(service, "listeners");
-            assertThat(Objects.requireNonNull(map).get(chatRoom.getId())).isEmpty();
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                assertThat(result1.getResult()).isNotNull();
+                assertThat(result2.getResult()).isNotNull();
+                assertThat((List<ChatMessageResponse>) result1.getResult())
+                                .containsExactly(response);
+                assertThat((List<ChatMessageResponse>) result2.getResult())
+                                .containsExactly(response);
+            });
         }
 
         @Test
-        @DisplayName("새로운 메세지 발행 성공 - 리스너 없음, 큐 비우기 확인")
+        @DisplayName("리스너가 없을 때도 예외 없이 동작")
         void notify_new_messages_success_no_listener () {
+            @SuppressWarnings("unchecked")
+            Map<Long, Map<Long, DeferredResult<List<ChatMessageResponse>>>> map =
+                    (Map<Long, Map<Long, DeferredResult<List<ChatMessageResponse>>>>)
+                            ReflectionTestUtils.getField(service, "listeners");
+
+            map.clear();
+
             when(chatMessageQueryMapper.toMessageResponse(message1, authorUser.getNickname(), authorUser.getImageKey()))
                     .thenReturn(response);
+            service.notifyNewMessage(message1, authorUser.getNickname(), authorUser.getImageKey(), context);
 
-            service.notifyNewMessage(
-                    message1,
-                    authorUser.getNickname(),
-                    authorUser.getImageKey(),
-                    context
+            await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
+                    assertThat(map.get(chatRoom.getId())).isNull()
             );
-
-            Awaitility.await()
-                    .atMost(Duration.ofSeconds(5))
-                    .untilAsserted(() -> {
-                        ///  리스너 없음
-                    });
-
-            @SuppressWarnings("unchecked")
-            Map<Long, List<DeferredResult<List<ChatMessageResponse>>>> map =
-                    (Map<Long, List<DeferredResult<List<ChatMessageResponse>>>>) ReflectionTestUtils.getField(service, "listeners");
-            assertThat(Objects.requireNonNull(map).get(chatRoom.getId())).isEmpty();
         }
-
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -36,8 +36,16 @@ cloud:
     s3:
       bucket: dummy-bucket
 
+app:
+  oauth:
+    kakao-client-id: dummy-client-id
+    kakao-client-secret: dummy-client-secret
+    kakao-redirect-uri: http://localhost:18080/oauth2/callback/kakao
+    kakao-complete-redirect: http://localhost:18080/dummy
+
 oauth:
   kakao:
     client-id: dummy-client-id
     client-secret: dummy-client-secret
     redirect-uri: http://localhost:18080/oauth2/callback/kakao
+    complete-redirect: http://localhost:18080/dummy


### PR DESCRIPTION
## 🔍 작업 개요
**채팅 Long-Polling** 연결, 공구 목록 커서 페이징, 자동 마감 스케줄러, 테스트 프로파일의 버그를 수정했습니다.

* **Long-Polling** ― _한 유저당 1개의 요청 대기 큐_ 만 유지해 중복 응답 제거  
* **공구 전체 리스트 API** ― 커서 비교 연산을 `>`(GREATER) 로 교체하고 중복 ROW 방지  
* **자동 공구 마감** ― `<= now` 조건으로 경계값 누락 해결  
* **application-test.yml** ― 누락된 더미 OAuth 프로퍼티 추가 후 테스트 복구  

---

## 🛠 주요 변경 사항

| # | 모듈 | 변경 사항 |
|:-:|------|-----------|
| **1** | **채팅 Long-Polling** | • `userId` 당 **BlockingQueue** 1개만 유지하도록 Registry 리팩터링<br>• 중복 큐 생성 시 기존 큐 반환 → “요청 1, 응답 1” 보장 |
| **2** | **채팅 테스트** | • 동일 `userId` 로 두 번 Polling 시 한 요청만 메시지 수신, 다른 요청은 타임아웃 확인 |
| **3** | **공구 목록 API** | • `Specification.where(distinct())` 적용<br>• 커서 조건 **`<` → `>`** 로 변경(가격·생성일·ID) |
| **4** | **자동 공구 마감** | • `dueDate <= now` 로 수정해 마감 시점 포함 |
| **5** | **테스트 프로파일** | • `application-test.yml` 에 더미 Kakao OAuth 키 삽입<br>• 전체 테스트(262 개) **성공** |

---

## ✅ 검증 사항

1. **Long-Polling** ― 두 클라이언트가 같은 `userId` 로 Polling ➜ 메시지는 한쪽만 수신, 다른 한쪽은 타임아웃  
2. **목록 API** ― `limit=10` 요청 시 반환 ≤ 10, 중복 ID 없음  
3. **마감 스케줄러** ― `dueDate == now` 레코드도 `OPEN → CLOSED` 전환 확인  
4. **Test Suite** ― `./gradlew clean test` 결과 **0 failures**

---

## 🔍 체크 리스트

- [x] Long-Polling 큐가 **유저당 1개**로 유지되는가?  
- [x] 커서 페이징 중복/누락 데이터가 없는가?  
- [x] `dueDate <= now` 조건이 정확히 동작하는가?  
- [x] 테스트 프로파일의 Placeholder 문제가 완전히 해결되었는가?  
- [x] 새로운 단위·통합 테스트가 모두 통과하는가?  

---

## ➕ 관련 이슈

- Relates to BE - v2 사전 배포 및 QA 진행 (#126 )  
