### PR TITLE
feat(notification): 공구 알림 기능 전반 구현 및 E2E 테스트 완료

### DIFF
--- a/infra/scripts/create-topics.sh
+++ b/infra/scripts/create-topics.sh
@@ -29,6 +29,9 @@ docker exec -it kafka-1 kafka-topics.sh --create --bootstrap-server ${BROKER} \
   --partitions 2 --replication-factor 3 --topic groupbuy.status.closed
 
 docker exec -it kafka-1 kafka-topics.sh --create --bootstrap-server ${BROKER} \
+  --partitions 2 --replication-factor 3 --topic groupbuy.status.finalized
+
+docker exec -it kafka-1 kafka-topics.sh --create --bootstrap-server ${BROKER} \
   --partitions 2 --replication-factor 3 --topic groupbuy.status.ended
 
 # 주문 상태

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/GroupBuyNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/GroupBuyNotificationListener.java
@@ -1,4 +1,81 @@
 package com.moogsan.moongsan_backend.adapters.kafka.listener;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyPickupUpdatedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusClosedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusEndedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderPendingEvent;
+import com.moogsan.moongsan_backend.domain.notification.service.GroupBuy.SendGroupBuyClosedNotiUseCase;
+import com.moogsan.moongsan_backend.domain.notification.service.GroupBuy.SendGroupBuyEndedNotiUseCase;
+import com.moogsan.moongsan_backend.domain.notification.service.GroupBuy.SendPickupChangedNotiUseCase;
+import com.moogsan.moongsan_backend.domain.notification.service.SendOrderNotificationUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIALIZATION_FAIL;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class GroupBuyNotificationListener {
+
+    private final SendGroupBuyClosedNotiUseCase useCase;
+    private final SendGroupBuyEndedNotiUseCase endedNotiUseCase;
+    private final SendPickupChangedNotiUseCase pickupChangedNotiUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopics.GROUPBUY_STATUS_CLOSED,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onGroupBuyClosed(GroupBuyStatusClosedEvent event,
+                                 Acknowledgment ack) {
+        try {
+
+            log.debug("groupBuy.status.closed 수신: {}", event);
+            useCase.handleGroupBuyClosed(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ GroupBuyStatusClosedEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+
+    @KafkaListener(
+            topics = KafkaTopics.GROUPBUY_STATUS_ENDED,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onGroupBuyClosed(GroupBuyStatusEndedEvent event,
+                                 Acknowledgment ack) {
+        try {
+
+            log.debug("groupBuy.status.ended 수신: {}", event);
+            endedNotiUseCase.handleGroupBuyEnded(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ GroupBuyStatusEndedEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+
+    @KafkaListener(
+            topics = KafkaTopics.GROUPBUY_PICKUP_UPDATED,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onGroupBuyClosed(GroupBuyPickupUpdatedEvent event,
+                                 Acknowledgment ack) {
+        try {
+
+            log.debug("groupBuy.pickup.updated 수신: {}", event);
+            pickupChangedNotiUseCase.handleGroupBuyPickupChanged(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ GroupBuyPickupUpdatedEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/KafkaTopics.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/KafkaTopics.java
@@ -14,6 +14,7 @@ public interface KafkaTopics {
     String GROUPBUY_PICKUP_APPROACHING = "groupbuy.pickup.approaching";
     String GROUPBUY_DUE_APPROACHING = "groupbuy.due.approaching";
     String GROUPBUY_STATUS_CLOSED = "groupbuy.status.closed";
+    String GROUPBUY_STATUS_FINALIZED = "groupbuy.status.finalized";
     String GROUPBUY_STATUS_ENDED = "groupbuy.status.ended";
 
     // 주문 상태 관련 이벤트

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyDueApproachingEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyDueApproachingEvent.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.List;
+
 /**
  * 토픽: groupbuy.due.approaching
  * 설명: 공구 마감일 임박 알림용 이벤트
@@ -14,5 +16,10 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 public class GroupBuyDueApproachingEvent extends BaseEvent{
-    private Long groupBuyId;  // 공구 게시글 아이디
+    private Long groupBuyId;                // 공구 게시글 아이디
+    private Long hostId;                    // 공구 주최자 아이디
+    private String groupBuyTitle;           // 공구 게시글 제목
+    private List<Long> participantIds;      // 공구 참여자 아이디 리스트
+    private String participantCount;        // 공구 참여자 수
+    private String leftQty;                 // 남은 상품 수
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyPickupApproachingEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyPickupApproachingEvent.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.List;
+
 /**
  * 토픽: groupbuy.pickup.approaching
  * 설명: 공구 픽업일 임박 알림용 이벤트
@@ -14,5 +16,10 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 public class GroupBuyPickupApproachingEvent extends BaseEvent{
-    private Long groupBuyId;  // 공구 게시글 아이디
+    private Long groupBuyId;                // 공구 게시글 아이디
+    private Long hostId;                    // 공구 주최자 아이디
+    private String groupBuyTitle;           // 공구 게시글 제목
+    private List<Long> participantIds;      // 공구 참여자 아이디 리스트
+    private String participantCount;        // 공구 참여자 수
+    private String totalQty;                // 전체 상품 수
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyPickupUpdatedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyPickupUpdatedEvent.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.List;
+
 /**
  * 토픽: groupbuy.pickup.updated
  * 설명: 공구 픽업일 변경 알림용 이벤트
@@ -14,5 +16,9 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 public class GroupBuyPickupUpdatedEvent extends BaseEvent{
-    private Long groupBuyId;  // 공구 게시글 아이디
+    private Long groupBuyId;                // 공구 게시글 아이디
+    private List<Long> participantIds;      // 공구 참여자 아이디 리스트
+    private String groupBuyTitle;           // 공구 게시글 제목
+    private String pickupDate;              // 새로운 공구 픽업일자
+    private String dateModificationReason;  // 공구 픽업일자 변경 사유
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusClosedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusClosedEvent.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.List;
+
 /**
  * 토픽: groupbuy.status.closed
  * 설명: 공구 모집 마감 알림용 이벤트
@@ -14,6 +16,10 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 public class GroupBuyStatusClosedEvent extends BaseEvent{
-    private Long groupBuyId;  // 공구 게시글 아이디
-    private String newStatus; // 공구 게시글 상태
+    private Long groupBuyId;            // 공구 게시글 아이디
+    private Long hostId;                // 공구 주최자 아아디
+    private List<Long> participantIds;  // 공구 참여자 아이디 리스트
+    private String groupBuyTitle;       // 공구 게시글 제목
+    private String participantCount;    // 공구 참여자 수
+    private String totalQty;            // 공구 거래량 수
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusEndedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusEndedEvent.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.List;
+
 /**
  * 토픽: groupbuy.status.ended
  * 설명: 공구 종료 알림용 이벤트
@@ -14,6 +16,10 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 public class GroupBuyStatusEndedEvent extends BaseEvent{
-    private Long groupBuyId;  // 공구 게시글 아이디
-    private String newStatus; // 공구 게시글 상태
+    private Long groupBuyId;            // 공구 게시글 아이디
+    private Long hostId;                // 공구 주최자 아아디
+    private List<Long> participantIds;  // 공구 참여자 아이디 리스트
+    private String groupBuyTitle;       // 공구 게시글 제목
+    private String participantCount;    // 공구 참여자 수
+    private String totalQty;            // 공구 거래량 수
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusEndedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusEndedEvent.java
@@ -20,6 +20,4 @@ public class GroupBuyStatusEndedEvent extends BaseEvent{
     private Long hostId;                // 공구 주최자 아아디
     private List<Long> participantIds;  // 공구 참여자 아이디 리스트
     private String groupBuyTitle;       // 공구 게시글 제목
-    private String participantCount;    // 공구 참여자 수
-    private String totalQty;            // 공구 거래량 수
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusFinalizedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusFinalizedEvent.java
@@ -1,0 +1,4 @@
+package com.moogsan.moongsan_backend.adapters.kafka.producer.dto;
+
+public class GroupBuyStatusFinalizedEvent {
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusFinalizedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusFinalizedEvent.java
@@ -1,4 +1,25 @@
 package com.moogsan.moongsan_backend.adapters.kafka.producer.dto;
 
-public class GroupBuyStatusFinalizedEvent {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+/**
+ * 토픽: groupbuy.status.finalized
+ * 설명: 공구 체결 알림용 이벤트
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class GroupBuyStatusFinalizedEvent extends BaseEvent{
+    private Long groupBuyId;            // 공구 게시글 아이디
+    private Long hostId;                // 공구 주최자 아아디
+    private List<Long> participantIds;  // 공구 참여자 아이디 리스트
+    private String groupBuyTitle;       // 공구 게시글 제목
+    private String participantCount;    // 공구 참여자 수
+    private String totalQty;                // 전체 상품 수
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
@@ -28,16 +28,28 @@ public class GroupBuyEventMapper {
 
     // 공동구매 마감 이벤트
     public GroupBuyStatusEndedEvent toGroupBuyEndedEvent(
-            Long groupBuyId, Long hostId, List<Long> participantIds, String groupBuyTitle,
-            String participantCount, String totalQty
+            Long groupBuyId, Long hostId, List<Long> participantIds, String groupBuyTitle
     ) {
         return GroupBuyStatusEndedEvent.builder()
                 .groupBuyId(groupBuyId)
                 .hostId(hostId)
                 .participantIds(participantIds)
                 .groupBuyTitle(groupBuyTitle)
+                .occurredAt(Instant.now().toString())
+                .build();
+    }
+
+    // 공동구매 마감 이벤트
+    public GroupBuyStatusFinalizedEvent toGroupBuyFinalizedEvent(
+            Long groupBuyId, Long hostId, List<Long> participantIds, String groupBuyTitle,
+            String participantCount, String totalQty
+    ) {
+        return GroupBuyStatusFinalizedEvent.builder()
+                .groupBuyId(groupBuyId)
+                .hostId(hostId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
                 .participantCount(participantCount)
-                .totalQty(totalQty)
                 .occurredAt(Instant.now().toString())
                 .build();
     }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
@@ -43,17 +43,33 @@ public class GroupBuyEventMapper {
     }
 
     // 공동구매 마감일자 임박 이벤트
-    public GroupBuyDueApproachingEvent toGroupBuyDueApproachingEvent(GroupBuy groupBuy) {
+    public GroupBuyDueApproachingEvent toGroupBuyDueApproachingEvent(
+            Long groupBuyId, Long hostId, String groupBuyTitle,
+            List<Long> participantIds, String participantCount, String leftQty
+    ) {
         return GroupBuyDueApproachingEvent.builder()
-                .groupBuyId(groupBuy.getId())
+                .groupBuyId(groupBuyId)
+                .hostId(hostId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
+                .participantCount(participantCount)
+                .leftQty(leftQty)
                 .occurredAt(Instant.now().toString())
                 .build();
     }
 
     // 공동구매 픽업일자 임박 이벤트
-    public GroupBuyPickupApproachingEvent toGroupBuyPickupApproachingEvent(GroupBuy groupBuy) {
+    public GroupBuyPickupApproachingEvent toGroupBuyPickupApproachingEvent(
+            Long groupBuyId, Long hostId, String groupBuyTitle,
+            List<Long> participantIds, String participantCount, String totalQty
+    ) {
         return GroupBuyPickupApproachingEvent.builder()
-                .groupBuyId(groupBuy.getId())
+                .groupBuyId(groupBuyId)
+                .hostId(hostId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
+                .participantCount(participantCount)
+                .totalQty(totalQty)
                 .occurredAt(Instant.now().toString())
                 .build();
     }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
@@ -5,24 +5,39 @@ import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
+import java.util.List;
 
 @Component
 public class GroupBuyEventMapper {
 
     // 공동구매 모집 종료 이벤트
-    public GroupBuyStatusClosedEvent toGroupBuyClosedEvent(GroupBuy groupBuy, String newStatus) {
+    public GroupBuyStatusClosedEvent toGroupBuyClosedEvent(
+            Long groupBuyId, Long hostId, List<Long> participantIds, String groupBuyTitle,
+            String participantCount, String totalQty
+    ) {
         return GroupBuyStatusClosedEvent.builder()
-                .groupBuyId(groupBuy.getId())
-                .newStatus(newStatus)
+                .groupBuyId(groupBuyId)
+                .hostId(hostId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
+                .participantCount(participantCount)
+                .totalQty(totalQty)
                 .occurredAt(Instant.now().toString())
                 .build();
     }
 
     // 공동구매 마감 이벤트
-    public GroupBuyStatusEndedEvent toGroupBuyEndedEvent(GroupBuy groupBuy, String newStatus) {
+    public GroupBuyStatusEndedEvent toGroupBuyEndedEvent(
+            Long groupBuyId, Long hostId, List<Long> participantIds, String groupBuyTitle,
+            String participantCount, String totalQty
+    ) {
         return GroupBuyStatusEndedEvent.builder()
-                .groupBuyId(groupBuy.getId())
-                .newStatus(newStatus)
+                .groupBuyId(groupBuyId)
+                .hostId(hostId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
+                .participantCount(participantCount)
+                .totalQty(totalQty)
                 .occurredAt(Instant.now().toString())
                 .build();
     }
@@ -44,9 +59,16 @@ public class GroupBuyEventMapper {
     }
 
     // 공동구매 픽업일자 변경 이벤트
-    public GroupBuyPickupUpdatedEvent toGroupBuyPickupUpdatedEvent(GroupBuy groupBuy) {
+    public GroupBuyPickupUpdatedEvent toGroupBuyPickupUpdatedEvent(
+            Long groupBuyId, List<Long> participantIds, String groupBuyTitle,
+            String pickupDate, String dateModificationReason
+    ) {
         return GroupBuyPickupUpdatedEvent.builder()
-                .groupBuyId(groupBuy.getId())
+                .groupBuyId(groupBuyId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
+                .pickupDate(pickupDate)
+                .dateModificationReason(dateModificationReason)
                 .occurredAt(Instant.now().toString())
                 .build();
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
@@ -57,7 +57,7 @@ public class EndGroupBuy {
             throw new GroupBuyInvalidStateException(AFTER_ENDED);
         }
 
-        if (!groupBuy.isFixed()) {
+        if (!groupBuy.isFinalized()) {
             throw new GroupBuyInvalidStateException(BEFORE_FIXED);
         }
 
@@ -86,9 +86,7 @@ public class EndGroupBuy {
                             groupBuy.getId(),
                             groupBuy.getUser().getId(),
                             participantIds,
-                            groupBuy.getTitle(),
-                            String.valueOf(groupBuy.getParticipantCount()),
-                            String.valueOf(groupBuy.getTotalAmount())
+                            groupBuy.getTitle()
                     );
             String payload = objectMapper.writeValueAsString(eventDto);
             kafkaEventPublisher.publish(GROUPBUY_STATUS_ENDED, String.valueOf(groupBuy.getId()), payload);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndPastPickupGroupBuys.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndPastPickupGroupBuys.java
@@ -54,9 +54,7 @@ public class EndPastPickupGroupBuys {
                                 gb.getId(),
                                 gb.getUser().getId(),
                                 participantIds,
-                                gb.getTitle(),
-                                String.valueOf(gb.getParticipantCount()),
-                                String.valueOf(gb.getTotalAmount())
+                                gb.getTitle()
                         );
                 String payload = objectMapper.writeValueAsString(eventDto);
                 kafkaEventPublisher.publish(GROUPBUY_STATUS_ENDED, String.valueOf(gb.getId()), payload);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/FinalizeGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/FinalizeGroupBuy.java
@@ -1,36 +1,87 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusEndedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusFinalizedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEventMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics.GROUPBUY_STATUS_ENDED;
+import static com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics.GROUPBUY_STATUS_FINALIZED;
+import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIALIZATION_FAIL;
+
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class FinalizeGroupBuy {
 
     private final OrderRepository orderRepository;
+    private final KafkaEventPublisher publisher;
+    private final GroupBuyEventMapper mapper;
+    private final ObjectMapper objectMapper;
 
     public void finalizeGroupBuy(GroupBuy groupBuy) {
 
-        Long groupBuyId = groupBuy.getId();
+        // 이미 확정이면 바로 반환 (중복차단)
+        if (groupBuy.isFixed()) return;
 
-        // 공구에 속한 취소되지 않은 모든 주문 조회
-        List<Order> validOrders = orderRepository.findByGroupBuyIdAndStatusNot(groupBuyId, "CANCELED");
+        // 유효 주문 수 & 미확정 주문 수 한 번에 구하기
+        long totalValid   = orderRepository.countByGroupBuyIdAndStatusNotIn(
+                groupBuy.getId(),
+                List.of("CANCELED", "REFUNDED"));
+        long unconfirmed  = orderRepository.countByGroupBuyIdAndStatusNot(
+                groupBuy.getId(),
+                "CONFIRMED");
 
-        // 모든 주문이 CONFIRMED 상태인지 확인
-        boolean allConfirmed = validOrders.stream()
-                .allMatch(order -> order.getStatus().equals("CONFIRMED"));
+        // 확정 판정
+        if (totalValid > 0 && unconfirmed == 0) {
+            groupBuy.setFixed(true);          // 플래그 갱신
 
-        // 조건 만족 시 공구 체결 처리
-        if (allConfirmed && !groupBuy.isFixed()) {
-            groupBuy.setFixed(true);
+            publishFinalizedEvent(groupBuy);  // 오직 '이번'에만 호출
         }
+    }
 
+    private void publishFinalizedEvent(GroupBuy groupBuy) {
+        try {
+            // 참여자 ID 모으기 — 필요할 때만 SELECT
+            List<Order> orders = orderRepository.findAllByGroupBuyIdOrderByStatusCustom(groupBuy.getId());
+
+            List<Long> participantIds = orders.stream()
+                    .map(order -> order.getUser().getId())
+                    .distinct()
+                    .toList();
+
+            GroupBuyStatusFinalizedEvent dto =
+                    mapper.toGroupBuyFinalizedEvent(
+                            groupBuy.getId(),
+                            groupBuy.getUser().getId(),
+                            participantIds,
+                            groupBuy.getTitle(),
+                            String.valueOf(groupBuy.getParticipantCount()),
+                            String.valueOf(groupBuy.getTotalAmount())
+                    );
+
+            publisher.publish(
+                    GROUPBUY_STATUS_FINALIZED,
+                    String.valueOf(groupBuy.getId()),
+                    objectMapper.writeValueAsString(dto)
+            );
+            log.info("✅ GroupBuy finalized: id={}", groupBuy.getId());
+
+        } catch (JsonProcessingException e) {
+            log.error("❌ 역직렬화 실패 (GroupBuyStatusFinalizedEvent)", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/PublishPickupApproachingEvents.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/PublishPickupApproachingEvents.java
@@ -7,6 +7,8 @@ import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEvent
 import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.order.entity.Order;
+import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -25,6 +27,7 @@ import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIAL
 @RequiredArgsConstructor
 public class PublishPickupApproachingEvents {
     private final GroupBuyRepository groupBuyRepository;
+    private final OrderRepository orderRepository;
     private final KafkaEventPublisher kafkaEventPublisher;
     private final GroupBuyEventMapper eventMapper;
     private final ObjectMapper objectMapper;
@@ -36,8 +39,22 @@ public class PublishPickupApproachingEvents {
 
         for (GroupBuy gb : toEnd) {
             try {
+                List<Order> orders = orderRepository.findAllByGroupBuyIdOrderByStatusCustom(gb.getId());
+
+                List<Long> participantIds = orders.stream()
+                        .map(order -> order.getUser().getId())
+                        .distinct()
+                        .toList();
+
                 GroupBuyPickupApproachingEvent eventDto =
-                        eventMapper.toGroupBuyPickupApproachingEvent(gb);
+                        eventMapper.toGroupBuyPickupApproachingEvent(
+                                gb.getId(),
+                                gb.getUser().getId(),
+                                gb.getTitle(),
+                                participantIds,
+                                String.valueOf(gb.getParticipantCount()),
+                                String.valueOf(gb.getTotalAmount())
+                        );
                 String payload = objectMapper.writeValueAsString(eventDto);
                 kafkaEventPublisher.publish(GROUPBUY_PICKUP_APPROACHING, String.valueOf(gb.getId()), payload);
             } catch (JsonProcessingException e) {

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
@@ -10,7 +10,7 @@ public enum NotificationType {
     ORDER_PENDING(
             KafkaTopics.ORDER_STATUS_PENDING,
             "주문이 들어왔어요!",
-            "{buyerName}님이 {qty}개를 주문했습니다."
+            "{buyerName}님이 {qty}개를 주문했어요. 입금 확인 후 주문을 확정해주세요!"
     ),
 
     ORDER_CONFIRMED(
@@ -43,13 +43,20 @@ public enum NotificationType {
                     "■ 총 주문 수량 : {totalQty}개\n\n"
     ),
 
+    GROUPBUY_STATUS_FINALIZED(
+            KafkaTopics.GROUPBUY_STATUS_FINALIZED,
+            "공구가 확정되었어요!",
+            "{groupBuyTitle}: 모든 주문이 확인되어 공구가 확정되었습니다.\n" +
+                    "■ 확정 참여 인원 : {participantCount}명\n" +
+                    "■ 총 주문 수량 : {totalQty}개\n\n" +
+                    "함께 뭉쳐주셔서 감사합니다!"
+    ),
+
     GROUPBUY_STATUS_ENDED(
             KafkaTopics.GROUPBUY_STATUS_ENDED,
             "공구가 종료됐어요!",
             "{groupBuyTitle}: 공구가 최종 종료되었습니다. {extraMessage}\n" +
-                    "■ 최종 참여 인원 : {participantCount}명\n" +
-                    "■ 총 주문 수량 : {totalQty}개\n\n" +
-                    "공구는 만족스러우셨나요? 다음 공구에도 힘을 보태 주세요!"
+                    "공구는 만족스러우셨나요? 다음 공구에서도 뭉티기가 되어 주세요!"
     ),
 
     GROUPBUY_DUE_APPROACHING(

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
@@ -35,9 +35,26 @@ public enum NotificationType {
     ),
 
     // ──────── 공동구매 상태 ────────
+    GROUPBUY_STATUS_CLOSED(
+            KafkaTopics.GROUPBUY_STATUS_CLOSED,
+            "공구 참여자 모집이 마감됐어요!",
+            "{groupBuyTitle}: 모집이 마감됐습니다!\n" +
+                    "■ 총 참여 인원 : {participantCount}명\n" +
+                    "■ 총 주문 수량 : {totalQty}개\n\n"
+    ),
+
+    GROUPBUY_STATUS_ENDED(
+            KafkaTopics.GROUPBUY_STATUS_ENDED,
+            "공구가 종료됐어요!",
+            "{groupBuyTitle}: 공구가 최종 종료되었습니다. {extraMessage}\n" +
+                    "■ 최종 참여 인원 : {participantCount}명\n" +
+                    "■ 총 주문 수량 : {totalQty}개\n\n" +
+                    "공구는 만족스러우셨나요? 다음 공구에도 힘을 보태 주세요!"
+    ),
+
     GROUPBUY_PICKUP_UPDATED(
             KafkaTopics.GROUPBUY_PICKUP_UPDATED,
-            "픽업 일정 변경",
+            "픽업 일정이 변경되었어요!",
             "새 픽업일: {pickupDate}, 변경 사유: {dateModificationReason}"
     );
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
@@ -52,6 +52,26 @@ public enum NotificationType {
                     "공구는 만족스러우셨나요? 다음 공구에도 힘을 보태 주세요!"
     ),
 
+    GROUPBUY_DUE_APPROACHING(
+            KafkaTopics.GROUPBUY_DUE_APPROACHING,
+            "마감 D-1! 내일 자정에 종료됩니다 🕛",
+            "{groupBuyTitle}: 모집 마감이 하루 남았어요.{extraMessage}\n" +
+                    "■ 현재 참여 인원 : {participantCount}명\n" +
+                    "■ 남은 주문 수량 : {LeftQty}개\n\n" +
+                    "필요하다면 오늘 안에 수량을 조정하시거나\n" +
+                    "친구에게 소식을 살짝 전해 보세요 😉"
+    ),
+
+    GROUPBUY_PICKUP_APPROACHING(
+            KafkaTopics.GROUPBUY_PICKUP_APPROACHING,
+            "픽업 D-1! 내일 수령을 준비해주세요 📦",
+            "{groupBuyTitle}: 상품 수령일이 내일입니다.{extraMessage}\n" +
+                    "■ 참여 인원 : {participantCount}명\n" +
+                    "■ 총 주문 수량 : {totalQty}개\n\n" +
+                    "수령 장소·시간을 다시 한 번 확인하시고,\n" +
+                    "문의 사항은 채팅방에 남겨주세요. 감사합니다!"
+    ),
+
     GROUPBUY_PICKUP_UPDATED(
             KafkaTopics.GROUPBUY_PICKUP_UPDATED,
             "픽업 일정이 변경되었어요!",

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyClosedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyClosedNotiUseCase.java
@@ -1,0 +1,87 @@
+package com.moogsan.moongsan_backend.domain.notification.service.GroupBuy;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusClosedEvent;
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.factory.NotificationFactory;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationPayload;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendGroupBuyClosedNotiUseCase {
+
+    private final SseEmitterRepository emitterRepository;
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationFactory notificationFactory;
+    private final NotificationRepository notificationRepository;
+
+    public void handleGroupBuyClosed(GroupBuyStatusClosedEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_STATUS_CLOSED);
+        String body = templateRegistry.body(NotificationType.GROUPBUY_STATUS_CLOSED)
+                .replace("{groupBuyTitle}", event.getGroupBuyTitle())
+                .replace("{participantCount}", String.valueOf(event.getParticipantCount()))
+                .replace("{totalQty}", String.valueOf(event.getTotalQty()));
+
+        NotificationPayload payload = new NotificationPayload(title, body, event);
+
+        Notification hostNoti = notificationFactory.create(
+                NotificationType.GROUPBUY_STATUS_CLOSED,
+                hostId,
+                event,
+                Map.of(
+                        "groupBuyTitle", event.getGroupBuyTitle(),
+                        "participantCount", event.getParticipantCount(),
+                        "totalQty", String.valueOf(event.getTotalQty())
+                )
+        );
+
+        List<Notification> participantNotis = event.getParticipantIds().stream()
+                .filter(id -> !id.equals(hostId))
+                .map(id -> notificationFactory.create(
+                        NotificationType.GROUPBUY_STATUS_CLOSED,
+                        id,
+                        event,
+                        Map.of(
+                                "groupBuyTitle", event.getGroupBuyTitle(),
+                                "participantCount", event.getParticipantCount(),
+                                "totalQty", String.valueOf(event.getTotalQty())
+                        )
+                ))
+                .toList();
+
+        notificationRepository.saveAll(Stream.concat(
+                Stream.of(hostNoti),
+                participantNotis.stream()
+        ).toList());
+
+        emitterRepository.send(hostId.toString(),
+                NotificationType.GROUPBUY_STATUS_CLOSED.name(),
+                payload);
+
+        participantNotis.forEach(noti ->
+                emitterRepository.send(noti.getReceiverId().toString(),
+                        NotificationType.GROUPBUY_STATUS_CLOSED.name(), payload));
+
+        log.debug("✅ 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyDueApproachingNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyDueApproachingNotiUseCase.java
@@ -1,0 +1,87 @@
+package com.moogsan.moongsan_backend.domain.notification.service.GroupBuy;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyDueApproachingEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusEndedEvent;
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.factory.NotificationFactory;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationPayload;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendGroupBuyDueApproachingNotiUseCase {
+
+    private final SseEmitterRepository emitterRepository;
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationFactory notificationFactory;
+    private final NotificationRepository notificationRepository;
+
+    public void handleGroupBuyDueApproaching(GroupBuyDueApproachingEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_DUE_APPROACHING);
+        String body = templateRegistry.body(NotificationType.GROUPBUY_DUE_APPROACHING);
+
+        NotificationPayload payload = new NotificationPayload(title, body, event);
+
+        Notification hostNoti = notificationFactory.create(
+                NotificationType.GROUPBUY_DUE_APPROACHING,
+                hostId,
+                event,
+                Map.of(
+                        "groupBuyTitle", event.getGroupBuyTitle(),
+                        "participantCount", event.getParticipantCount(),
+                        "totalQty", String.valueOf(event.getLeftQty()),
+                        "extraMessage","채팅방에 확인 메세지를 보내주세요!"
+                )
+        );
+
+        List<Notification> participantNotis = event.getParticipantIds().stream()
+                .filter(id -> !id.equals(hostId))
+                .map(id -> notificationFactory.create(
+                        NotificationType.GROUPBUY_DUE_APPROACHING,
+                        id,
+                        event,
+                        Map.of(
+                                "groupBuyTitle", event.getGroupBuyTitle(),
+                                "participantCount", event.getParticipantCount(),
+                                "totalQty", String.valueOf(event.getLeftQty()),
+                                "extraMessage", "주최자의 메세지를 확인해주세요!"
+                        )
+                ))
+                .toList();
+
+        notificationRepository.saveAll(Stream.concat(
+                Stream.of(hostNoti),
+                participantNotis.stream()
+        ).toList());
+
+        emitterRepository.send(hostId.toString(),
+                NotificationType.GROUPBUY_DUE_APPROACHING.name(),
+                payload);
+
+        participantNotis.forEach(noti ->
+                emitterRepository.send(noti.getReceiverId().toString(),
+                        NotificationType.GROUPBUY_DUE_APPROACHING.name(), payload));
+
+        log.debug("✅ 공구 종료 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyEndedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyEndedNotiUseCase.java
@@ -48,8 +48,6 @@ public class SendGroupBuyEndedNotiUseCase {
                 event,
                 Map.of(
                         "groupBuyTitle", event.getGroupBuyTitle(),
-                        "participantCount", event.getParticipantCount(),
-                        "totalQty", String.valueOf(event.getTotalQty()),
                         "extraMessage","다음 공구에서 만나요!"
                         )
         );
@@ -62,8 +60,6 @@ public class SendGroupBuyEndedNotiUseCase {
                         event,
                         Map.of(
                                 "groupBuyTitle", event.getGroupBuyTitle(),
-                                "participantCount", event.getParticipantCount(),
-                                "totalQty", String.valueOf(event.getTotalQty()),
                                 "extraMessage", "참여해 주셔서 감사합니다! 🎉"
                         )
                 ))

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyEndedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyEndedNotiUseCase.java
@@ -1,0 +1,87 @@
+package com.moogsan.moongsan_backend.domain.notification.service.GroupBuy;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusClosedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusEndedEvent;
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.factory.NotificationFactory;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationPayload;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendGroupBuyEndedNotiUseCase {
+
+    private final SseEmitterRepository emitterRepository;
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationFactory notificationFactory;
+    private final NotificationRepository notificationRepository;
+
+    public void handleGroupBuyEnded(GroupBuyStatusEndedEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_STATUS_ENDED);
+        String body = templateRegistry.body(NotificationType.GROUPBUY_STATUS_ENDED);
+
+        NotificationPayload payload = new NotificationPayload(title, body, event);
+
+        Notification hostNoti = notificationFactory.create(
+                NotificationType.GROUPBUY_STATUS_ENDED,
+                hostId,
+                event,
+                Map.of(
+                        "groupBuyTitle", event.getGroupBuyTitle(),
+                        "participantCount", event.getParticipantCount(),
+                        "totalQty", String.valueOf(event.getTotalQty()),
+                        "extraMessage","다음 공구에서 만나요!"
+                        )
+        );
+
+        List<Notification> participantNotis = event.getParticipantIds().stream()
+                .filter(id -> !id.equals(hostId))
+                .map(id -> notificationFactory.create(
+                        NotificationType.GROUPBUY_STATUS_ENDED,
+                        id,
+                        event,
+                        Map.of(
+                                "groupBuyTitle", event.getGroupBuyTitle(),
+                                "participantCount", event.getParticipantCount(),
+                                "totalQty", String.valueOf(event.getTotalQty()),
+                                "extraMessage", "참여해 주셔서 감사합니다! 🎉"
+                        )
+                ))
+                .toList();
+
+        notificationRepository.saveAll(Stream.concat(
+                Stream.of(hostNoti),
+                participantNotis.stream()
+        ).toList());
+
+        emitterRepository.send(hostId.toString(),
+                NotificationType.GROUPBUY_STATUS_ENDED.name(),
+                payload);
+
+        participantNotis.forEach(noti ->
+                emitterRepository.send(noti.getReceiverId().toString(),
+                        NotificationType.GROUPBUY_STATUS_ENDED.name(), payload));
+
+        log.debug("✅ 공구 종료 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyFinalizedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyFinalizedNotiUseCase.java
@@ -1,4 +1,87 @@
 package com.moogsan.moongsan_backend.domain.notification.service.GroupBuy;
 
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusClosedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusFinalizedEvent;
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.factory.NotificationFactory;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationPayload;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class SendGroupBuyFinalizedNotiUseCase {
+    private final SseEmitterRepository emitterRepository;
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationFactory notificationFactory;
+    private final NotificationRepository notificationRepository;
+
+    public void handleGroupBuyFinalized(GroupBuyStatusFinalizedEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_STATUS_FINALIZED);
+        String body = templateRegistry.body(NotificationType.GROUPBUY_STATUS_FINALIZED)
+                .replace("{groupBuyTitle}", event.getGroupBuyTitle())
+                .replace("{participantCount}", String.valueOf(event.getParticipantCount()))
+                .replace("{totalQty}", String.valueOf(event.getTotalQty()));
+
+        NotificationPayload payload = new NotificationPayload(title, body, event);
+
+        Notification hostNoti = notificationFactory.create(
+                NotificationType.GROUPBUY_STATUS_FINALIZED,
+                hostId,
+                event,
+                Map.of(
+                        "groupBuyTitle", event.getGroupBuyTitle(),
+                        "participantCount", event.getParticipantCount(),
+                        "totalQty", String.valueOf(event.getTotalQty())
+                )
+        );
+
+        List<Notification> participantNotis = event.getParticipantIds().stream()
+                .filter(id -> !id.equals(hostId))
+                .map(id -> notificationFactory.create(
+                        NotificationType.GROUPBUY_STATUS_FINALIZED,
+                        id,
+                        event,
+                        Map.of(
+                                "groupBuyTitle", event.getGroupBuyTitle(),
+                                "participantCount", event.getParticipantCount(),
+                                "totalQty", String.valueOf(event.getTotalQty())
+                        )
+                ))
+                .toList();
+
+        notificationRepository.saveAll(Stream.concat(
+                Stream.of(hostNoti),
+                participantNotis.stream()
+        ).toList());
+
+        emitterRepository.send(hostId.toString(),
+                NotificationType.GROUPBUY_STATUS_FINALIZED.name(),
+                payload);
+
+        participantNotis.forEach(noti ->
+                emitterRepository.send(noti.getReceiverId().toString(),
+                        NotificationType.GROUPBUY_STATUS_FINALIZED.name(), payload));
+
+        log.debug("✅ 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyFinalizedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyFinalizedNotiUseCase.java
@@ -1,0 +1,4 @@
+package com.moogsan.moongsan_backend.domain.notification.service.GroupBuy;
+
+public class SendGroupBuyFinalizedNotiUseCase {
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyPickupApproachingNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyPickupApproachingNotiUseCase.java
@@ -1,0 +1,87 @@
+package com.moogsan.moongsan_backend.domain.notification.service.GroupBuy;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyDueApproachingEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyPickupApproachingEvent;
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.factory.NotificationFactory;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationPayload;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendGroupBuyPickupApproachingNotiUseCase {
+
+    private final SseEmitterRepository emitterRepository;
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationFactory notificationFactory;
+    private final NotificationRepository notificationRepository;
+
+    public void handleGroupBuyPickupApproaching(GroupBuyPickupApproachingEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_PICKUP_APPROACHING);
+        String body = templateRegistry.body(NotificationType.GROUPBUY_PICKUP_APPROACHING);
+
+        NotificationPayload payload = new NotificationPayload(title, body, event);
+
+        Notification hostNoti = notificationFactory.create(
+                NotificationType.GROUPBUY_PICKUP_APPROACHING,
+                hostId,
+                event,
+                Map.of(
+                        "groupBuyTitle", event.getGroupBuyTitle(),
+                        "participantCount", event.getParticipantCount(),
+                        "totalQty", String.valueOf(event.getTotalQty()),
+                        "extraMessage","채팅방에 확인 메세지를 보내주세요!"
+                )
+        );
+
+        List<Notification> participantNotis = event.getParticipantIds().stream()
+                .filter(id -> !id.equals(hostId))
+                .map(id -> notificationFactory.create(
+                        NotificationType.GROUPBUY_PICKUP_APPROACHING,
+                        id,
+                        event,
+                        Map.of(
+                                "groupBuyTitle", event.getGroupBuyTitle(),
+                                "participantCount", event.getParticipantCount(),
+                                "totalQty", String.valueOf(event.getTotalQty()),
+                                "extraMessage", "주최자의 메세지를 확인해주세요!"
+                        )
+                ))
+                .toList();
+
+        notificationRepository.saveAll(Stream.concat(
+                Stream.of(hostNoti),
+                participantNotis.stream()
+        ).toList());
+
+        emitterRepository.send(hostId.toString(),
+                NotificationType.GROUPBUY_PICKUP_APPROACHING.name(),
+                payload);
+
+        participantNotis.forEach(noti ->
+                emitterRepository.send(noti.getReceiverId().toString(),
+                        NotificationType.GROUPBUY_PICKUP_APPROACHING.name(), payload));
+
+        log.debug("✅ 공구 종료 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendPickupChangedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendPickupChangedNotiUseCase.java
@@ -1,0 +1,58 @@
+package com.moogsan.moongsan_backend.domain.notification.service.GroupBuy;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyPickupUpdatedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusClosedEvent;
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.factory.NotificationFactory;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationPayload;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendPickupChangedNotiUseCase {
+    private final SseEmitterRepository emitterRepository;
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationFactory notificationFactory;
+    private final NotificationRepository notificationRepository;
+
+    public void handleGroupBuyPickupChanged(GroupBuyPickupUpdatedEvent event) {
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_PICKUP_UPDATED);
+        String body = templateRegistry.body(NotificationType.GROUPBUY_PICKUP_UPDATED);
+
+        NotificationPayload payload = new NotificationPayload(title, body, event);
+
+        List<Notification> participantNotis = event.getParticipantIds().stream()
+                .map(id -> notificationFactory.create(
+                        NotificationType.GROUPBUY_PICKUP_UPDATED,
+                        id,
+                        event,
+                        Map.of(
+                                "pickupDate", event.getPickupDate(),
+                                "dateModificationReason", event.getDateModificationReason()
+                        )
+                ))
+                .toList();
+
+        notificationRepository.saveAll(participantNotis);
+
+        participantNotis.forEach(noti ->
+                emitterRepository.send(noti.getReceiverId().toString(),
+                        NotificationType.GROUPBUY_PICKUP_UPDATED.name(), payload));
+
+        log.debug("✅ 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/order/repository/OrderRepository.java
@@ -34,7 +34,9 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     int countByUserIdAndGroupBuyIdAndStatusIn(Long userId, Long groupBuyId, List<String> statuses);
 
     // 특정 공구의 주문 목록 확인
+    long countByGroupBuyIdAndStatusNotIn(Long groupBuyId, List<String> statuses);
     List<Order> findByGroupBuyIdAndStatusNot(Long groupBuyId, String status);
+    List<Order> findByGroupBuyIdAndStatusNotIn(Long groupBuyId, List<String> statuses);
 
     // 모든 공구의 컨펌, 취소되지 않은 주문 검사
     List<Order> findAllByCreatedAtBeforeAndStatusNotAndStatusNot(

--- a/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderStatusUpdateService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderStatusUpdateService.java
@@ -9,6 +9,7 @@ import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.OrderEventMap
 import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.FinalizeGroupBuy;
 import com.moogsan.moongsan_backend.domain.order.dto.request.OrderStatusUpdateRequest;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
@@ -27,6 +28,7 @@ import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIAL
 @Service
 @RequiredArgsConstructor
 public class OrderStatusUpdateService {
+    private final FinalizeGroupBuy finalizeGroupBuy;
     private final OrderRepository orderRepository;
     private final KafkaEventPublisher kafkaEventPublisher;
     private final OrderEventMapper eventMapper;
@@ -39,6 +41,10 @@ public class OrderStatusUpdateService {
             ).orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "주문을 찾을 수 없습니다."));
 
             order.updateStatus(request.getStatus());
+
+            if (request.getStatus().equals("CONFIRMED")){
+                finalizeGroupBuy.finalizeGroupBuy(order.getGroupBuy());
+            }
 
             String currentStatus = request.getStatus();
 

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/UpdateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/UpdateGroupBuyTest.java
@@ -15,6 +15,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandServi
 import com.moogsan.moongsan_backend.domain.image.entity.Image;
 import com.moogsan.moongsan_backend.domain.image.mapper.ImageMapper;
 import com.moogsan.moongsan_backend.domain.image.service.S3Service;
+import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +41,9 @@ class UpdateGroupBuyTest {
 
     @Mock
     private GroupBuyRepository groupBuyRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
 
     @Mock
     private ImageMapper imageMapper;
@@ -111,6 +115,7 @@ class UpdateGroupBuyTest {
 
         updateGroupBuy = new UpdateGroupBuy(
                 groupBuyRepository,
+                orderRepository,
                 imageMapper,
                 s3Service,
                 eventMapper,


### PR DESCRIPTION
## 🔎 작업 개요
- 공구 도메인 전반에 걸친 알림 기능(모집 마감, 종료, 하루 전, 체결, 픽업일 변경)을 통합 구현하고  
  End-to-End 테스트를 작성하여 각 시나리오별 알림 정상 동작을 검증했습니다.

## 🛠️ 주요 변경 사항
- **모집 마감 알림**  
  - `GROUPBUY_DUE_APPROACHING` 토픽 구독 및 모집 마감 시 알림 발송 로직 추가  
- **종료 알림**  
  - `GROUPBUY_STATUS_ENDED` 이벤트 처리 및 공구 종료 시 메시지 발송  
- **하루 전 알림**  
  - 모집 마감ㆍ종료 하루 전 알림(`GROUPBUY_DUE_APPROACHING`, `GROUPBUY_PICKUP_APPROACHING`) 구현  
- **체결 알림**  
  - 모든 주문이 확정되면 `GROUPBUY_STATUS_FINALIZED` 이벤트 발행 및 알림 처리  
- **픽업일 변경 알림**  
  - 픽업일자 변경 시 `GROUPBUY_PICKUP_APPROACHING` 이벤트 구독 및 알림 추가  
- **E2E 테스트**  
  - 각 알림 시나리오에 대한 End-to-End 테스트 케이스 작성  
  - CI 파이프라인에 `./gradlew e2eTest` 통합

## ✅ 검증 방법
1. 로컬 Kafka 클러스터 및 애플리케이션 실행  
2. 수동으로 각 이벤트(topic) 발행  
3. SSE 또는 Kafka Consumer 로 알림 메시지 수신 확인  
4. `./gradlew e2eTest` 실행 후 모든 E2E 테스트 통과 여부 검증

## 🔍 머지 전 확인사항
- [x] 알림 템플릿 메시지 문구 및 변수 치환 검수  
- [x] `infra/scripts/create-topics.sh` 와 실제 Kafka 토픽 설정 동기화  
- [x] E2E 테스트 실패 케이스 없음  
- [x] 관련 이슈(#273, #265)에 링크 및 코멘트 반영

## ➕ 이슈 링크
- #273 
- #265 