### PR TITLE
feat(Kafka): Kafka 도입 및 로그 최적화, Outbox 패턴 준비

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	testImplementation 'org.mockito:mockito-inline:5.2.0'
+	implementation "org.springframework.kafka:spring-kafka"
+	implementation("org.springframework.kafka:spring-kafka-test")
 }
 
 test {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+# docker-compose.yml
 
 services:
   # 1) Redis 서비스
@@ -35,8 +35,138 @@ services:
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/config/
       SPRING_PROFILES_ACTIVE: docker
 
+  # ------- Zookeeper 3대 -------
+  zookeeper-1:
+    image: bitnami/zookeeper:3.9
+    volumes:
+      - zookeeper-1-data:/bitnami/zookeeper
+    container_name: zookeeper-1
+    restart: unless-stopped
+    networks: [moongsan-net]
+    ports:
+      - "2181:2181"
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+      ZOO_SERVER_ID: 1
+      ZOO_SERVERS: |
+        0.0.0.0:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
+
+  zookeeper-2:
+    image: bitnami/zookeeper:3.9
+    volumes:
+      - zookeeper-2-data:/bitnami/zookeeper
+    container_name: zookeeper-2
+    restart: unless-stopped
+    networks: [moongsan-net]
+    ports:
+      - "2182:2181"
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+      ZOO_SERVER_ID: 2
+      ZOO_SERVERS: |
+        zookeeper-1:2888:3888;0.0.0.0:2888:3888;zookeeper-3:2888:3888
+
+  zookeeper-3:
+    image: bitnami/zookeeper:3.9
+    volumes:
+      - zookeeper-3-data:/bitnami/zookeeper
+    container_name: zookeeper-3
+    restart: unless-stopped
+    networks: [moongsan-net]
+    ports:
+      - "2183:2181"
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+      ZOO_SERVER_ID: 3
+      ZOO_SERVERS: |
+        zookeeper-1:2888:3888;zookeeper-2:2888:3888;0.0.0.0:2888:3888
+
+  # ------- Kafka 브로커 3대 -------
+  kafka-1:
+    image: bitnami/kafka:3.6
+    volumes:
+      - kafka-1-data:/bitnami/kafka/data
+    container_name: kafka-1
+    restart: unless-stopped
+    depends_on:
+      - zookeeper-1
+      - zookeeper-2
+      - zookeeper-3
+    networks: [moongsan-net]
+    ports:
+      - "19092:19092"    # 호스트 ↔ 컨테이너 EXTERNAL 리스너
+    environment:
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_CFG_NODE_ID: 1
+      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+      KAFKA_CFG_LISTENERS: INTERNAL://0.0.0.0:9092,EXTERNAL://0.0.0.0:19092
+      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://kafka-1:9092,EXTERNAL://localhost:19092
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: '3'
+      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '3'
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: false
+
+  kafka-2:
+    image: bitnami/kafka:3.6
+    volumes:
+      - kafka-2-data:/bitnami/kafka/data
+    container_name: kafka-2
+    restart: unless-stopped
+    depends_on:
+      - zookeeper-1
+      - zookeeper-2
+      - zookeeper-3
+    networks: [moongsan-net]
+    ports:
+      - "19093:19093"
+    environment:
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_CFG_NODE_ID: 2
+      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+      KAFKA_CFG_LISTENERS: INTERNAL://0.0.0.0:9092,EXTERNAL://0.0.0.0:19093
+      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://kafka-2:9092,EXTERNAL://localhost:19093
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: '3'
+      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '3'
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: false
+
+  kafka-3:
+    image: bitnami/kafka:3.6
+    volumes:
+      - kafka-3-data:/bitnami/kafka/data
+    container_name: kafka-3
+    restart: unless-stopped
+    depends_on:
+      - zookeeper-1
+      - zookeeper-2
+      - zookeeper-3
+    networks: [moongsan-net]
+    ports:
+      - "19094:19094"
+    environment:
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_CFG_NODE_ID: 3
+      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+      KAFKA_CFG_LISTENERS: INTERNAL://0.0.0.0:9092,EXTERNAL://0.0.0.0:19094
+      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://kafka-3:9092,EXTERNAL://localhost:19094
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: '3'
+      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '3'
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: false
+
 volumes:
   redis-data:
+
+  zookeeper-1-data:
+  zookeeper-2-data:
+  zookeeper-3-data:
+
+  kafka-1-data:
+  kafka-2-data:
+  kafka-3-data:
 
 networks:
   moongsan-net:

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/controller/KafkaTestController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/controller/KafkaTestController.java
@@ -1,0 +1,33 @@
+package com.moogsan.moongsan_backend.domain.notification.controller;
+
+import com.moogsan.moongsan_backend.domain.notification.dto.SimpleMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/kafka")
+public class KafkaTestController {
+
+    private final KafkaTemplate<String, SimpleMessage> kafkaTemplate;
+
+    @PostMapping("/send")
+    public void send(@RequestBody SimpleMessage message) {
+        log.info("[KAFKA SEND 요청] message={}", message);
+        try {
+            SendResult<String,SimpleMessage> r = kafkaTemplate
+                    .send("test.simple.message", message.getContent(), message)
+                    .get(10, TimeUnit.SECONDS);
+            log.info("✅ 전송 동기 확인 offset={}", r.getRecordMetadata().offset());
+        } catch (Exception e) {
+            log.error("❌ 전송 동기 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/dto/SimpleMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/dto/SimpleMessage.java
@@ -1,0 +1,13 @@
+package com.moogsan.moongsan_backend.domain.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SimpleMessage {
+    private String sender;
+    private String content;
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/KafkaMessageListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/KafkaMessageListener.java
@@ -1,0 +1,24 @@
+package com.moogsan.moongsan_backend.domain.notification.service;
+
+import com.moogsan.moongsan_backend.domain.notification.dto.SimpleMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@EnableKafka
+@Component
+public class KafkaMessageListener {
+
+    @KafkaListener(
+            topics = "test.simple.message",
+            groupId = "${spring.kafka.consumer.group-id}",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void listen(SimpleMessage message, Acknowledgment ack) {
+        log.info("카프카 수신 => {}", message);
+        ack.acknowledge();
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/KafkaConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/KafkaConfig.java
@@ -1,0 +1,26 @@
+package com.moogsan.moongsan_backend.global.config;
+
+import com.moogsan.moongsan_backend.domain.notification.dto.SimpleMessage;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, SimpleMessage> kafkaListenerContainerFactory(
+            ConsumerFactory<String, SimpleMessage> cf
+    ) {
+        var factory = new ConcurrentKafkaListenerContainerFactory<String, SimpleMessage>();
+        factory.setConsumerFactory(cf);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        factory.getContainerProperties().setSyncCommits(true);
+
+        // 재시도 추가 예정
+        return factory;
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/global/outbox/OutboxEventEntity.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/outbox/OutboxEventEntity.java
@@ -1,0 +1,60 @@
+package com.moogsan.moongsan_backend.global.outbox;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "outbox_event")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OutboxEventEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false, unique = true)
+    private String eventId;
+
+    @Column(name = "aggregate_type", nullable = false, length = 64)
+    private String aggregateType;
+
+    @Column(name = "aggregate_id", nullable = false, length = 64)
+    private String aggregateId;
+
+    @Column(name = "kafka_topic", nullable = false, length = 100)
+    private String kafkaTopic;
+
+    @Column(name = "kafka_partition_key", length = 100)
+    private String kafkaPartitionKey;
+
+    @Column(columnDefinition = "json", nullable = false)
+    private String payload;
+
+    @Column(columnDefinition = "json")
+    private String headers;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OutboxEventStatus status = OutboxEventStatus.PENDING;
+
+    @Column(name = "retry_count")
+    private Integer retryCount = 0;
+
+    @Column(name = "next_retry_at")
+    private LocalDateTime nextRetryAt = LocalDateTime.now();
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt = LocalDateTime.now();
+}

--- a/src/main/java/com/moogsan/moongsan_backend/global/outbox/OutboxEventStatus.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/outbox/OutboxEventStatus.java
@@ -1,0 +1,8 @@
+package com.moogsan.moongsan_backend.global.outbox;
+
+public enum OutboxEventStatus {
+    PENDING,
+    PUBLISHED,
+    FAILED,
+    DEAD
+}

--- a/src/main/java/com/moogsan/moongsan_backend/global/outbox/OutboxWorker.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/outbox/OutboxWorker.java
@@ -1,0 +1,18 @@
+package com.moogsan.moongsan_backend.global.outbox;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxWorker {
+
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=moongsan-backend
 
-spring.config.import: optional:file:./config/application-secrets.yml
+spring.config.import=optional:file:./config/application-secrets.yml
 
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
@@ -55,3 +55,22 @@ management.endpoints.web.exposure.include=*
 
 spring.data.mongodb.uri=${MONGO_DB_URI}
 spring.data.mongodb.database=${MONGO_DB}
+
+spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS}
+
+spring.kafka.producer.acks=all
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+spring.kafka.producer.properties.enable.idempotence=true
+
+spring.kafka.consumer.group-id=${KAFKA_CONSUMER_GROUP}
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.enable-auto-commit=false
+spring.kafka.consumer.properties.spring.json.trusted.packages=com.moogsan.moongsan_backend.*
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.producer.properties.allow.auto.create.topics=false
+spring.kafka.producer.properties.spring.json.add.type.headers=true
+spring.kafka.admin.auto-create=false
+
+spring.kafka.consumer.properties.spring.json.trusted-packages=com.moogsan.moongsan_backend.domain.notification.dto

--- a/src/main/resources/db/migration/V11__create_outbox_event_table.sql
+++ b/src/main/resources/db/migration/V11__create_outbox_event_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE outbox_event (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  event_id CHAR(36) NOT NULL UNIQUE,
+  aggregate_type VARCHAR(64) NOT NULL,
+  aggregate_id VARCHAR(64) NOT NULL,
+  kafka_topic VARCHAR(100) NOT NULL,
+  kafka_partition_key VARCHAR(100),
+  payload JSON NOT NULL,
+  headers JSON,
+  status ENUM('PENDING', 'PUBLISHED', 'FAILED', 'DEAD') NOT NULL DEFAULT 'PENDING',
+  retry_count TINYINT UNSIGNED DEFAULT 0,
+  next_retry_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  published_at TIMESTAMP DEFAULT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+  KEY idx_status_created (status, created_at),
+  KEY idx_retry (status, next_retry_at),
+  KEY idx_aggregate (aggregate_type, aggregate_id)
+);

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,21 @@
+<configuration>
+
+    <!-- 스프링 부트 기본 콘솔 설정 불러오기 -->
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <!-- 루트 로거: INFO 이하 전부 차단 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <!-- 스프링·하이버네이트·데이터모듈 등 잡다한 INFO도 ERROR 이상만 -->
+    <logger name="org.springframework" level="ERROR"/>
+    <logger name="org.hibernate"         level="ERROR"/>
+    <logger name="com.zaxxer.hikari"     level="ERROR"/>
+    <logger name="org.mongodb.driver"    level="ERROR"/>
+
+    <!-- 카프카 클라이언트/컨슈머 내부 로그 완전 OFF -->
+    <logger name="org.apache.kafka"      level="ERROR"/>
+    <logger name="org.springframework.kafka" level="ERROR"/>
+
+</configuration>


### PR DESCRIPTION
## 📌 PR 개요  
- Kafka를 벤치마킹한 후 **초기 Zookeeper 3대 고정** 설정을 완료했습니다.  
- Docker Compose와 Dockerfile을 작성해 **Kafka–Zookeeper–앱** 스택을 로컬/데브 환경에서 부트스트랩했습니다.  
- Spring Boot 애플리케이션에 **Kafka Producer/Consumer** 코드를 추가해 메시지 전송과 응답을 동기 방식으로 확인했습니다.  
- application.properties만으로는 제어되지 않던 **Kafka 내부 DEBUG/INFO 로그**를 `logback-spring.xml`로 레벨 조정해 깔끔하게 출력되도록 개선했습니다.  
- Outbox 패턴 도입을 위해 **OutboxEvent 테이블(V11 마이그레이션)** 과 **OutboxWorker** 초안을 준비했습니다.  

---

## 🛠️ 주요 변경사항 상세  
1. **Zookeeper & Kafka 클러스터 구성**  
   - Zookeeper 3대, Kafka 브로커 3대를 Docker Compose로 고정했습니다.  
   - 개발 단계에서는 각 토픽의 복제 팩터(RF)를 1로 설정했고, 프로덕션 환경에서는 RF≥2를 허용하도록 추가 구현이 필요함을 명시했습니다.  

2. **Docker 환경 설정**  
   - `docker-compose.yml`과 `Dockerfile`에 Zookeeper, Kafka, Redis, Backend 컨테이너를 정의했습니다.  
   - 각 서비스의 볼륨을 분리해 데이터 영속화를 구현했으나, 볼륨 삭제 시 토픽이 함께 삭제되는 문제를 후속 과제로 남겼습니다.  

3. **Spring Kafka 연동 및 테스트**  
   - `KafkaTestController`에 `/api/kafka/send` 엔드포인트를 추가해 `KafkaTemplate<String, SimpleMessage>`로 메시지를 전송하도록 구현했습니다.  
   - `SendResult`를 동기적으로 확인하며, 성공 시 offset 로그를 출력하고 실패 시 예외를 로깅했습니다.  
   - `@KafkaListener` 기반 컨슈머(그룹 ID `dev.moongsan.test`)를 구성해 토픽 메시지 수신을 검증했습니다.  

4. **로그 레벨 최적화**  
   - 너무 많이 쌓이던 `org.apache.kafka.clients.consumer.internals` 등 내부 로그를 `WARN`/`ERROR` 이상으로 제한했습니다.  
   - `logback-spring.xml`을 작성해 `root` 및 패키지별 로그 레벨을 명시적으로 설정했습니다.  

5. **Outbox 패턴 준비**  
   - `V11__create_outbox_event_table.sql` 마이그레이션 파일을 추가해 OutboxEvent 테이블을 생성했습니다.  
   - `OutboxEventStatus` enum과 `OutboxWorker` 빈을 구현해, 향후 이벤트 저장→발행 워크플로우를 완성할 기반을 마련했습니다.  

---

## ✅ 체크리스트  
- [x] Zookeeper 3대·Kafka 3대 Docker Compose 구성 완료  
- [x] Kafka 토픽 생성 및 메시지 송수신 검증 완료  
- [x] Kafka 내부 로그 레벨 조정 확인 (`logback-spring.xml`)  
- [x] Outbox 마이그레이션 및 워커 초안 커밋 완료  

---

## 📝 향후 과제  
1. **프로덕션용 복제 팩터(RF) 동적 설정** 구현  
2. **Docker 볼륨 삭제 시 토픽 보존** 방안 마련  
3. Outbox 패턴 **이벤트 발행→처리 워크플로우 완성**  

---

## 🔗 연관 이슈  
- #252 카프카 벤치마크
- #258 카프카 도입 및 도커 파일 작성
- #259 OutBox 패턴 적용


