### PR TITLE
feat(notification): Order 이벤트 수신 · 알림 API · E2E 테스트 통합

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/OrderNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/OrderNotificationListener.java
@@ -2,6 +2,7 @@ package com.moogsan.moongsan_backend.adapters.kafka.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderCanceledEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderConfirmedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderPendingEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderRefundedEvent;

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/OrderNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/OrderNotificationListener.java
@@ -2,7 +2,6 @@ package com.moogsan.moongsan_backend.adapters.kafka.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics;
-import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderCanceledEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderConfirmedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderPendingEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderRefundedEvent;

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/repository/CategoryRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/repository/CategoryRepository.java
@@ -2,6 +2,8 @@ package com.moogsan.moongsan_backend.domain.groupbuy.repository;
 
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/controller/NotificationCommandController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/controller/NotificationCommandController.java
@@ -1,0 +1,32 @@
+package com.moogsan.moongsan_backend.domain.notification.controller;
+
+import com.moogsan.moongsan_backend.domain.WrapperResponse;
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationReadStatus;
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationResponse;
+import com.moogsan.moongsan_backend.domain.notification.dto.PagedResponse;
+import com.moogsan.moongsan_backend.domain.notification.service.GetPastNotifications;
+import com.moogsan.moongsan_backend.domain.notification.service.NotificationMarkAsRead;
+import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/sse")
+public class NotificationCommandController {
+
+    private final NotificationMarkAsRead notificationMarkAsRead;
+
+    @PatchMapping("/{notificationId}")
+    public ResponseEntity<WrapperResponse<PagedResponse<NotificationResponse>>> getPastNotifications(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long notificationId,
+            @RequestBody NotificationReadStatus request) {
+
+        notificationMarkAsRead.execute(userDetails.getUser().getId(), notificationId, request);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/controller/NotificationListController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/controller/NotificationListController.java
@@ -1,0 +1,45 @@
+package com.moogsan.moongsan_backend.domain.notification.controller;
+
+import com.moogsan.moongsan_backend.domain.WrapperResponse;
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationResponse;
+import com.moogsan.moongsan_backend.domain.notification.dto.PagedResponse;
+import com.moogsan.moongsan_backend.domain.notification.service.GetPastNotifications;
+import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
+import com.moogsan.moongsan_backend.global.exception.specific.UnauthenticatedAccessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.moogsan.moongsan_backend.domain.notification.message.ResponseMessage.GET_PAST_NOTIFICATION_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/sse")
+public class NotificationListController {
+
+    private final GetPastNotifications getPastNotifications;
+
+    @GetMapping("/latest")
+    public ResponseEntity<WrapperResponse<PagedResponse<NotificationResponse>>> getPastNotifications(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false, defaultValue = "10") int size
+    ) {
+        if (userDetails == null) throw new UnauthenticatedAccessException("로그인이 필요합니다.");
+
+        PagedResponse<NotificationResponse> response = getPastNotifications
+                .getPastNotifications(userDetails.getUser().getId(), cursorId, size);
+
+        return ResponseEntity.ok(
+                WrapperResponse.<PagedResponse<NotificationResponse>>builder()
+                        .message(GET_PAST_NOTIFICATION_SUCCESS)
+                        .data(response)
+                        .build());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/dto/NotificationReadStatus.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/dto/NotificationReadStatus.java
@@ -1,0 +1,12 @@
+package com.moogsan.moongsan_backend.domain.notification.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class NotificationReadStatus {
+
+    private Boolean read;
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,19 @@
+package com.moogsan.moongsan_backend.domain.notification.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class NotificationResponse {
+
+    private Long id;
+    private String title;
+    private String body;
+    private String type;
+    private LocalDateTime createdAt;
+    private boolean read;
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/dto/PagedResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/dto/PagedResponse.java
@@ -1,0 +1,15 @@
+package com.moogsan.moongsan_backend.domain.notification.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PagedResponse<T> {
+
+    private List<T> items;
+    private Long nextCursor;
+    private boolean hasNext;
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/Notification.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/Notification.java
@@ -1,18 +1,51 @@
 package com.moogsan.moongsan_backend.domain.notification.entity;
 
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
+@Table(name = "notification")
 public class Notification {
-    private final Long receiverId;
-    private final String title;
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private Long receiverId;
+    private String title;
     private String body;
+
+    @Enumerated(EnumType.STRING)
     private NotificationType notificationType;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
     private Map<String, Object> data;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime readAt;
+
+    @Builder.Default
+    @Column(columnDefinition = "bit(1) default 0", name = "`read`")
+    private Boolean read = false;
+
+    public void markAsRead(Boolean read) {
+        if (!Boolean.TRUE.equals(this.read)) {
+            this.read = true;
+            this.readAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/exception/base/NotiException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/exception/base/NotiException.java
@@ -1,0 +1,26 @@
+package com.moogsan.moongsan_backend.domain.notification.exception.base;
+
+import com.moogsan.moongsan_backend.domain.chatting.participant.exception.code.ChattingErrorCode;
+import com.moogsan.moongsan_backend.domain.groupbuy.exception.code.GroupBuyErrorCode;
+import com.moogsan.moongsan_backend.domain.notification.exception.code.NotiErrorCode;
+import com.moogsan.moongsan_backend.global.exception.base.BusinessException;
+
+import java.util.Map;
+
+public class NotiException extends BusinessException {
+    public NotiException(NotiErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public NotiException(NotiErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public NotiException(NotiErrorCode errorCode, Map<String, Object> parameters) {
+        super(errorCode, parameters);
+    }
+
+    public NotiException(NotiErrorCode errorCode, String message, Map<String, Object> parameters) {
+        super(errorCode, message, parameters);
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/exception/code/NotiErrorCode.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/exception/code/NotiErrorCode.java
@@ -1,0 +1,19 @@
+package com.moogsan.moongsan_backend.domain.notification.exception.code;
+
+import com.moogsan.moongsan_backend.global.exception.code.ErrorCodeType;
+import org.springframework.http.HttpStatus;
+
+public enum NotiErrorCode implements ErrorCodeType {
+    NOTI_NOT_FOUND("NOTI_NOT_FOUND", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final HttpStatus status;
+
+    NotiErrorCode(String code, HttpStatus status) {
+        this.code = code;
+        this.status = status;
+    }
+
+    public String getCode() { return code; }
+    public HttpStatus getStatus() { return status; }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/exception/specific/NotiNotFoundException.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/exception/specific/NotiNotFoundException.java
@@ -1,0 +1,17 @@
+package com.moogsan.moongsan_backend.domain.notification.exception.specific;
+
+import com.moogsan.moongsan_backend.domain.notification.exception.base.NotiException;
+import com.moogsan.moongsan_backend.domain.notification.exception.code.NotiErrorCode;
+
+import static com.moogsan.moongsan_backend.domain.notification.exception.code.NotiErrorCode.NOTI_NOT_FOUND;
+import static com.moogsan.moongsan_backend.domain.notification.message.ResponseMessage.NOTIFICATION_NOT_FOUND;
+
+public class NotiNotFoundException extends NotiException {
+    public NotiNotFoundException() {
+        super(NOTI_NOT_FOUND, NOTIFICATION_NOT_FOUND);
+    }
+
+    public NotiNotFoundException(String message) {
+        super(NOTI_NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/factory/NotificationFactory.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/factory/NotificationFactory.java
@@ -1,0 +1,42 @@
+package com.moogsan.moongsan_backend.domain.notification.factory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationFactory {
+
+    private final NotificationTemplateRegistry registry;
+    private final ObjectMapper objectMapper;
+
+    public Notification create(
+            NotificationType type, Long receiverId, Object event, Map<String, String> variables
+    ) {
+        String title = registry.title(type);
+        String body = registry.body(type);
+
+        for (Map.Entry<String, String> entry : variables.entrySet()) {
+            body = body.replace("{" + entry.getKey() + "}", entry.getValue());
+        }
+
+        Map<String, Object> data = objectMapper.convertValue(event, Map.class);
+
+        return Notification.builder()
+                .receiverId(receiverId)
+                .title(title)
+                .body(body)
+                .notificationType(type)
+                .data(data)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/mapper/NotificationMapper.java
@@ -1,4 +1,18 @@
 package com.moogsan.moongsan_backend.domain.notification.mapper;
 
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationResponse;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+
 public class NotificationMapper {
+
+    public static NotificationResponse toNotificationReponse(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .title(notification.getTitle())
+                .body(notification.getBody())
+                .type(notification.getNotificationType().toString())
+                .createdAt(notification.getCreatedAt())
+                .read(notification.getRead())
+                .build();
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/message/ResponseMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/message/ResponseMessage.java
@@ -1,0 +1,16 @@
+package com.moogsan.moongsan_backend.domain.notification.message;
+
+public final class ResponseMessage {
+
+    private ResponseMessage() {
+    }
+
+    /// SUCCESS
+
+    public static final String GET_PAST_NOTIFICATION_SUCCESS =
+            "과거 알람을 성공적으로 조회했습니다.";
+
+    /// FAIL
+    public static final String NOTIFICATION_NOT_FOUND =
+            "존재하지 않는 알림입니다.";
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,19 @@
+package com.moogsan.moongsan_backend.domain.notification.repository;
+
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // cursorId 없을 때
+    List<Notification> findByReceiverIdOrderByIdDesc(Long receiverId, Pageable pageable);
+
+    // cursorId 있을 때
+    List<Notification> findByReceiverIdAndIdLessThanOrderByIdDesc(
+            Long receiverId, Long cursorId, Pageable pageable);
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GetPastNotifications.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GetPastNotifications.java
@@ -1,0 +1,50 @@
+package com.moogsan.moongsan_backend.domain.notification.service;
+
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationResponse;
+import com.moogsan.moongsan_backend.domain.notification.dto.PagedResponse;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.mapper.NotificationMapper;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GetPastNotifications {
+
+    private final NotificationRepository notificationRepository;
+
+    public PagedResponse<NotificationResponse> getPastNotifications(Long userId, Long cursorId, int size) {
+
+        Pageable page = PageRequest.of(0, size + 1);
+
+        List<Notification> raw = (cursorId == null)
+                ? notificationRepository.findByReceiverIdOrderByIdDesc(userId, page)
+                : notificationRepository.findByReceiverIdAndIdLessThanOrderByIdDesc(userId, cursorId, page);
+
+        boolean hasNext = raw.size() > size;
+
+        if (hasNext) raw = raw.subList(0, size);
+
+        List<NotificationResponse> items = raw.stream()
+                .map(NotificationMapper::toNotificationReponse)
+                .toList();
+
+        Long nextCursor = hasNext ? raw.getLast().getId() : null;
+
+        return PagedResponse.<NotificationResponse>builder()
+                .items(items)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/NotificationMarkAsRead.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/NotificationMarkAsRead.java
@@ -1,0 +1,30 @@
+package com.moogsan.moongsan_backend.domain.notification.service;
+
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationReadStatus;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.exception.specific.NotiNotFoundException;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationMarkAsRead {
+
+    private final NotificationRepository notificationRepository;
+
+    public void execute(Long userId, Long notificationId, NotificationReadStatus request) {
+
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(NotiNotFoundException::new);
+
+        notification.markAsRead(request.getRead());
+
+        notificationRepository.save(notification);
+
+    }
+}

--- a/src/main/resources/db/migration/V12__create_notification_table.sql
+++ b/src/main/resources/db/migration/V12__create_notification_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE notification (
+    id                BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    receiver_id       BIGINT UNSIGNED NOT NULL,
+    title             VARCHAR(200)  NOT NULL,
+    body              TEXT          NOT NULL,
+    notification_type VARCHAR(50)   NOT NULL,
+    data              JSON          NULL,
+    created_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    read_at           DATETIME      NULL,
+    `read`            BIT(1)        NOT NULL DEFAULT 0,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_notification_user_unread
+    ON notification (receiver_id, `read`, created_at DESC);


### PR DESCRIPTION
## 🔎 작업 개요
- **Order 도메인 이벤트 컨슈머** 로직을 적용해 알림 발행 파이프라인 완성
- 주문 생성 → 확인 → 취소 → 환불 **End-to-End 테스트** 구축으로 회귀 안정성 확보
- **과거 알림 조회·읽음 처리 API** 구현

---

## 🛠️ 주요 변경 사항
- **Consumer / Use-Case**
  - Kafka Order 이벤트 수신 → `SendOrderNotificationUseCase` 확장
  - 주문 생성·확인·취소·환불 이벤트별 알림 템플릿 매핑
- **API**
  - `NotificationListController` : `GET /api/notifications/latest` (커서 기반 페이징)
  - `NotificationCommandController` : `PATCH /api/notifications/{id}` (읽음 처리)
- **DTO·Mapper**
  - `PagedResponse`, `NotificationReadStatus` 신규 도입
  - `NotificationMapper` 리팩터링 (엔티티 ↔ DTO 변환)
- **Repository**
  - `findByReceiverIdAndIdLessThanOrderByIdDesc` 커서 쿼리 추가
- **Exception / Message**
  - 알림 전용 예외 계층(`NotiException`, `NotiErrorCode`) 정의
  - `ResponseMessage` 값 추가·정비
- **Entity**
  - `Notification`에 `@NoArgsConstructor(access = PROTECTED)` 추가
  - `read` 컬럼 예약어 충돌 방지를 위해 백틱(`\``read`\``) 적용
- **Test**
  - 주문 플로우 **E2E 시나리오** 완성 (MockKafka + Testcontainers)

---

## ✅ 검증 방법
1. **단위 테스트** 모두 통과
2. 로컬 수동 검증 통과

## 🔍 머지 전 확인사항
- [x] DB 마이그레이션 스크립트 적용 여부
- [x] application-prod.yml Kafka 토픽 설정 PR 반영 후 배포
- [x] api 명세서 작성 여부

## ➕ 이슈 링크
- closes #273
- closes #265
- closes #276