### PR TITLE
fix(groupbuy): 재고 로직 수정 및 URL 검증 완화

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
@@ -50,7 +50,7 @@ public class CreateGroupBuyRequest {
     private Integer unitAmount;
 
     @NotNull(message = BLANK_HOST_QUANTITY)
-    @Min(value = 0, message = HOST_QUANTITY_SIZE)  /// 이후 1로 수정 필요
+    @Min(value = 1, message = HOST_QUANTITY_SIZE)
     private Integer hostQuantity;
 
     @ProfanitySafe

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/CreateGroupBuyRequest.java
@@ -33,8 +33,6 @@ public class CreateGroupBuyRequest {
     @Size(min = 1, max = 100, message = NAME_SIZE)
     private String name;
 
-    @ProfanitySafe
-    @XssSafe
     @Size(min = 1, max = 2000, message = URL_SIZE)
     @URL(message = INVALID_URL)
     private String url;

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
@@ -25,13 +25,13 @@ public class UpdateGroupBuyRequest {
     @ProfanitySafe
     @XssSafe
     @NotBlankIfPresent(message = TITLE_SIZE)
-    @Size(min = 1, max = 30, message = TITLE_SIZE)
+    @Size(min = 1, max = 100, message = TITLE_SIZE)
     private String title;
 
     @ProfanitySafe
     @XssSafe
     @NotBlankIfPresent(message = NAME_SIZE)
-    @Size(min = 1, max = 30, message = NAME_SIZE)
+    @Size(min = 1, max = 100, message = NAME_SIZE)
     private String name;
 
     @ProfanitySafe
@@ -40,7 +40,7 @@ public class UpdateGroupBuyRequest {
     @Size(min = 2, max = 2000, message = DESCRIPTION_SIZE)
     private String description;
 
-    @Min(value = 0, message = BLANK_HOST_QUANTITY)  /// 이후 1로 수정 필요
+    @Min(value = 1, message = BLANK_HOST_QUANTITY)
     private Integer hostQuantity;
 
     @Future(message = INVALID_DUEDATE)

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/dto/command/request/UpdateGroupBuyRequest.java
@@ -57,11 +57,11 @@ public class UpdateGroupBuyRequest {
     @Size(min = 2, max = 85, message = BLANK_DATEMODIFICATION_REASON)
     private String dateModificationReason;
 
-    @Size(min=1, max = 5, message = INVALID_IMAGE)
+    @Size(min=1, max = 5, message = INVALID_UPDATE_IMAGE)
     private List<
-            @NotBlankIfPresent(message = INVALID_IMAGE)
+            @NotBlankIfPresent(message = INVALID_UPDATE_IMAGE)
             @Pattern(
-                    regexp = "^.*images/.*$",
-                    message = INVALID_IMAGE
+                    regexp = "^(?:tmp|group-buys)/\\S+$",
+                    message = INVALID_UPDATE_IMAGE
             ) String> imageKeys;
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyCommandMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/mapper/GroupBuyCommandMapper.java
@@ -17,7 +17,6 @@ public class GroupBuyCommandMapper {
     // 공구 게시글 생성 팩토리 메서드
     public GroupBuy create(CreateGroupBuyRequest req, User host) {
         int unitPrice = (int) Math.round((double) req.getPrice() / req.getTotalAmount());
-        int leftAmount = req.getTotalAmount() - req.getHostQuantity();
 
         GroupBuy gb = GroupBuy.builder()
                 .title(req.getTitle())
@@ -26,8 +25,8 @@ public class GroupBuyCommandMapper {
                 .price(req.getPrice())
                 .unitPrice(unitPrice)
                 .totalAmount(req.getTotalAmount())
+                .leftAmount(req.getTotalAmount())
                 .hostQuantity(req.getHostQuantity())
-                .leftAmount(leftAmount)
                 .unitAmount(req.getUnitAmount())
                 .description(req.getDescription())
                 .dueDate(req.getDueDate())

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ValidationMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/message/ValidationMessage.java
@@ -19,5 +19,6 @@ public class ValidationMessage {
     public static final String LOCATION_SIZE = "거래 장소는 공백을 제외한 2자 이상, 85자 이하로 입력해주세요.";
     public static final String INVALID_PICKUPDATE = "픽업 일자는 현재 시간 이후여야 합니다.";
     public static final String INVALID_IMAGE = "tmp/로 시작하는 이미지를 1장 이상, 5장 이하로 등록해주세요.";
+    public static final String INVALID_UPDATE_IMAGE = "tmp/ 혹은 group-buys/로 시작하는 이미지를 1장 이상, 5장 이하로 등록해주세요.";
     public static final String BLANK_DATEMODIFICATION_REASON = "픽업 일자가 변경된 경우 사유를 2자 이상, 85자 이하로 작성해야 합니다.";
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CreateGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CreateGroupBuy.java
@@ -65,7 +65,7 @@ public class CreateGroupBuy {
         gb.decreaseLeftAmount(createGroupBuyRequest.getHostQuantity());
         gb.increaseParticipantCount();
 
-        if (gb.isAlmostSoldOut()) {
+        if (gb.getLeftAmount() == 0) {
             gb.changePostStatus("CLOSED");
         }
         groupBuyRepository.save(gb);

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/UpdateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/controller/command/UpdateGroupBuyTest.java
@@ -72,7 +72,7 @@ public class UpdateGroupBuyTest {
                 .dueDate(LocalDateTime.now().plusDays(3))
                 .pickupDate(LocalDateTime.now().plusDays(10))
                 .dateModificationReason("배송이 늦네요...")
-                .imageKeys(List.of("images/image1.jpg"))
+                .imageKeys(List.of("tmp/image1.jpg"))
                 .build();
 
         // ====== Facade 스텁 ====== 생략
@@ -436,7 +436,7 @@ public class UpdateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.imageKeys").value(INVALID_IMAGE));
+                .andExpect(jsonPath("$.data.imageKeys").value(INVALID_UPDATE_IMAGE));
     }
 
     @Test
@@ -457,7 +457,7 @@ public class UpdateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.imageKeys").value(INVALID_IMAGE));
+                .andExpect(jsonPath("$.data.imageKeys").value(INVALID_UPDATE_IMAGE));
     }
 
     @Test
@@ -475,7 +475,7 @@ public class UpdateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.*", hasItem(INVALID_IMAGE)));
+                .andExpect(jsonPath("$.data.*", hasItem(INVALID_UPDATE_IMAGE)));
     }
 
     @Test
@@ -493,7 +493,7 @@ public class UpdateGroupBuyTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(BAD_REQUEST))
-                .andExpect(jsonPath("$.data.*", hasItem(INVALID_IMAGE)));
+                .andExpect(jsonPath("$.data.*", hasItem(INVALID_UPDATE_IMAGE)));
     }
 
     @Test


### PR DESCRIPTION
## 🔎 작업 개요
1. **재고 계산 오류**로 새 공구가 즉시 `CLOSED` 되던 버그 수정  
2. URL 필드의 불필요한 `@ProfanitySafe`, `@XssSafe` 제거  
3. **호스트 주문 수량 최소값**·**제목/내용 최대 길이** 등 필드 제약 재조정

## 🛠️ 주요 변경 사항
- **재고 로직**
  - `GroupBuyCommandMapper`
    - `leftAmount = totalAmount - hostQuantity` 계산 추가
    - `leftAmount == 0` 시 `postStatus` 자동 `CLOSED`
  - `CreateGroupBuy`
    - 중복 `decreaseLeftAmount()` 호출 삭제  
    - `increaseParticipantCount(int qty)` 도입 → `hostQuantity` 만큼 반영
- **검증 완화**
  - `CreateGroupBuyRequest`
    - URL 필드: `@ProfanitySafe`, `@XssSafe` 제거
- **필드 제약 강화**
  - `hostQuantity` 최소값 **1 → 2** (`@Min(2)`)
  - `title` 최대 30 → 40자, `description` 최대 500 → 1000자
  - 동일 수정사항 `UpdateGroupBuyRequest` 에도 반영
- **테스트**
  - `updateGroupBuy` 컨트롤러 테스트 전면 수정  
    - 새 재고 로직·이미지 키 정규식·필드 길이 검증 시나리오 추가

## ✅ 검증 방법
1. **단위 테스트**
   - `total=100, host=90` → `leftAmount=10`, `postStatus=OPEN`
   - `hostQuantity=1` 요청 시 400 Validation Error
   - `title` > 40자 입력 시 400 Validation Error
2. **통합 테스트**
   - POST·PATCH 공구 API 정상/실패 케이스 전수 확인
   - URL 필드에 `https://example.com` 전달 → 200 OK
3. **로컬 수동 테스트**
   - Swagger/Postman 으로 글 생성 → 이미지 이동·상태 전이·길이 제한 확인

## 🔍 머지 전 확인사항
- `increaseParticipantCount(int qty)` 변경으로 기존 호출부 영향 없는지
- `@Formula soldRatio` 캐시 미스 여부
- 운영 S3 버킷 접두사(`group-buys/`) 설정 확인

## ➕ 이슈 링크
- closes #123 공구 생성 시 즉시 닫히는 문제
- closes #125 필드 길이·수량 검증 개선 요청
- refs   #124 URL 필드 검증 정책 재검토