### PR TITLE
fix(chatting): 작성자 본인 메시지 중복 수신 제거 및 실시간 반응 속도 개선

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/CreateChatMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/command/CreateChatMessage.java
@@ -75,19 +75,6 @@ public class CreateChatMessage {
         SecurityContext context = SecurityContextHolder.getContext();
         chatMessageRepository.save(document);
 
-        String redisKey = "chatting:messages:" + chatRoomId;
-
-        try {
-            String json = objectMapper.writeValueAsString(document);
-            double score = toScore(document.getId()); // tie-breaker 점수
-            Boolean added = redisTemplate.opsForZSet().add(redisKey, json, score);
-            if (Boolean.TRUE.equals(added)) {
-                redisTemplate.expire(redisKey, Duration.ofHours(1)); // 키가 새로 생성됐을 때만 TTL 부여
-            }
-        } catch (JsonProcessingException e) {
-            log.warn("❌ Redis 캐싱 실패 [chatRoomId={}]: {}", chatRoomId, e.getMessage());
-        }
-
         // 롱 폴링
         getLatestMessages.notifyNewMessage(document, currentUser.getNickname(), currentUser.getImageKey(), context);
 
@@ -101,5 +88,18 @@ public class CreateChatMessage {
         );
 
          */
+
+        String redisKey = "chatting:messages:" + chatRoomId;
+
+        try {
+            String json = objectMapper.writeValueAsString(document);
+            double score = toScore(document.getId()); // tie-breaker 점수
+            Boolean added = redisTemplate.opsForZSet().add(redisKey, json, score);
+            if (Boolean.TRUE.equals(added)) {
+                redisTemplate.expire(redisKey, Duration.ofHours(1)); // 키가 새로 생성됐을 때만 TTL 부여
+            }
+        } catch (JsonProcessingException e) {
+            log.warn("❌ Redis 캐싱 실패 [chatRoomId={}]: {}", chatRoomId, e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetPastMessages.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetPastMessages.java
@@ -129,7 +129,7 @@ public class GetPastMessages {
         finalQ.with(Sort.by(Sort.Order.asc("_id")));
         List<ChatMessageDocument> finalPage = mongoTemplate.find(finalQ, ChatMessageDocument.class);
 
-        // ❗ 정렬 역전 보정
+        // 정렬 역전 보정
         if (isPrev) {
             Collections.reverse(finalPage);
         }
@@ -154,7 +154,7 @@ public class GetPastMessages {
             );
         }).collect(Collectors.toList());
 
-        String nextCursor = finalPage.isEmpty() ? null : finalPage.get(finalPage.size() - 1).getId();
+        String nextCursor = finalPage.isEmpty() ? null : finalPage.getLast().getId();
 
         return ChatMessagePageResponse.builder()
                 .chatMessageResponses(responses)


### PR DESCRIPTION
## 🔎 작업 개요

- **작성자 본인이 작성한 메시지를 롱폴링을 통해 다시 수신하는 문제를 해결**
- **메시지 저장 직후 바로 알림을 전송하여 실시간성이 떨어진다는 체감 문제 개선**
- 궁극적으로는 SSE 또는 WebSocket으로의 전환이 필요하다고 판단되나,  
  우선 현 롱폴링 구조에서 최대한 반응성을 끌어올리는 조치를 적용

---

## 🛠 주요 변경 사항

1. **작성자 메시지 롱폴링 제외**
   - `notifyNewMessage()` 내부에서 메시지 작성자의 `participantId`와 리스너의 `participantId`를 비교하여,
     작성자 본인에게는 알림을 보내지 않도록 조건 분기 추가

2. **알림 호출 시점 개선**
   - 기존에는 Redis 캐싱 이후에 `notifyNewMessage()`를 호출했으나, 메시지 저장 직후로 알림 호출 위치를 **선행 배치**
   - Redis 캐싱은 실패해도 사용자 경험에 영향을 주지 않도록 뒤에서 처리

---

## ✅ 검증 방법

- 채팅 메시지 전송 시, 작성자 본인은 한 번만 메시지를 확인함 (낙관적 렌더링 or POST 응답 기반)
- 타 참여자는 롱폴링을 통해 실시간으로 새 메시지를 수신함
- Redis 캐싱 실패 시에도 메시지 실시간 전송에는 영향 없음

---

## 🔍 머지 전 확인사항

- [x] 프론트 메시지 상태(`messages`)에서 중복 제거 로직이 적용되어 있는지 확인
- [x] 작성자에게만 메시지가 중복으로 렌더링되지 않는지 QA 검증 필요
- [x] 추후 SSE 또는 WebSocket 구조로의 전환 여부 내부 논의 필요

## ➕ 이슈 링크
- Relates to **BE - v2 사전 배포 및 QA 진행 (#126)**