### PR TITLE
fix(groupbuy): price_asc 커서 비교 로직 오름차순으로 수정

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
@@ -52,55 +52,62 @@ public class GetGroupBuyListByCursor {
         boolean isSearch = keyword != null && !keyword.isBlank();
 
         if (categoryId != null) {
-            Category category = categoryRepository.findById(categoryId)
+            categoryRepository.findById(categoryId)
                     .orElseThrow(CategoryNotFoundException::new);
-
         }
-
 
         // 1) 정렬 기준
         Sort sort = isSearch
                 ? Sort.by("id").descending()
                 : switch (orderBy) {
-                    case "price_asc"    -> Sort.by("unitPrice").ascending()
-                            .and(Sort.by("createdAt").ascending())
-                            .and(Sort.by("id").ascending());
-                    case "ending_soon"  -> Sort.by("soldRatio").descending()   // 비율 높은 순
-                            .and(Sort.by("id").ascending());
-                    case "due_soon_only"-> Sort.by("dueDate").ascending()
-                            .and(Sort.by("id").ascending());
-                    default            -> Sort.by("createdAt").descending()
-                            .and(Sort.by("id").descending());
+            case "price_asc"    -> Sort.by("unitPrice").ascending()
+                    .and(Sort.by("createdAt").ascending())
+                    .and(Sort.by("id").ascending());
+            case "ending_soon"  -> Sort.by("soldRatio").descending()
+                    .and(Sort.by("id").ascending());
+            case "due_soon_only"-> Sort.by("dueDate").ascending()
+                    .and(Sort.by("id").ascending());
+            default            -> Sort.by("createdAt").descending()
+                    .and(Sort.by("id").descending());
         };
 
-        // 2) 페이징 객체
-        Pageable page = PageRequest.of(0, limit, sort);
-
-        // 3) Specification 조립
-        Specification<GroupBuy> spec = Specification.where(excludeEndedOrDeleted())
+        // 2) 공통 스펙 (cursor 제외, 전체 count용)
+        Specification<GroupBuy> baseSpec = Specification.where(excludeEndedOrDeleted())
                 .and(dueSoonOnlyEq(orderBy))
                 .and(categoryEq(categoryId))
                 .and(openOnlyEq(openOnly))
-                .and(keywordLike(keyword))
+                .and(keywordLike(keyword));
+
+        // 3) 변하지 않는 전체 건수
+        long totalCount = groupBuyRepository.count(baseSpec);
+
+        // 4) 페이징 스펙에 cursor 포함
+        Specification<GroupBuy> pagedSpec = baseSpec
                 .and(cursorSpec(orderBy, cursorId, cursorCreatedAt, cursorSoldRatio, cursorPrice));
 
-        // 4) DB 조회 (필터+정렬+커서+페이징)
-        Page<GroupBuy> result = groupBuyRepository.findAll(spec, page);
-        List<GroupBuy> entities = result.getContent();
+        // 5) limit+1 개 조회
+        Pageable page = PageRequest.of(0, limit + 1, sort);
+        Page<GroupBuy> result = groupBuyRepository.findAll(pagedSpec, page);
+        List<GroupBuy> fetched = result.getContent();
 
-        // 5) 찜 여부 맵 & DTO 변환
+        // 6) hasMore 판단 & 실제 반환할 entities
+        boolean hasMore = fetched.size() > limit;
+        List<GroupBuy> entities = hasMore
+                ? fetched.subList(0, limit)
+                : fetched;
+
+        // 7) DTO 변환
         Map<Long, Boolean> wishMap = fetchWishUtil.fetchWishMap(userId, entities);
         List<BasicListResponse> posts = groupBuyQueryMapper.toBasicListWishResponses(entities, wishMap);
 
-        // 6) 다음 커서 계산
-        boolean hasMore = result.hasNext();
+        // 8) nextCursor 계산 (entities 기준 마지막 요소)
         Long nextCursorId = null;
         Integer nextCursorPrice = null;
         LocalDateTime nextCreatedAt = null;
         Integer nextCursorSoldRatio = null;
 
-        if (hasMore) {
-            GroupBuy last = entities.getLast();
+        if (hasMore && !entities.isEmpty()) {
+            GroupBuy last = entities.get(entities.size() - 1);
             nextCursorId    = last.getId();
             nextCreatedAt   = last.getCreatedAt();
             if ("price_asc".equals(orderBy)) {
@@ -110,8 +117,9 @@ public class GetGroupBuyListByCursor {
             }
         }
 
+        // 9) 응답 빌드 (count는 변하지 않는 totalCount)
         return PagedResponse.<BasicListResponse>builder()
-                .count(result.getTotalElements())
+                .count(totalCount)
                 .posts(posts)
                 .nextCursor(nextCursorId != null ? nextCursorId.intValue() : null)
                 .nextCursorPrice(nextCursorPrice)
@@ -121,42 +129,27 @@ public class GetGroupBuyListByCursor {
                 .build();
     }
 
-    // ────────────────────────────────────────────────────────────────────
-    // Specification 헬퍼 메서드들
-    // ────────────────────────────────────────────────────────────────────
-
     private Specification<GroupBuy> excludeEndedOrDeleted() {
         return (root, query, cb) ->
                 cb.not(root.get("postStatus").in("ENDED", "DELETED"));
     }
 
-
     private Specification<GroupBuy> dueSoonOnlyEq(String orderBy) {
         return (root, query, cb) -> {
             Predicate statusOpen = cb.equal(root.get("postStatus"), "OPEN");
-            if (!"due_soon_only".equals(orderBy)) {
-                return cb.conjunction();
-            }
-            return cb.and(
-                    statusOpen,
-                    cb.isTrue(root.get("dueSoon"))
-            );
+            return "due_soon_only".equals(orderBy)
+                    ? cb.and(statusOpen, cb.isTrue(root.get("dueSoon")))
+                    : cb.conjunction();
         };
     }
 
     private Specification<GroupBuy> categoryEq(Long categoryId) {
         return (root, query, cb) -> {
-            if (categoryId == null) {
-                return cb.conjunction();
-            }
-            // 1) root: GroupBuy
-            // 2) join("groupBuyCategories"): GroupBuy ↔ GroupBuyCategory (List<GroupBuyCategory>)
-            // 3) get("category"): GroupBuyCategory 안의 Category 엔티티
-            // 4) get("id"): Category 엔티티의 PK (category_id)
+            if (categoryId == null) return cb.conjunction();
             return cb.equal(
-                    root.join("groupBuyCategories")   // 엔티티 필드명: groupBuyCategories
-                            .get("category")              // GroupBuyCategory 엔티티의 category 필드
-                            .get("id"),                   // Category 엔티티의 id 필드
+                    root.join("groupBuyCategories")
+                            .get("category")
+                            .get("id"),
                     categoryId
             );
         };
@@ -171,19 +164,12 @@ public class GetGroupBuyListByCursor {
 
     private Specification<GroupBuy> keywordLike(String keyword) {
         return (root, query, cb) -> {
-            if (keyword == null || keyword.isBlank()) {
-                return cb.conjunction();
-            }
-            String pattern = "%" + keyword.trim().toLowerCase() + "%";
-            Expression<String> title   = cb.lower(root.get("title"));
-            Expression<String> name    = cb.lower(root.get("name"));
-            Expression<String> descr   = cb.lower(root.get("description"));
-
-            return cb.or(
-                    cb.like(title,   pattern),
-                    cb.like(name,    pattern),
-                    cb.like(descr,   pattern)
-            );
+            if (keyword == null || keyword.isBlank()) return cb.conjunction();
+            String p = "%" + keyword.trim().toLowerCase() + "%";
+            Expression<String> title = cb.lower(root.get("title"));
+            Expression<String> name  = cb.lower(root.get("name"));
+            Expression<String> descr = cb.lower(root.get("description"));
+            return cb.or(cb.like(title, p), cb.like(name, p), cb.like(descr, p));
         };
     }
 
@@ -195,56 +181,50 @@ public class GetGroupBuyListByCursor {
             Integer cursorPrice
     ) {
         return (root, query, cb) -> {
-            if (cursorId == null) {
-                return cb.conjunction();
-            }
-            // 각 페이징 전략별 커서 조건
+            if (cursorId == null) return cb.conjunction();
+
             switch (orderBy) {
                 case "price_asc": {
-                    Path<Integer> price  = root.get("unitPrice");
+                    Path<Integer> price   = root.get("unitPrice");
                     Path<LocalDateTime> created = root.get("createdAt");
                     return cb.or(
-                            cb.lessThan(price, cursorPrice),
+                            // price가 더 큰 것
+                            cb.greaterThan(price, cursorPrice),
+                            // price 같고 createdAt이 더 나중인 것
                             cb.and(
                                     cb.equal(price, cursorPrice),
-                                    cb.lessThan(created, cursorCreatedAt)
+                                    cb.greaterThan(created, cursorCreatedAt)
                             ),
+                            // price·createdAt 같고 id가 더 큰 것
                             cb.and(
                                     cb.equal(price, cursorPrice),
                                     cb.equal(created, cursorCreatedAt),
-                                    cb.lessThan(root.get("id"), cursorId)
+                                    cb.greaterThan(root.get("id"), cursorId)
                             )
                     );
                 }
-                case "ending_soon":
+                case "ending_soon": {
                     Path<Integer> ratio = root.get("soldRatio");
                     return cb.or(
-                            // 비율이 낮은 것(= 뒤 페이지)
                             cb.lessThan(ratio, cursorSoldRatio),
-                            // 같은 비율일 땐 ID 작은 순
-                            cb.and(
-                                cb.equal(ratio,cursorSoldRatio),
-                                cb.lessThan(root.get("id"), cursorId)
-                            )
-                    );
-                case "due_soon_only": {
-                    Path<LocalDateTime> dueDate = root.get("dueDate");
-                    return cb.or(
-                            cb.lessThan(dueDate, cursorCreatedAt),
-                            cb.and(
-                                    cb.equal(dueDate, cursorCreatedAt),
-                                    cb.lessThan(root.get("id"), cursorId)
-                            )
+                            cb.and(cb.equal(ratio, cursorSoldRatio),
+                                    cb.lessThan(root.get("id"), cursorId))
                     );
                 }
-                default: { // latest
-                    Path<LocalDateTime> createdAt = root.get("createdAt");
+                case "due_soon_only": {
+                    Path<LocalDateTime> due = root.get("dueDate");
                     return cb.or(
-                            cb.lessThan(createdAt, cursorCreatedAt),
-                            cb.and(
-                                    cb.equal(createdAt, cursorCreatedAt),
-                                    cb.lessThan(root.get("id"), cursorId)
-                            )
+                            cb.lessThan(due, cursorCreatedAt),
+                            cb.and(cb.equal(due, cursorCreatedAt),
+                                    cb.lessThan(root.get("id"), cursorId))
+                    );
+                }
+                default: {
+                    Path<LocalDateTime> created = root.get("createdAt");
+                    return cb.or(
+                            cb.lessThan(created, cursorCreatedAt),
+                            cb.and(cb.equal(created, cursorCreatedAt),
+                                    cb.lessThan(root.get("id"), cursorId))
                     );
                 }
             }


### PR DESCRIPTION
## 🔎 작업 개요
`price_asc` 정렬에서 커서 기반 페이징이 다음 페이지로 이어질 때 잘못된 비교 연산(`lessThan`)을 사용하여, 항상 낮은 가격(예: postId 9)이 반복 조회되는 문제가 있었습니다.  
이 PR은 `cursorSpec`의 `price_asc` 분기에서 오름차순 페이징에 맞는 `greaterThan` 연산으로 수정하여, 중복 없이 올바른 순서로 다음 페이지를 가져오도록 개선했습니다.

---

## 🛠 주요 변경 사항
- `cursorSpec` 내 `price_asc` 케이스:
  - `cb.lessThan(price, cursorPrice)` → `cb.greaterThan(price, cursorPrice)`
  - `cb.lessThan(created, cursorCreatedAt)` → `cb.greaterThan(created, cursorCreatedAt)`
  - `cb.lessThan(root.get("id"), cursorId)` → `cb.greaterThan(root.get("id"), cursorId)`
- 커서 기반 페이징 조건을 **가격 오름차순 정렬**에 맞게 일관성 있게 적용

---

## ✅ 검증 방법
1. `GET /api/group-buys?orderBy=price_asc` 로 첫 페이지 조회  
2. 응답에서 `nextCursor`, `nextCursorPrice`, `nextCreatedAt` 값을 확인  
3. 다음 페이지의 첫 요소가 이전 페이지 마지막 요소와 중복되지 않고, 가격 기준으로 올바르게 이어지는지 확인

---

## 🔍 머지 전 확인사항
- [x] `cursorSpec` 테스트를 통해 `price_asc` 페이징 시 중복 없이 정상 동작하는지  
- [x] 다른 정렬 옵션 (`ending_soon`, `due_soon_only`, 기본 정렬) 에서 기존 동작 그대로 유지되는지  

---

## ➕ 이슈 링크
- Relates to **BE - v2 사전 배포 및 QA 진행 (#126)**
