### PR TITLE
feat(chatting-anon): 과거 채팅 조회 api 구현, stomp기반 작성 완료

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/anonymous/controller/ChatAnonQueryController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/anonymous/controller/ChatAnonQueryController.java
@@ -1,0 +1,23 @@
+package com.moogsan.moongsan_backend.domain.chatting.anonymous.controller;
+
+import com.moogsan.moongsan_backend.domain.chatting.anonymous.entity.ChatAnon;
+import com.moogsan.moongsan_backend.domain.chatting.anonymous.repository.ChatAnonRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat-anon")
+public class ChatAnonQueryController {
+    private final ChatAnonRepository chatAnonRepository;
+
+    @GetMapping("/{postId}")
+    public List<ChatAnon> getAllMessages(@PathVariable Long postId){
+        return chatAnonRepository.findByPostIdOrderByCreatedAtAsc(postId);
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/anonymous/repository/ChatAnonRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/anonymous/repository/ChatAnonRepository.java
@@ -12,4 +12,6 @@ public interface ChatAnonRepository extends MongoRepository<ChatAnon, String> {
 
     @Query(value = "{ 'postId': ?0 }", fields = "{ 'aliasId': 1 }")
     List<ChatAnon> findByPostId(Long postId);
+
+    List<ChatAnon> findByPostIdOrderByCreatedAtAsc(Long postId);
 }

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
@@ -45,20 +45,22 @@ public class SecurityConfig {
                 .requestMatchers(
                         "/",
                         "/static/**",
-                    "/error", "/error/**",
-                    "/api/users",                           // 회원가입
-                    "/api/users/token",                     // 로그인
-                    "/api/users/check-nickname",            // 닉네임 중복 확인
-                    "/api/users/check-email",               // 이메일 중복 확인
-                    "/uploads/**",                          // 이미지 업로드
-                    "/api/group-buys/generation/description", // AI 응답 생성
-                    "/api/users/check/account",             // 계좌 예금주 확인
-                    "/kakao/callback",                      // 카카오 OAuth Callback Redirect URI
-                    "/api/oauth/kakao/callback/complete",   // OAuth 연동
-                    "/ws/chat",                            // WebSocket 핸드셰이크 직접 허용
-                    "/ws/chat/**",                          // STOMP WebSocket 연결 허용
-                    "/test-chat.html",                      // WebSocket 테스트 HTML
-                    "/favicon.ico"                          // 브라우저 요청 아이콘
+                        "/error", "/error/**",
+                        "/api/users",                           // 회원가입
+                        "/api/users/token",                     // 로그인
+                        "/api/users/check-nickname",            // 닉네임 중복 확인
+                        "/api/users/check-email",               // 이메일 중복 확인
+                        "/uploads/**",                          // 이미지 업로드
+                        "/api/group-buys/generation/description", // AI 응답 생성
+                        "/api/users/check/account",             // 계좌 예금주 확인
+                        "/kakao/callback",                      // 카카오 OAuth Callback Redirect URI
+                        "/api/oauth/kakao/callback/complete",   // OAuth 연동
+                        "/ws/chat",                             // WebSocket 핸드셰이크 직접 허용
+                        "/ws/chat/**",                          // STOMP WebSocket 연결 허용
+                        "/test-chat.html",                      // WebSocket 테스트 HTML
+                        "/favicon.ico",                         // 브라우저 요청 아이콘
+                        "/api/chat-anon/**"                     // 익명 채팅 내역 첫 조회
+
                 ).permitAll()
                 .requestMatchers(HttpMethod.GET,
                     "/api/group-buys",                      // 공구글 목록 조회


### PR DESCRIPTION
## feat(chatting-anon): 채팅 조회 api 구현, stomp기반 작성 완료

## 🔎 작업 개요
- 과거 채팅 조회 api 구현
- stomp 기반으로 작성을 완료하여 kafka 도입 및 반영을 진행하면 됩니다

## 🛠️ 주요 변경 사항
- 채팅 조회 api 구현

## ✅ 검증 방법
- ./gradlew build, 실행 완료
- 포스트맨 통과

## 🔍 머지 전 확인사항  
- [x] 테스트 통과 여부

## ➕ 이슈 링크
- #246 
