### PR TITLE
fix(chatting): Cursor-based 페이징 & 정렬 안정화 버그 픽스

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
@@ -65,8 +65,8 @@ public class GetGroupBuyListByCursor {
                             .and(Sort.by("createdAt").ascending())
                             .and(Sort.by("id").ascending());
                     case "ending_soon"  -> Sort.by("dueDate").ascending()
-                            .and(Sort.by("createdAt").descending())
-                            .and(Sort.by("id").descending());
+                            .and(Sort.by("createdAt").ascending())
+                            .and(Sort.by("id").ascending());
                     case "due_soon_only"-> Sort.by("dueDate").ascending()
                             .and(Sort.by("id").ascending());
                     default            -> Sort.by("createdAt").descending()


### PR DESCRIPTION
## 🔎 작업 개요
1. **중복 응답** – Redis ↔ Mongo 병합 과정에서 같은 메시지가 여러 번 반환되던 문제를 해결했습니다.  
2. **잘못된 범위** – `cursorId` **이전(<)** 이 아닌 **이후(>)** 메시지를 조회하도록 페이징 로직을 바로잡았습니다.  
3. **정렬 안정화** – `ending_soon` / `due_soon_only` 목록이 **deterministic** 하게 정렬되도록 Sort 키를 보강했습니다.

---

## 🛠️ 주요 변경 사항
###  `GetPastMessages` 서비스
- **Exclusive range** : Redis ZSET 조회를 `(cursorScore, +∞]` 범위로 변경, `cursorId` 제외  
- **Mongo Criteria** : `Criteria.where("_id").gt(new ObjectId(cursorId))` 로 수정 → _이후_ 메시지만 검색  
- `dedup` 결과를 `finalPage`로 캡슐화하여  
  - `nextCursorId` · `hasNext` 계산  
  - DTO 변환(source of truth)  
- TTL(24 h) 부여 시점 → **새 키 생성 시**로 제한  

###  `GroupBuyQueryService`
| orderBy 옵션 | **변경 전** | **변경 후** |
|--------------|------------|-------------|
| `price_asc` | `unitPrice ASC → createdAt ASC → id ASC` | _(동일)_ |
| `ending_soon` | `dueDate ASC → createdAt DESC → id DESC` | **`dueDate ASC → createdAt ASC → id ASC`** |
| `due_soon_only` | `dueDate ASC → id DESC` | **`dueDate ASC → id ASC`** |
> 세 가지 키(또는 두 가지 키)로 안정된 순서를 보장하여 커서 기반 페이징 중 중복·누락을 제거했습니다.

###  테스트
- **통합 테스트**  
  - 동일 `cursorId` 요청 시 **중복 없는 10건**과 올바른 `hasNext` 값 검증  
  - `cursorId`보다 **큰** 메시지만 반환되는지 검증  
  - `ending_soon` / `due_soon_only` 목록이 _consistent order_ 로 반환되는지 검증
- **단위 테스트**  
  - Redis 캐시 HIT / L1 부족분 Mongo Fallback 시 최종 결과 검증

---

## ✅ 검증 방법
1. **Postman / Swagger**  
   - `GET /api/chats/participant/{id}/message/past` 첫 호출 후 `nextCursorId`로 재호출  
   - 두 번째 호출 결과가 **중복 없이** 이전 응답보다 **더 나중**(ID > cursorId) 메시지인지 확인  
   - `GET /api/group-buys?orderBy=ending_soon` 연속 호출하여 정렬 & 커서 누락 여부 확인
2. **자동 테스트**  
   - `./gradlew test` 전부 통과  
   - 로컬 Redis + Mongo 환경에서 통합 테스트 성공
3. **로그 확인**  
   - `[Chat-Cache] ... hitCount, finalSize, hasNext=` 로그가 정확히 출력되는지 확인

---

## 🔍 머지 전 확인사항
- [x] 프론트엔드 페이징 로직과 `nextCursorId` 타입 호환성
- [x] 캐시 TTL(24 h) 정책 확정 (운영 중 메시지 빈도에 따라 조정 가능)

---

### ➕ 이슈 링크
- Relates to **BE - v2 사전 배포 및 QA 진행 (#126)**
