### PR TITLE
fix(chatting): 채팅 메시지 역방향 조회 로직 제거 및 단일 방향으로 고정 

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetPastMessages.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/service/query/GetPastMessages.java
@@ -132,11 +132,6 @@ public class GetPastMessages {
         finalQ.with(Sort.by(Sort.Order.asc("_id")));
         List<ChatMessageDocument> finalPage = mongoTemplate.find(finalQ, ChatMessageDocument.class);
 
-        // 정렬 역전 보정
-        if (isPrev) {
-            Collections.reverse(finalPage);
-        }
-
         // 7) hasNext 계산
         boolean hasNext = finalPage.size() == PAGE_SIZE && (
                 !dbDocs.isEmpty() || cachedMembers.size() > PAGE_SIZE


### PR DESCRIPTION
### 📌 PR 제목  
`fix(chatting): 과거 채팅 메시지 역방향 조회 로직 제거`

---

### 🔍 작업 개요  
- 채팅 메시지 조회 시 과거 방향으로의 pagination 분기(`isPrev`) 로직을 제거하고,  
  최신 → 과거 방향의 단일 흐름으로 통합 처리했습니다.

---

### 🛠 주요 변경 사항  
- Redis 조회 시 `reverseRangeByScore`를 고정 사용하여 정방향 캐시 조회  
- MongoDB 쿼리에서 `_id < cursorId` 및 `Sort.Direction.DESC`만 사용하도록 정렬 방향 통일  
- `isPrev` 기반 분기 로직 및 불필요한 정렬 조건 제거  
- Redis/MongoDB 병합 후 최종 정렬 처리 단순화

---

### ✅ 검증 방법  
- 채팅방 입장 후, 위로 스크롤 시 과거 메시지가 순차적으로 불러와지는지 확인  
- 중복 없이 정확히 `PAGE_SIZE`만큼 메시지가 로드되는지 검증  
- 캐시 미스 시 MongoDB 보완 로직이 정상 동작하는지 확인  
- 최종 메시지 리스트가 시간순으로 정렬되어 있는지 시각적 확인

---

### 🔍 머지 전 확인사항   
- 프론트엔드에서 양방향 pagination을 사용하지 않는지 확인  

---

### ➕ 이슈 링크  
- Relates to **BE - v2 사전 배포 및 QA 진행 (#126)**
