### PR TITLE
feat(groupbuy): 마감임박순 페이징 중복 제거 및 주문 즉시 마감 반영, 액추에이터 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
 	implementation 'org.flywaydb:flyway-mysql'
 	implementation 'com.google.code.gson:gson:2.10.1'
 	implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20211018.1'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyListController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/query/GroupBuyListController.java
@@ -30,6 +30,7 @@ public class GroupBuyListController {
             @RequestParam(value = "cursorId", required = false) Long cursorId,
             @RequestParam(value = "cursorCreatedAt", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorCreatedAt,
+            @RequestParam(value = "cursorSoldRatio", required = false) Integer cursorSoldRatio,
             @RequestParam(value = "cursorPrice", required = false) Integer cursorPrice,
             @RequestParam(value = "limit", defaultValue = "10") Integer limit,
             @RequestParam(value = "openOnly", required = false) Boolean openOnly,
@@ -38,7 +39,7 @@ public class GroupBuyListController {
         Long userId = (principal != null) ? principal.getUser().getId() : null;
         PagedResponse<BasicListResponse> pagedResponse =
                 queryFacade.getGroupBuyListByCursor(userId, categoryId, orderBy,
-                        cursorId, cursorCreatedAt, cursorPrice, limit, openOnly, keyword);
+                        cursorId, cursorCreatedAt, cursorSoldRatio, cursorPrice, limit, openOnly,keyword);
         return ResponseEntity.ok(
                 WrapperResponse.<PagedResponse<BasicListResponse>>builder()
                         .message(GET_LIST_SUCCESS)

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/PagedResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/query/response/groupBuyList/PagedResponse.java
@@ -16,6 +16,7 @@ public class PagedResponse<T> {
     private Integer nextCursor;           // 다음 페이지용 postId
     private Integer nextCursorPrice;      // 다음 페이지용 unitPrice
     private LocalDateTime nextCreatedAt;  // 다음 페이지용 createdAt
+    private Integer nextSoldRatio;        // 다음 페이지용 soldRatio
 
     private boolean hasMore;              // 다음 페이지 존재 여부
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/entity/GroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/entity/GroupBuy.java
@@ -58,6 +58,9 @@ public class GroupBuy extends BaseEntity {
     @Column(nullable = false)
     private boolean dueSoon = false;
 
+    @org.hibernate.annotations.Formula("(total_amount -  left_amount) * 100 / total_amount ")
+    private int soldRatio;
+
     @Column(length = 20)
     private String badge;
 
@@ -115,14 +118,8 @@ public class GroupBuy extends BaseEntity {
     }
 
     @Transient
-    public double getSoldRatio() {
-        if (totalAmount == 0) return 0.0;
-        return (double)(totalAmount - leftAmount) / totalAmount;
-    }
-
-    @Transient
     public boolean isAlmostSoldOut() {
-        return getSoldRatio() >= 0.8;
+        return soldRatio >= 80;
     }
 
     public void increaseLeftAmount(int quantity) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/facade/query/GroupBuyQueryFacade.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/facade/query/GroupBuyQueryFacade.java
@@ -29,6 +29,7 @@ public interface GroupBuyQueryFacade {
             String orderBy,
             Long cursorId,
             LocalDateTime cursorCreatedAt,
+            Integer cursorSoldRatio,
             Integer cursorPrice,
             Integer limit,
             Boolean openOnly,

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/facade/query/GroupBuyQueryFacadeImpl.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/facade/query/GroupBuyQueryFacadeImpl.java
@@ -10,7 +10,6 @@ import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyL
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyList.WishList.WishListResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.query.response.groupBuyUpdate.GroupBuyForUpdateResponse;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyQueryService.*;
-import com.moogsan.moongsan_backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -51,6 +50,7 @@ public class GroupBuyQueryFacadeImpl implements GroupBuyQueryFacade {
             String orderBy,
             Long cursorId,
             LocalDateTime cursorCreatedAt,
+            Integer cursorSoldRatio,
             Integer cursorPrice,
             Integer limit,
             Boolean openOnly,
@@ -58,7 +58,7 @@ public class GroupBuyQueryFacadeImpl implements GroupBuyQueryFacade {
 
         return listByCursorSvc.getGroupBuyListByCursor(
                 userId, categoryId, orderBy, cursorId,
-                cursorCreatedAt, cursorPrice, limit, openOnly, keyword);
+                cursorCreatedAt, cursorSoldRatio, cursorPrice, limit, openOnly, keyword);
     }
 
     @Override

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CreateGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CreateGroupBuy.java
@@ -62,7 +62,12 @@ public class CreateGroupBuy {
             }).toList();
 
         imageMapper.mapImagesToGroupBuy(destKeys, gb);
+        gb.decreaseLeftAmount(createGroupBuyRequest.getHostQuantity());
         gb.increaseParticipantCount();
+
+        if (gb.isAlmostSoldOut()) {
+            gb.changePostStatus("CLOSED");
+        }
         groupBuyRepository.save(gb);
 
         Long chatRoomId = chattingCommandFacade.joinChatRoom(currentUser, gb.getId());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,3 +49,5 @@ server.tomcat.threads.min-spare=30
 app.oauth.kakao-client-id=${OAUTH_KAKAO_CLIENT_ID}
 app.oauth.kakao-redirect-uri=${OAUTH_KAKAO_REDIRECT_URI}
 app.oauth.kakao-complete-redirect=${OAUTH_KAKAO_COMPLETE_REDIRECT}
+
+management.endpoints.web.exposure.include=*

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyListByCursorTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/query/GetGroupBuyListByCursorTest.java
@@ -73,6 +73,7 @@ public class GetGroupBuyListByCursorTest {
                 eq("created"),                       // orderBy
                 eq(50L),                             // cursorId
                 eq(LocalDateTime.parse("2025-05-26T12:00:00")), // cursorCreatedAt
+                eq(5),
                 eq(1000),                            // cursorPrice
                 eq(5),                               // limit
                 eq(false),                           // openOnly
@@ -98,6 +99,7 @@ public class GetGroupBuyListByCursorTest {
                 eq("created"),                                  // orderBy
                 eq(50L),                                        // cursorId
                 eq(LocalDateTime.parse("2025-05-26T12:00:00")), // cursorCreatedAt
+                eq(5),
                 eq(1000),                                       // cursorPrice
                 eq(5),                                          // limit
                 eq(false),                                      // openOnly


### PR DESCRIPTION
## 🔎 작업 개요
1. **마감임박순 중복 제거**  
   - 동일 `soldRatio` 내에서 페이지네이션 시 중복 아이템이 반환되는 문제 해결  
   - 커서 페이징에 `cursorSoldRatio` 파라미터 추가  
2. **주문 즉시 마감임박 검사**  
   - 주문(참여) 직후 `soldRatio`를 계산해 80% 이상 시 `postStatus`를 “CLOSED”로 변경  
3. **모니터링용 Spring Boot Actuator 추가**  
   - ‘spring-boot-starter-actuator’ 의존성 추가  
   - actuator 엔드포인트(health, metrics 등) 전부 노출 설정  

## 🛠️ 주요 변경 사항
1. **GetGroupBuyListByCursor**  
   - 메서드 시그니처에 `Integer cursorSoldRatio` 파라미터 추가  
   - `Sort` 설정: `ending_soon` 모드에서 `soldRatio DESC, id ASC` 적용  
   - `cursorSpec` 업데이트:  
     - `ending_soon` 분기에서 `cb.lessThan(ratio, cursorSoldRatio)` 및 동률 시 `id` 비교 로직 추가  
   - `PagedResponse` DTO에 `nextCursorSoldRatio` 필드 추가 및 빌더 반영  
2. **Controller API**  
   - `/api/group-buys` GET 요청에 `cursorSoldRatio` RequestParam 추가  
3. **CreateGroupBuy Service**  
   - 주문 처리 흐름에 `gb.decreaseLeftAmount(unitAmount)` 호출 추가  
   - 재고 비율(`soldRatio`) 검사 후 80% 이상 시 `gb.changePostStatus("CLOSED")` 로직 배치  
   - 단일 `save(gb)` 호출로 통합  
4. **Actuator 설정**  
   - **build.gradle**  
     ```groovy
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     ```  
   - **application.properties**  
     ```properties
     management.endpoints.web.exposure.include=*
     ```  

## ✅ 검증 방법
- **마감임박순 페이징**  
  1. `orderBy=ending_soon&limit=4` 로 첫 페이지 요청  
  2. 응답의 `posts` 순서가 `soldRatio` 내림차순, 동률 시 `id` 오름차순인지 확인  
  3. 반환된 `nextCursorSoldRatio` 값과 `nextCursorId` 로 두 번째 페이지 요청 시 중복 없이 이어지는지 검증  
- **주문 즉시 마감임박 반영**  
  1. `unitAmount` 만큼 주문 후 응답에서 `postStatus`가 “OPEN” → “CLOSED” 로 변경되는지 확인  
  2. DB에 저장된 `postStatus` 필드 값도 “CLOSED” 로 반영됐는지 조회  
- **Actuator 엔드포인트 확인**  
  - `/actuator/health`, `/actuator/metrics` 등 기본 엔드포인트에 접근하여 200 OK 응답 확인  

## 🔍 머지 전 확인사항
- [ ] `soldRatio` 계산식(`@Formula`)이 실제 컬럼명(`total_amount`, `left_amount`) 기반으로 올바르게 매핑됐는지  
- [ ] 컨트롤러 Swagger(OpenAPI) 스펙에 `cursorSoldRatio` 파라미터가 문서화됐는지  
- [ ] 단위 및 인티그레이션 테스트에서 `ending_soon` 모드 커서 페이징과 주문 마감 로직 커버리지 확인  
- [ ] Actuator 의존성 버전이 Spring Boot 버전과 호환되는지  
- [ ] 공개된 actuator 엔드포인트별 보안(인증/인가) 설정 검토  

## ➕ 이슈 링크
- Relates to **BE - v2 사전 배포 및 QA 진행 (#126)**
