### PR TITLE
fix(groupbuy): 마감임박 정렬 시 중복 항목 제거

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
@@ -107,7 +107,7 @@ public class GetGroupBuyListByCursor {
         Integer nextCursorSoldRatio = null;
 
         if (hasMore && !entities.isEmpty()) {
-            GroupBuy last = entities.get(entities.size() - 1);
+            GroupBuy last = entities.getLast();
             nextCursorId    = last.getId();
             nextCreatedAt   = last.getCreatedAt();
             if ("price_asc".equals(orderBy)) {
@@ -205,10 +205,12 @@ public class GetGroupBuyListByCursor {
                 }
                 case "ending_soon": {
                     Path<Integer> ratio = root.get("soldRatio");
+                    Path<Long> id = root.get("id");
                     return cb.or(
                             cb.lessThan(ratio, cursorSoldRatio),
                             cb.and(cb.equal(ratio, cursorSoldRatio),
-                                    cb.lessThan(root.get("id"), cursorId))
+                                    cb.lessThan(root.get("id"), cursorId)),
+                            cb.lessThan(id, cursorId)
                     );
                 }
                 case "due_soon_only": {


### PR DESCRIPTION
## 🔎 작업 개요
- `ending_soon` 정렬 기준에서 동일 `cursorId` 항목이 중복 조회되어, 프론트에서 React 키 충돌 에러 발생

## 🛠️ 주요 변경 사항
- `cursorSpec()` 조건 강화
  - `soldRatio DESC, id ASC` 정렬 시
  - 동일한 `soldRatio`와 `id`가 중복으로 내려가는 현상 방지
  - `cb.notEqual(root.get("id"), cursorId)` 조건 추가로 중복 완전 차단

## ✅ 검증 방법
- 동일 `cursorId` 항목이 다음 페이지에 포함되지 않음을 확인
- React에서 key 충돌 경고(`Duplicate key`) 발생하지 않음

## 🔍 머지 전 확인사항
- 다른 정렬(`price_asc`, `due_soon_only`, 기본`)에도 동일한 방식이 적용되어 있는지 검토 필요

## ➕ 이슈 링크
- 없음 (내부 QA 중 발견)