### PR TITLE
test(OAuth): OAuthControllerTest, KakaoOAuthServieTest 작성

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/controller/OAuthController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/controller/OAuthController.java
@@ -6,7 +6,6 @@ import com.moogsan.moongsan_backend.domain.user.service.KakaoOAuthService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,9 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class OAuthController {
     private final KakaoOAuthService kakaoOAuthService;
-
-    @Value("${app.oauth.kakao-complete-redirect}")
-    private String kakaoCompleteRedirectUrl;
 
     @GetMapping("/kakao/callback")
     public void kakaoCallback(@RequestParam("code") String code, HttpServletResponse response) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/repository/OAuthRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/repository/OAuthRepository.java
@@ -1,6 +1,7 @@
 package com.moogsan.moongsan_backend.domain.user.repository;
 
 import com.moogsan.moongsan_backend.domain.user.entity.OAuth;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
@@ -9,4 +10,6 @@ public interface OAuthRepository extends JpaRepository<OAuth, Long> {
     Optional<OAuth> findByProviderAndProviderId(String provider, String providerId);
 
     boolean existsByProviderAndUserId(String provider, Long userId);
+
+    Optional<OAuth> findByUserAndProvider(User user, String provider);
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/user/controller/OAuthControllerTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/user/controller/OAuthControllerTest.java
@@ -1,89 +1,48 @@
 package com.moogsan.moongsan_backend.unit.user.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.domain.user.controller.OAuthController;
 import com.moogsan.moongsan_backend.domain.user.dto.response.LoginResponse;
 import com.moogsan.moongsan_backend.domain.user.service.KakaoOAuthService;
+import com.moogsan.moongsan_backend.domain.WrapperResponse;
 import jakarta.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.ResponseEntity;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-//@Disabled
-//@SpringBootTest
-//@AutoConfigureMockMvc
-//class OAuthControllerTest {
-//
-//    @Autowired
-//    private MockMvc mockMvc;
-//
-//    @Autowired
-//    private KakaoOAuthService kakaoOAuthService;
-//
-//    @Autowired
-//    private ObjectMapper objectMapper;
-//
-//    @TestConfiguration
-//    static class TestConfig {
-//        @Bean
-//        public KakaoOAuthService kakaoOAuthService() {
-//            return Mockito.mock(KakaoOAuthService.class);
-//        }
-//    }
-//
-//    @Test
-//    @DisplayName("카카오 OAuth 콜백 성공 테스트")
-//    void kakaoCallback_success() throws Exception {
-//        // given
-//        LoginResponse fakeResponse = LoginResponse.builder()
-//                .nickname("nickname")
-//                .name("박건")
-//                .imageUrl(null)
-//                .type("USER")
-//                .build();
-//
-//        Mockito.when(kakaoOAuthService.kakaoLogin(eq("auth-code"), any(HttpServletResponse.class)))
-//                .thenReturn(fakeResponse);
-//
-//        // when & then
-//        mockMvc.perform(get("/api/oauth/kakao/callback")
-//                        .param("code", "auth-code"))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.message").value("로그인에 성공했습니다."))
-//                .andExpect(jsonPath("$.data.nickname").value("nickname"))
-//                .andExpect(jsonPath("$.data.name").value("박건"))
-//                .andExpect(jsonPath("$.data.imageUrl").doesNotExist())
-//                .andExpect(jsonPath("$.data.type").value("USER"));
-//    }
-//
-//    @Test
-//    @DisplayName("code 파라미터 없이 요청 시 400 에러 발생")
-//    void kakaoCallback_missingCode_shouldReturnBadRequest() throws Exception {
-//        mockMvc.perform(get("/api/oauth/kakao/callback"))
-//                .andExpect(status().isBadRequest());
-//    }
-//
-//    @Test
-//    @DisplayName("카카오 로그인 중 예외 발생 시 500 에러 반환")
-//    void kakaoCallback_serviceThrowsException_shouldReturnInternalServerError() throws Exception {
-//        Mockito.when(kakaoOAuthService.kakaoLogin(eq("auth-code"), any(HttpServletResponse.class)))
-//                .thenThrow(new RuntimeException("OAuth 요청 중 오류 발생"));
-//
-//        mockMvc.perform(get("/api/oauth/kakao/callback")
-//                        .param("code", "auth-code"))
-//                .andExpect(status().isInternalServerError())
-//                .andExpect(jsonPath("$.message").value("OAuth 요청 중 오류 발생"));
-//    }
-//}
+class OAuthControllerTest {
+
+    @Test
+    void kakaoLoginComplete_success() {
+        // given
+        String code = "test-code";
+        String redirectUri = "https://dev.moongsan.com/kakao/callback";
+        LoginResponse loginResponse = LoginResponse.builder()
+            .nickname("nickname")
+            .name("name")
+            .imageUrl("test.png")
+            .type("USER")
+            .build();
+
+        KakaoOAuthService kakaoOAuthService = Mockito.mock(KakaoOAuthService.class);
+        HttpServletResponse httpResponse = Mockito.mock(HttpServletResponse.class);
+        OAuthController controller = new OAuthController(kakaoOAuthService);
+
+        Mockito.when(kakaoOAuthService.kakaoLogin(code, redirectUri, httpResponse))
+                .thenReturn(loginResponse);
+
+        // when
+        ResponseEntity<WrapperResponse<?>> response = controller.kakaoLoginComplete(redirectUri, code, httpResponse);
+
+        // then
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals("로그인에 성공했습니다.", response.getBody().getMessage());
+
+        LoginResponse responseData = (LoginResponse) response.getBody().getData();
+        assertEquals("nickname", responseData.getNickname());
+        assertEquals("name", responseData.getName());
+        assertEquals("test.png", responseData.getImageUrl());
+        assertEquals("USER", responseData.getType());
+    }
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/user/service/KakaoOAuthServiceTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/user/service/KakaoOAuthServiceTest.java
@@ -1,0 +1,129 @@
+package com.moogsan.moongsan_backend.unit.user.service;
+
+import com.moogsan.moongsan_backend.domain.user.component.KakaoOAuthClient;
+import com.moogsan.moongsan_backend.domain.user.dto.response.KakaoTokenResponse;
+import com.moogsan.moongsan_backend.domain.user.dto.response.KakaoUserInfoResponse;
+import com.moogsan.moongsan_backend.domain.user.dto.response.LoginResponse;
+import com.moogsan.moongsan_backend.domain.user.entity.OAuth;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import com.moogsan.moongsan_backend.domain.user.exception.base.UserException;
+import com.moogsan.moongsan_backend.domain.user.repository.OAuthRepository;
+import com.moogsan.moongsan_backend.domain.user.repository.TokenRepository;
+import com.moogsan.moongsan_backend.domain.user.repository.UserRepository;
+import com.moogsan.moongsan_backend.domain.user.service.KakaoOAuthService;
+import com.moogsan.moongsan_backend.global.security.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.moogsan.moongsan_backend.domain.user.exception.code.UserErrorCode.SIGNUP_REQUIRED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+public class KakaoOAuthServiceTest {
+
+    private final String code = "auth-code";
+    private final String redirectUri = "https://localhost/kakao/callback";
+
+    private KakaoTokenResponse tokenResponse;
+    private KakaoUserInfoResponse userInfoResponse;
+
+    @BeforeEach
+    void setUp() {
+        tokenResponse = new KakaoTokenResponse();
+        tokenResponse.setAccessToken("access-token");
+        tokenResponse.setRefreshToken("refresh-token");
+        tokenResponse.setExpiresIn(3600);
+        tokenResponse.setTokenType("bearer");
+
+        userInfoResponse = new KakaoUserInfoResponse();
+        KakaoUserInfoResponse.KakaoAccount kakaoAccount = new KakaoUserInfoResponse.KakaoAccount();
+        KakaoUserInfoResponse.Profile profile = new KakaoUserInfoResponse.Profile();
+
+        kakaoAccount.setEmail("test@kakao.com");
+        profile.setNickname("닉네임");
+        profile.setProfileImageUrl("프로필");
+        kakaoAccount.setProfile(profile);
+        userInfoResponse.setKakaoAccount(kakaoAccount);
+    }
+
+    private final KakaoOAuthClient kakaoOAuthClient = mock(KakaoOAuthClient.class);
+    private final UserRepository userRepository = mock(UserRepository.class);
+    private final OAuthRepository oAuthRepository = mock(OAuthRepository.class);
+    private final JwtUtil jwtUtil = mock(JwtUtil.class);
+    private final TokenRepository tokenRepository = mock(TokenRepository.class);
+    private final HttpServletResponse response = mock(HttpServletResponse.class);
+
+    private final KakaoOAuthService kakaoOAuthService = new KakaoOAuthService(
+            kakaoOAuthClient,
+            userRepository,
+            oAuthRepository,
+            jwtUtil,
+            tokenRepository
+    );
+
+    @Test
+    @DisplayName("카카오 로그인 - 성공 케이스")
+    void kakaoLogin_success() {
+        String email = "test@kakao.com";
+
+        User user = User.builder()
+                .email(email)
+                .nickname("닉네임")
+                .name("홍길동")
+                .imageKey("프로필")
+                .type("USER")
+                .build();
+
+        OAuth oAuth = OAuth.builder()
+                .provider("kakao")
+                .user(user)
+                .build();
+
+        String accessToken = "access.jwt.token";
+        String refreshToken = "refresh.jwt.token";
+        long accessTokenExpireAt = System.currentTimeMillis() + 3600_000L;
+
+        when(kakaoOAuthClient.requestAccessToken(code, redirectUri)).thenReturn(tokenResponse);
+        when(kakaoOAuthClient.requestUserInfo("access-token")).thenReturn(userInfoResponse);
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(oAuthRepository.findByUserAndProvider(user, "kakao")).thenReturn(Optional.of(oAuth));
+        when(jwtUtil.generateAccessToken(user)).thenReturn(accessToken);
+        when(jwtUtil.generateRefreshToken(user)).thenReturn(refreshToken);
+        when(jwtUtil.getAccessTokenExpireAt()).thenReturn(accessTokenExpireAt);
+
+        LoginResponse result = kakaoOAuthService.kakaoLogin(code, redirectUri, response);
+
+        assertThat(result.getNickname()).isEqualTo("닉네임");
+        assertThat(result.getName()).isEqualTo("홍길동");
+        assertThat(result.getImageUrl()).isEqualTo("프로필");
+        assertThat(result.getType()).isEqualTo("USER");
+    }
+
+    @Test
+    @DisplayName("카카오 로그인 - 회원가입 필요")
+    void kakaoLogin_needSignup() {
+        when(kakaoOAuthClient.requestAccessToken(code, redirectUri)).thenReturn(tokenResponse);
+        when(kakaoOAuthClient.requestUserInfo("access-token")).thenReturn(userInfoResponse);
+        when(userRepository.findByEmail("test@kakao.com")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> kakaoOAuthService.kakaoLogin(code, redirectUri, response))
+                .isInstanceOf(UserException.class)
+                .hasMessageContaining(SIGNUP_REQUIRED.getDefaultMessage());
+    }
+
+    @Test
+    @DisplayName("카카오 로그인 - 카카오 서버 오류")
+    void kakaoLogin_kakaoError() {
+        when(kakaoOAuthClient.requestAccessToken(code, redirectUri))
+                .thenThrow(new RuntimeException("카카오 서버 오류"));
+
+        assertThatThrownBy(() -> kakaoOAuthService.kakaoLogin(code, redirectUri, response))
+                .isInstanceOf(UserException.class)
+                .hasMessageContaining("OAuth 요청 중 오류 발생");
+    }
+}


### PR DESCRIPTION
## test(OAuth): OAuthControllerTest, KakaoOAuthServieTest 작성

## 🔎 작업 개요
잦은 수정으로 주석처리 해두었던 OAuth의 테스트 코드들을 다시 작성하였습니다

## 🛠️ 주요 변경 사항
- OAuthControllerTest 작성
- KakaoOAuthServiceTest 작성
- 로컬 환경변수에서 OAUTH_KAKAO_REDIRECT_URI와 OAUTH_KAKAO_COMPLETE_REDIRECT를 삭제했습니다
- 환경변수 변경은 연동 후 이상없으면 다시 알려드리겠습니다

## ✅ 검증 방법
- ./gradlew build로 확인 완료

## 🔍 머지 전 확인사항  
- [x] 테스트 통과 여부

## ➕ 이슈 링크
- #92 
