### PR TITLE
feat(notification): 주문 컨슈머, SSE 알림 파이프라인 구축 및 주문 E2E 테스트 완료

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/ChatNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/ChatNotificationListener.java
@@ -1,0 +1,4 @@
+package com.moogsan.moongsan_backend.adapters.kafka.listener;
+
+public class ChatNotificationListener {
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/GroupBuyNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/GroupBuyNotificationListener.java
@@ -1,0 +1,4 @@
+package com.moogsan.moongsan_backend.adapters.kafka.listener;
+
+public class GroupBuyNotificationListener {
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/OrderNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/OrderNotificationListener.java
@@ -2,6 +2,7 @@ package com.moogsan.moongsan_backend.adapters.kafka.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderCanceledEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderConfirmedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderPendingEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderRefundedEvent;
@@ -52,6 +53,23 @@ public class OrderNotificationListener {
             ack.acknowledge();
         } catch (Exception e) {
             log.error("❌ OrderConfirmedEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+
+    @KafkaListener(
+            topics = KafkaTopics.ORDER_STATUS_CANCELED,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onOrderCanceled(OrderCanceledEvent event,
+                                Acknowledgment ack) {
+        try {
+
+            log.debug("order.status.canceled 수신: {}", event);
+            useCase.handleOrderCanceled(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ OrderCanceledEvent 역직렬화 실패. raw", e);
             throw new RuntimeException(SERIALIZATION_FAIL, e);
         }
     }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/OrderCanceledEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/OrderCanceledEvent.java
@@ -14,5 +14,11 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 public class OrderCanceledEvent extends BaseEvent{
-    private Long orderId;  // 주문 아이디
+    private Long orderId;          // 주문 아이디
+    private Long groupBuyId;       // 공동구매 게시글 아이디
+    private Long hostId;           // 주최자 아이디
+    private String buyerName;      // 구매자 성명
+    private String buyerBank;      // 구매자 은행
+    private String buyerAccount;   // 구매자 계좌 번호
+    private int price;             // 환불 금액
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/OrderConfirmedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/OrderConfirmedEvent.java
@@ -14,5 +14,9 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 public class OrderConfirmedEvent extends BaseEvent{
-    private Long orderId;  // 주문 아이디
+    private Long orderId;          // 주문 아이디
+    private Long groupBuyId;       // 공동구매 게시글 아이디
+    private Long participantId;    // 구매자 아이디
+    private String buyerName;      // 구매자 성명
+    private String groupBuyName;   // 공동구매 게시글 제목
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/OrderRefundedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/OrderRefundedEvent.java
@@ -14,5 +14,9 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 public class OrderRefundedEvent extends BaseEvent{
-    private Long orderId;  // 주문 아이디
+    private Long orderId;          // 주문 아이디
+    private Long groupBuyId;       // 공동구매 게시글 아이디
+    private Long participantId;    // 구매자 아이디
+    private String buyerName;      // 구매자 성명
+    private String groupBuyName;   // 공동구매 게시글 제목
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/OrderEventMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/OrderEventMapper.java
@@ -28,25 +28,46 @@ public class OrderEventMapper {
     }
 
     // 주문 확인 이벤트
-    public OrderConfirmedEvent toConfirmedEvent(Long orderId) {
+    public OrderConfirmedEvent toConfirmedEvent(
+            Long orderId, Long groupBuyId, Long participantId, String buyerName, String groupBuyName
+    ) {
         return OrderConfirmedEvent.builder()
                 .orderId(orderId)
+                .groupBuyId(groupBuyId)
+                .participantId(participantId)
+                .buyerName(buyerName)
+                .groupBuyName(groupBuyName)
                 .occurredAt(Instant.now().toString())
                 .build();
     }
 
     // 주문 취소 이벤트
-    public OrderCanceledEvent toCanceledEvent(Long orderId) {
+    public OrderCanceledEvent toCanceledEvent(
+            Long orderId, Long groupBuyId, Long hostId, String buyerName, String buyerBank, String buyerAccount, int price
+
+    ) {
         return OrderCanceledEvent.builder()
                 .orderId(orderId)
+                .groupBuyId(groupBuyId)
+                .hostId(hostId)
+                .buyerName(buyerName)
+                .buyerBank(buyerBank)
+                .buyerAccount(buyerAccount)
+                .price(price)
                 .occurredAt(Instant.now().toString())
                 .build();
     }
 
     // 주문 환불 이벤트
-    public OrderRefundedEvent toRefundedEvent(Long orderId) {
+    public OrderRefundedEvent toRefundedEvent(
+            Long orderId, Long groupBuyId, Long participantId, String buyerName, String groupBuyName
+    ) {
         return OrderRefundedEvent.builder()
                 .orderId(orderId)
+                .groupBuyId(groupBuyId)
+                .participantId(participantId)
+                .buyerName(buyerName)
+                .groupBuyName(groupBuyName)
                 .occurredAt(Instant.now().toString())
                 .build();
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
@@ -16,14 +16,29 @@ public enum NotificationType {
     ORDER_CONFIRMED(
             KafkaTopics.ORDER_STATUS_CONFIRMED,
             "주문이 확정됐어요!",
-            "{buyerName}님의 주문이 확정됐습니다."
+            "{groupBuyTitle}: {buyerName}님의 주문이 확정됐습니다."
+    ),
+
+    ORDER_CANCELED(
+            KafkaTopics.ORDER_STATUS_CANCELED,
+            "주문이 취소됐어요!",
+            "{buyerName}님의 주문이 취소되었습니다.\n" +
+                    "■ 환불 계좌  : {buyerBank} {buyerAccount}\n" +
+                    "■ 환불 금액  : {price}원\n\n" +
+                    "영업일 1일 이내로 환불을 진행해 주세요."
+    ),
+
+    ORDER_REFUNDED(
+            KafkaTopics.ORDER_STATUS_REFUNDED,
+            "환불이 완료됐어요!",
+            "{groupBuyTitle}: {buyerName}님의 주문에 대한 환불이 완료됐습니다."
     ),
 
     // ──────── 공동구매 상태 ────────
     GROUPBUY_PICKUP_UPDATED(
             KafkaTopics.GROUPBUY_PICKUP_UPDATED,
             "픽업 일정 변경",
-            "새 픽업일: {pickupDate}"
+            "새 픽업일: {pickupDate}, 변경 사유: {dateModificationReason}"
     );
 
     // ───────── 필드 ─────────

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/SendOrderNotificationUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/SendOrderNotificationUseCase.java
@@ -1,7 +1,10 @@
 package com.moogsan.moongsan_backend.domain.notification.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderCanceledEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderConfirmedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderPendingEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderRefundedEvent;
 import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
 import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
 import com.moogsan.moongsan_backend.domain.notification.template.NotificationPayload;
@@ -14,13 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SendOrderNotificationUseCase {
 
     private final SseEmitterRepository emitterRepository;
     private final NotificationTemplateRegistry templateRegistry;
     private final ObjectMapper objectMapper;
 
-    @Transactional(readOnly = true)
     public void handleOrderPending(OrderPendingEvent event) {
 
         Long hostId = event.getHostId();
@@ -30,7 +33,7 @@ public class SendOrderNotificationUseCase {
         }
 
         String title = templateRegistry.title(NotificationType.ORDER_PENDING);
-        String body = templateRegistry.title(NotificationType.ORDER_PENDING)
+        String body = templateRegistry.body(NotificationType.ORDER_PENDING)
                         .replace("{buyerName}", event.getBuyerName())
                         .replace("{qty}", String.valueOf(event.getQuantity()));
 
@@ -41,6 +44,74 @@ public class SendOrderNotificationUseCase {
                 payload);
 
         log.debug("✅ 알림 전송 완료: hostId={}, orderId={}", hostId, event.getOrderId());
+    }
+
+    public void handleOrderConfirmed(OrderConfirmedEvent event) {
+
+        Long participantId = event.getParticipantId();
+        if (participantId == null) {
+            log.warn("participantId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.ORDER_CONFIRMED);
+        String body = templateRegistry.body(NotificationType.ORDER_CONFIRMED)
+                .replace("{groupBuyTitle}", event.getGroupBuyName())
+                .replace("{buyerName}", event.getBuyerName());
+
+        NotificationPayload payload = new NotificationPayload(title, body, event);
+
+        emitterRepository.send(participantId.toString(),
+                NotificationType.ORDER_CONFIRMED.name(),
+                payload);
+
+        log.debug("✅ 알림 전송 완료: hostId={}, orderId={}", participantId, event.getOrderId());
+    }
+
+    public void handleOrderCanceled(OrderCanceledEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.ORDER_CANCELED);
+        String body = templateRegistry.body(NotificationType.ORDER_CANCELED)
+                .replace("{buyerName}", event.getBuyerName())
+                .replace("{buyerBank}", event.getBuyerBank())
+                .replace("{buyerAccount}", event.getBuyerAccount())
+                .replace("{price}", String.valueOf(event.getPrice()));
+
+        NotificationPayload payload = new NotificationPayload(title, body, event);
+
+        emitterRepository.send(hostId.toString(),
+                NotificationType.ORDER_CANCELED.name(),
+                payload);
+
+        log.debug("✅ 알림 전송 완료: hostId={}, orderId={}", hostId, event.getOrderId());
+    }
+
+    public void handleOrderRefunded(OrderRefundedEvent event) {
+
+        Long participantId = event.getParticipantId();
+        if (participantId == null) {
+            log.warn("participantId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.ORDER_REFUNDED);
+        String body = templateRegistry.body(NotificationType.ORDER_REFUNDED)
+                .replace("{groupBuyTitle}", event.getGroupBuyName())
+                .replace("{buyerName}", event.getBuyerName());
+
+        NotificationPayload payload = new NotificationPayload(title, body, event);
+
+        emitterRepository.send(participantId.toString(),
+                NotificationType.ORDER_REFUNDED.name(),
+                payload);
+
+        log.debug("✅ 알림 전송 완료: hostId={}, orderId={}", participantId, event.getOrderId());
     }
 
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderStatusUpdateService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderStatusUpdateService.java
@@ -7,6 +7,8 @@ import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderConfirmedEv
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderPendingEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.OrderEventMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import com.moogsan.moongsan_backend.domain.order.dto.request.OrderStatusUpdateRequest;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
@@ -26,6 +28,7 @@ import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIAL
 @RequiredArgsConstructor
 public class OrderStatusUpdateService {
     private final OrderRepository orderRepository;
+    private final GroupBuyRepository groupBuyRepository;
     private final KafkaEventPublisher kafkaEventPublisher;
     private final OrderEventMapper eventMapper;
     private final ObjectMapper objectMapper;
@@ -43,17 +46,42 @@ public class OrderStatusUpdateService {
             Object eventDto;
             String topic;
 
+            GroupBuy groupBuy = order.getGroupBuy();
+
             switch (currentStatus) {
                 case "CONFIRMED":
-                    eventDto = eventMapper.toConfirmedEvent(order.getId());
+                    eventDto = eventMapper.toConfirmedEvent(
+                            order.getId(),
+                            groupBuy.getId(),
+                            order.getUser().getId(),
+                            order.getUser().getNickname(),
+                            groupBuy.getTitle()
+                    );
                     topic = ORDER_STATUS_CONFIRMED;
                     break;
                 case "CANCELED":
-                    eventDto = eventMapper.toCanceledEvent(order.getId());
+                    int price = order.getPrice();
+                    int quantity = order.getQuantity();
+                    int totalPrice = price * quantity;
+                    eventDto = eventMapper.toCanceledEvent(
+                            order.getId(),
+                            groupBuy.getId(),
+                            groupBuy.getUser().getId(),
+                            order.getUser().getNickname(),
+                            order.getUser().getAccountBank(),
+                            order.getUser().getAccountNumber(),
+                            totalPrice
+                    );
                     topic = ORDER_STATUS_CANCELED;
                     break;
                 case "REFUNDED":
-                    eventDto = eventMapper.toRefundedEvent(order.getId());
+                    eventDto = eventMapper.toRefundedEvent(
+                            order.getId(),
+                            groupBuy.getId(),
+                            order.getUser().getId(),
+                            order.getUser().getNickname(),
+                            groupBuy.getTitle()
+                    );
                     topic = ORDER_STATUS_REFUNDED;
                     break;
                 default:

--- a/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderStatusUpdateService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderStatusUpdateService.java
@@ -28,7 +28,6 @@ import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIAL
 @RequiredArgsConstructor
 public class OrderStatusUpdateService {
     private final OrderRepository orderRepository;
-    private final GroupBuyRepository groupBuyRepository;
     private final KafkaEventPublisher kafkaEventPublisher;
     private final OrderEventMapper eventMapper;
     private final ObjectMapper objectMapper;
@@ -58,21 +57,6 @@ public class OrderStatusUpdateService {
                             groupBuy.getTitle()
                     );
                     topic = ORDER_STATUS_CONFIRMED;
-                    break;
-                case "CANCELED":
-                    int price = order.getPrice();
-                    int quantity = order.getQuantity();
-                    int totalPrice = price * quantity;
-                    eventDto = eventMapper.toCanceledEvent(
-                            order.getId(),
-                            groupBuy.getId(),
-                            groupBuy.getUser().getId(),
-                            order.getUser().getNickname(),
-                            order.getUser().getAccountBank(),
-                            order.getUser().getAccountNumber(),
-                            totalPrice
-                    );
-                    topic = ORDER_STATUS_CANCELED;
                     break;
                 case "REFUNDED":
                     eventDto = eventMapper.toRefundedEvent(

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/LeaveGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/LeaveGroupBuyTest.java
@@ -1,5 +1,9 @@
 package com.moogsan.moongsan_backend.unit.groupbuy.service.command;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEventMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.OrderEventMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.domain.chatting.participant.Facade.command.ChattingCommandFacade;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
@@ -33,12 +37,12 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class LeaveGroupBuyTest {
-    @Mock
-    private GroupBuyRepository groupBuyRepository;
-    @Mock
-    private OrderRepository orderRepository;
-    @Mock
-    private DueSoonPolicy dueSoonPolicy;
+    @Mock private GroupBuyRepository groupBuyRepository;
+    @Mock private OrderRepository orderRepository;
+    @Mock private DueSoonPolicy dueSoonPolicy;
+    @Mock private KafkaEventPublisher kafkaEventPublisher;
+    @Mock private OrderEventMapper eventMapper;
+    @Mock private ObjectMapper objectMapper;
     @Mock private ChattingCommandFacade chattingCommandFacade;
 
     private LeaveGroupBuy leaveGroupBuy;
@@ -66,6 +70,9 @@ public class LeaveGroupBuyTest {
                 orderRepository,
                 dueSoonPolicy,
                 chattingCommandFacade,
+                kafkaEventPublisher,
+                eventMapper,
+                objectMapper,
                 fixedClock
         );
     }


### PR DESCRIPTION
## 🔎 작업 개요
- **Notification 서브도메인** 초판 도입 → Kafka Consumer → SSE Push 파이프라인 구축  
- **Order 이벤트 컨슈머**(대기‧확정‧취소‧환불) 로직 적용  
- **실시간 알림 인프라 구성**  
  - `SseEmitterRepository`, `NotificationType`, `NotificationTemplateRegistry` 신규 도입  
- **주문 End-to-End 테스트** 구현 (#265)  
- Kafka Listener 컨테이너팩토리 & JSON Deserializer 설정 리팩터링  

---

## 🛠️ 주요 변경 사항

| 범주 | 변경 내역 |
| ---- | -------- |
| **Kafka Consumer** | `KafkaNotificationListener` 추가<br>  • `ORDER_STATUS_PENDING` 수신 & manual ack<br>  • `ConsumerGroups.NOTIFICATION` 상수 정의 |
| **Notification** | `NotificationType` enum / `NotificationTemplateRegistry` 신설<br>`SendOrderNotificationUseCase` → 호스트 대상 알림 전송<br>`SseEmitterRepository` (동시성 안전) & `/api/sse/notifications` 컨트롤러 |
| **DTO** | `OrderPendingEvent` 필드 확장 (`hostId`, `buyerName`, `quantity`) |
| **Config** | `KafkaConfig` → `JsonDeserializer` 기반, manual commit, retry-backoff 설정 |
| **테스트** | `OrderFlowE2ETest` : Testcontainers-Kafka 로 주문 전환 전 과정 검증 |

---

## ✅ 검증 방법
1.  통합 테스트 통과 완료
2. curl 및 포스트맨으로 api 호출, 이벤트 트리거 로그 및 알림 응답 확인

## ➕ 이슈 링크  
- #270 공동구매, 채팅, 주문 Service에 이벤트 발행 부착
- #273 group-id 구체화 및 이벤트 별 컨슈머 로직 작성
- #264 SSE Gateway 개발
- #263 Notification 도메인 코드 작성
- #265 End to End 테스트

