### PR TITLE
fix(chatting): 최신 메세지부터 조회하도록 정렬 방향 수정 및 Mongo 정렬 예외 처리

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetPastMessagesController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/controller/query/GetPastMessagesController.java
@@ -35,6 +35,15 @@ public class GetPastMessagesController {
             @RequestParam(required = false) String cursorMessageIdAfter
     ) {
 
+        if (cursorMessageIdBefore == null && cursorMessageIdAfter == null) {
+            // 최초 요청 → 최신 메시지부터 시작
+            return ResponseEntity.ok(
+                    WrapperResponse.<ChatMessagePageResponse>builder()
+                            .message("최신 메시지 조회 성공")
+                            .data(chattingQueryFacade.getPastMessages(userDetails.getUser(), chatRoomId, null, true)) // 최신 → 과거 방향
+                            .build());
+        }
+
         if (cursorMessageIdBefore != null && cursorMessageIdAfter != null) {
             throw new IllegalArgumentException("하나의 커서만 제공해야 합니다.");
         }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/dto/query/ChatMessagePageResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/dto/query/ChatMessagePageResponse.java
@@ -11,8 +11,7 @@ import java.util.List;
 public class ChatMessagePageResponse {
     private List<ChatMessageResponse> chatMessageResponses;   // 채팅 메세지
 
-    private String nextCursorId;           // 다음 페이지용 postId
-    private LocalDateTime nextCreatedAt;  // 다음 페이지용 createdAt
+    private String beforeCursorId;           // 이전 페이지용 postId
 
-    private boolean hasNext;              // 다음 페이지 존재 여부
+    private boolean hasBefore;               // 이전 페이지 존재 여부
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetPastMessages.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetPastMessages.java
@@ -154,12 +154,12 @@ public class GetPastMessages {
             );
         }).collect(Collectors.toList());
 
-        String nextCursor = finalPage.isEmpty() ? null : finalPage.getLast().getId();
+        String beforeCursor = finalPage.isEmpty() ? null : finalPage.getLast().getId();
 
         return ChatMessagePageResponse.builder()
                 .chatMessageResponses(responses)
-                .nextCursorId(nextCursor)
-                .hasNext(hasNext)
+                .beforeCursorId(beforeCursor)
+                .hasBefore(hasNext)
                 .build();
     }
 }


### PR DESCRIPTION
## 🔎 작업 개요

- 채팅 메시지 조회 시, 기존에는 **과거 → 최신** 순으로 응답하던 구조를
- **최신 → 과거** 순으로 조회하도록 방향성 전면 수정
- 가장 최근 메시지 기준으로 커서 페이징하여 **위로 스크롤 시 더 과거 메시지를 가져오는 구조**로 변경
- 또한, MongoDB 정렬 조건에서 필드 누락으로 발생하던 `Sort.by()` 런타임 예외를 수정

---

## 🛠 주요 변경 사항

- 기본 조회 시 커서가 없으면 `Double.MAX_VALUE`부터 시작하여 최신 메시지 기준 조회
- Redis 조회 방식: `reverseRangeByScore()`를 항상 사용하여 최신 → 과거 순 정렬
- MongoDB 조회 시 정렬을 항상 `Sort.by(Sort.Direction.DESC, "_id")`로 통일
  - 기존 `Sort.by(Sort.Direction.DESC)` → `IllegalArgumentException` 발생
  - `_id` 필드를 명시하여 예외 방지
- 커서 기준 Mongo 조건: `_id < cursor` 로 설정하여 더 과거 메시지 조회
- 최종 응답도 `DESC` 정렬된 그대로 반환 (정렬 역전 없음)
- `Collections.reverse()` 제거

---

## ✅ 검증 방법

- 채팅방 진입 시 가장 최신 메시지가 리스트 상단에 위치하는지 확인
- 위로 스크롤할수록 이전(과거) 메시지가 정상적으로 로딩되는지 확인
- 메시지 순서가 **최신 → 과거**로 일관성 있게 내려오는지 확인
- 커서 기반 조회 시 중복 없이 정확히 이어지는지 확인
- 기존 `500 Internal Server Error` (`Sort.by()` 예외) 미발생 여부 확인

---

## ➕ 관련 이슈
- Relates to **BE - v2 사전 배포 및 QA 진행 (#126)**
