### PR TITLE
fix(group_buy): ending_soon 정렬 기준에서 커서 기반 페이징 중복 응답 문제 해결

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyQueryService/GetGroupBuyListByCursor.java
@@ -208,9 +208,7 @@ public class GetGroupBuyListByCursor {
                     Path<Long> id = root.get("id");
                     return cb.or(
                             cb.lessThan(ratio, cursorSoldRatio),
-                            cb.and(cb.equal(ratio, cursorSoldRatio),
-                                    cb.lessThan(root.get("id"), cursorId)),
-                            cb.lessThan(id, cursorId)
+                            cb.and(cb.equal(ratio, cursorSoldRatio), cb.greaterThan(id, cursorId))
                     );
                 }
                 case "due_soon_only": {


### PR DESCRIPTION
## 🔎 작업 개요
`ending_soon` 정렬 시 커서 기반 페이지네이션에서 동일한 항목이 반복 응답되는 문제를 해결했습니다.  
정렬 기준(`soldRatio DESC, id ASC`)과 커서 조건이 불일치하여 중복된 응답이 발생하고 있었습니다.

---

## 🛠 주요 변경 사항
- `cursorSpec()` 내 `"ending_soon"` 조건 로직 수정
  - **Before**
    ```java
    cb.or(
        cb.lessThan(ratio, cursorSoldRatio),
        cb.and(cb.equal(ratio, cursorSoldRatio), cb.lessThan(id, cursorId)),
        cb.lessThan(id, cursorId)
    )
    ```
  - **After**
    ```java
    cb.or(
        cb.lessThan(ratio, cursorSoldRatio),
        cb.and(cb.equal(ratio, cursorSoldRatio), cb.greaterThan(id, cursorId))
    )
    ```
  - `id` 오름차순 정렬 기준에 맞춰 `cb.greaterThan(id, cursorId)`로 수정
  - 불필요한 조건 `cb.lessThan(id, cursorId)` 제거

---

## ✅ 검증 방법
- 동일 커서 요청 시, 같은 `postId`가 다시 포함되지 않음을 확인
- 프론트엔드 무한 스크롤에서 중복 아이템 제거 없이도 정상 동작하는지 확인
- 로그 또는 응답값 기준 `nextCursorId`, `nextSoldRatio` 정상 이동 여부 확인

---

## 🔍 머지 전 확인 사항
- [x] 기존 정렬 방식에 영향이 없는지 전체 조회 방식 테스트
- [x] 중복 응답 케이스 재현 테스트 통과 여부

---

## ➕ 관련 이슈
- Relates to **BE - v2 사전 배포 및 QA 진행 (#126)**
