### PR TITLE
refactor(notification): SSE 이벤트 및 과거 알림 조회 형식 통일

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/GroupBuyNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/GroupBuyNotificationListener.java
@@ -1,0 +1,96 @@
+package com.moogsan.moongsan_backend.adapters.kafka.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.*;
+import com.moogsan.moongsan_backend.domain.notification.service.useCase.GroupBuy.SendGroupBuyClosedNotiUseCase;
+import com.moogsan.moongsan_backend.domain.notification.service.useCase.GroupBuy.SendGroupBuyEndedNotiUseCase;
+import com.moogsan.moongsan_backend.domain.notification.service.useCase.GroupBuy.SendGroupBuyFinalizedNotiUseCase;
+import com.moogsan.moongsan_backend.domain.notification.service.useCase.GroupBuy.SendPickupChangedNotiUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIALIZATION_FAIL;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GroupBuyNotificationListener {
+
+    private final SendGroupBuyClosedNotiUseCase useCase;
+    private final SendGroupBuyEndedNotiUseCase endedNotiUseCase;
+    private final SendGroupBuyFinalizedNotiUseCase finalizedNotiUseCase;
+    private final SendPickupChangedNotiUseCase pickupChangedNotiUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopics.GROUPBUY_STATUS_CLOSED,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onGroupBuyClosed(GroupBuyStatusClosedEvent event,
+                                 Acknowledgment ack) {
+        try {
+
+            log.debug("groupBuy.status.closed 수신: {}", event);
+            useCase.handleGroupBuyClosed(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ GroupBuyStatusClosedEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+
+    @KafkaListener(
+            topics = KafkaTopics.GROUPBUY_STATUS_FINALIZED,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onGroupBuyFinalized(GroupBuyStatusFinalizedEvent event,
+                                    Acknowledgment ack) {
+        try {
+
+            log.debug("groupBuy.status.finalized 수신: {}", event);
+            finalizedNotiUseCase.handleGroupBuyFinalized(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ GroupBuyStatusFinalizedEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+
+    @KafkaListener(
+            topics = KafkaTopics.GROUPBUY_STATUS_ENDED,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onGroupBuyEnded(GroupBuyStatusEndedEvent event,
+                                 Acknowledgment ack) {
+        try {
+
+            log.debug("groupBuy.status.ended 수신: {}", event);
+            endedNotiUseCase.handleGroupBuyEnded(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ GroupBuyStatusEndedEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+
+    @KafkaListener(
+            topics = KafkaTopics.GROUPBUY_PICKUP_UPDATED,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onGroupBuyClosed(GroupBuyPickupUpdatedEvent event,
+                                 Acknowledgment ack) {
+        try {
+
+            log.debug("groupBuy.pickup.updated 수신: {}", event);
+            pickupChangedNotiUseCase.handleGroupBuyPickupChanged(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ GroupBuyPickupUpdatedEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/OrderNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/OrderNotificationListener.java
@@ -1,0 +1,95 @@
+package com.moogsan.moongsan_backend.adapters.kafka.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderCanceledEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderConfirmedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderPendingEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderRefundedEvent;
+import com.moogsan.moongsan_backend.domain.notification.service.useCase.Order.SendOrderNotificationUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIALIZATION_FAIL;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderNotificationListener {
+
+    private final SendOrderNotificationUseCase useCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopics.ORDER_STATUS_PENDING,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onOrderPending(OrderPendingEvent event,
+                               Acknowledgment ack) {
+        try {
+
+            log.debug("order.status.pending 수신: {}", event);
+            useCase.handleOrderPending(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ OrderPendingEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+
+    @KafkaListener(
+            topics = KafkaTopics.ORDER_STATUS_CONFIRMED,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onOrderConfirmed(OrderConfirmedEvent event,
+                                 Acknowledgment ack) {
+        try {
+
+            log.debug("order.status.confirmed 수신: {}", event);
+            useCase.handleOrderConfirmed(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ OrderConfirmedEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+
+    @KafkaListener(
+            topics = KafkaTopics.ORDER_STATUS_CANCELED,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onOrderCanceled(OrderCanceledEvent event,
+                                Acknowledgment ack) {
+        try {
+
+            log.debug("order.status.canceled 수신: {}", event);
+            useCase.handleOrderCanceled(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ OrderCanceledEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+
+
+
+    @KafkaListener(
+            topics = KafkaTopics.ORDER_STATUS_REFUNDED,
+            groupId = ConsumerGroups.NOTIFICATION
+    )
+    public void onOrderRefunded(OrderRefundedEvent event,
+                                 Acknowledgment ack) {
+        try {
+
+            log.debug("order.status.refunded 수신: {}", event);
+            useCase.handleOrderRefunded(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ OrderRefundedEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusFinalizedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusFinalizedEvent.java
@@ -1,0 +1,4 @@
+package com.moogsan.moongsan_backend.adapters.kafka.producer.dto;
+
+public class GroupBuyStatusFinalizedEvent {
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusFinalizedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuyStatusFinalizedEvent.java
@@ -1,4 +1,25 @@
 package com.moogsan.moongsan_backend.adapters.kafka.producer.dto;
 
-public class GroupBuyStatusFinalizedEvent {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+/**
+ * 토픽: groupbuy.status.finalized
+ * 설명: 공구 체결 알림용 이벤트
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class GroupBuyStatusFinalizedEvent extends BaseEvent{
+    private Long groupBuyId;            // 공구 게시글 아이디
+    private Long hostId;                // 공구 주최자 아아디
+    private List<Long> participantIds;  // 공구 참여자 아이디 리스트
+    private String groupBuyTitle;       // 공구 게시글 제목
+    private String participantCount;    // 공구 참여자 수
+    private String totalQty;                // 전체 상품 수
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
@@ -28,16 +28,28 @@ public class GroupBuyEventMapper {
 
     // 공동구매 마감 이벤트
     public GroupBuyStatusEndedEvent toGroupBuyEndedEvent(
-            Long groupBuyId, Long hostId, List<Long> participantIds, String groupBuyTitle,
-            String participantCount, String totalQty
+            Long groupBuyId, Long hostId, List<Long> participantIds, String groupBuyTitle
     ) {
         return GroupBuyStatusEndedEvent.builder()
                 .groupBuyId(groupBuyId)
                 .hostId(hostId)
                 .participantIds(participantIds)
                 .groupBuyTitle(groupBuyTitle)
+                .occurredAt(Instant.now().toString())
+                .build();
+    }
+
+    // 공동구매 마감 이벤트
+    public GroupBuyStatusFinalizedEvent toGroupBuyFinalizedEvent(
+            Long groupBuyId, Long hostId, List<Long> participantIds, String groupBuyTitle,
+            String participantCount, String totalQty
+    ) {
+        return GroupBuyStatusFinalizedEvent.builder()
+                .groupBuyId(groupBuyId)
+                .hostId(hostId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
                 .participantCount(participantCount)
-                .totalQty(totalQty)
                 .occurredAt(Instant.now().toString())
                 .build();
     }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
@@ -1,0 +1,75 @@
+package com.moogsan.moongsan_backend.adapters.kafka.producer.mapper;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.*;
+import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+@Component
+public class GroupBuyEventMapper {
+
+    // 공동구매 모집 종료 이벤트
+    public GroupBuyStatusClosedEvent toGroupBuyClosedEvent(
+            Long groupBuyId, Long hostId, List<Long> participantIds, String groupBuyTitle,
+            String participantCount, String totalQty
+    ) {
+        return GroupBuyStatusClosedEvent.builder()
+                .groupBuyId(groupBuyId)
+                .hostId(hostId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
+                .participantCount(participantCount)
+                .totalQty(totalQty)
+                .occurredAt(Instant.now().toString())
+                .build();
+    }
+
+    // 공동구매 마감 이벤트
+    public GroupBuyStatusEndedEvent toGroupBuyEndedEvent(
+            Long groupBuyId, Long hostId, List<Long> participantIds, String groupBuyTitle,
+            String participantCount, String totalQty
+    ) {
+        return GroupBuyStatusEndedEvent.builder()
+                .groupBuyId(groupBuyId)
+                .hostId(hostId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
+                .participantCount(participantCount)
+                .totalQty(totalQty)
+                .occurredAt(Instant.now().toString())
+                .build();
+    }
+
+    // 공동구매 마감일자 임박 이벤트
+    public GroupBuyDueApproachingEvent toGroupBuyDueApproachingEvent(GroupBuy groupBuy) {
+        return GroupBuyDueApproachingEvent.builder()
+                .groupBuyId(groupBuy.getId())
+                .occurredAt(Instant.now().toString())
+                .build();
+    }
+
+    // 공동구매 픽업일자 임박 이벤트
+    public GroupBuyPickupApproachingEvent toGroupBuyPickupApproachingEvent(GroupBuy groupBuy) {
+        return GroupBuyPickupApproachingEvent.builder()
+                .groupBuyId(groupBuy.getId())
+                .occurredAt(Instant.now().toString())
+                .build();
+    }
+
+    // 공동구매 픽업일자 변경 이벤트
+    public GroupBuyPickupUpdatedEvent toGroupBuyPickupUpdatedEvent(
+            Long groupBuyId, List<Long> participantIds, String groupBuyTitle,
+            String pickupDate, String dateModificationReason
+    ) {
+        return GroupBuyPickupUpdatedEvent.builder()
+                .groupBuyId(groupBuyId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
+                .pickupDate(pickupDate)
+                .dateModificationReason(dateModificationReason)
+                .occurredAt(Instant.now().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
@@ -43,17 +43,33 @@ public class GroupBuyEventMapper {
     }
 
     // 공동구매 마감일자 임박 이벤트
-    public GroupBuyDueApproachingEvent toGroupBuyDueApproachingEvent(GroupBuy groupBuy) {
+    public GroupBuyDueApproachingEvent toGroupBuyDueApproachingEvent(
+            Long groupBuyId, Long hostId, String groupBuyTitle,
+            List<Long> participantIds, String participantCount, String leftQty
+    ) {
         return GroupBuyDueApproachingEvent.builder()
-                .groupBuyId(groupBuy.getId())
+                .groupBuyId(groupBuyId)
+                .hostId(hostId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
+                .participantCount(participantCount)
+                .leftQty(leftQty)
                 .occurredAt(Instant.now().toString())
                 .build();
     }
 
     // 공동구매 픽업일자 임박 이벤트
-    public GroupBuyPickupApproachingEvent toGroupBuyPickupApproachingEvent(GroupBuy groupBuy) {
+    public GroupBuyPickupApproachingEvent toGroupBuyPickupApproachingEvent(
+            Long groupBuyId, Long hostId, String groupBuyTitle,
+            List<Long> participantIds, String participantCount, String totalQty
+    ) {
         return GroupBuyPickupApproachingEvent.builder()
-                .groupBuyId(groupBuy.getId())
+                .groupBuyId(groupBuyId)
+                .hostId(hostId)
+                .participantIds(participantIds)
+                .groupBuyTitle(groupBuyTitle)
+                .participantCount(participantCount)
+                .totalQty(totalQty)
                 .occurredAt(Instant.now().toString())
                 .build();
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
@@ -1,27 +1,44 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusEndedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEventMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.order.entity.Order;
+import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.List;
 
+import static com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics.GROUPBUY_STATUS_ENDED;
 import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessage.*;
+import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIALIZATION_FAIL;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class EndGroupBuy {
 
     private final GroupBuyRepository groupBuyRepository;
+    private final OrderRepository orderRepository;
     private final Clock clock;
+    private final KafkaEventPublisher kafkaEventPublisher;
+    private final GroupBuyEventMapper eventMapper;
+    private final ObjectMapper objectMapper;
 
     /// 공구 게시글 공구 종료
     public void endGroupBuy(User currentUser, Long postId) {
@@ -40,16 +57,6 @@ public class EndGroupBuy {
             throw new GroupBuyInvalidStateException(AFTER_ENDED);
         }
 
-        // dueDate 이후인지 조회 -> 아니면 409
-        if (groupBuy.getDueDate().isAfter(LocalDateTime.now(clock))) {
-            throw new GroupBuyInvalidStateException(BEFORE_CLOSED);
-        }
-
-        // pickupDate 이후인지 조회 -> 아니면 409
-        if (groupBuy.getPickupDate().isAfter(LocalDateTime.now(clock))) {
-            throw new GroupBuyInvalidStateException(BEFORE_PICKUP_DATE);
-        }
-
         if (!groupBuy.isFixed()) {
             throw new GroupBuyInvalidStateException(BEFORE_FIXED);
         }
@@ -64,7 +71,31 @@ public class EndGroupBuy {
 
         groupBuyRepository.save(groupBuy);
 
-        // TODO V2, V3에서는 참여자 채팅방 해제 카운트 시작(2주- CS 고려), 익명 채팅방 즉시 해제
+        // TODO V3에서는 참여자 채팅방 해제 카운트 시작(2주- CS 고려), 익명 채팅방 즉시 해제
+
+        try {
+            List<Order> orders = orderRepository.findAllByGroupBuyIdOrderByStatusCustom(groupBuy.getId());
+
+            List<Long> participantIds = orders.stream()
+                    .map(order -> order.getUser().getId())
+                    .distinct()
+                    .toList();
+
+            GroupBuyStatusEndedEvent eventDto =
+                    eventMapper.toGroupBuyEndedEvent(
+                            groupBuy.getId(),
+                            groupBuy.getUser().getId(),
+                            participantIds,
+                            groupBuy.getTitle(),
+                            String.valueOf(groupBuy.getParticipantCount()),
+                            String.valueOf(groupBuy.getTotalAmount())
+                    );
+            String payload = objectMapper.writeValueAsString(eventDto);
+            kafkaEventPublisher.publish(GROUPBUY_STATUS_ENDED, String.valueOf(groupBuy.getId()), payload);
+        } catch (JsonProcessingException e) {
+            log.error("❌ Failed to serialize GroupBuyStatusEndedEvent: groupBuyId={}", groupBuy.getId(), e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
 
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
@@ -57,7 +57,7 @@ public class EndGroupBuy {
             throw new GroupBuyInvalidStateException(AFTER_ENDED);
         }
 
-        if (!groupBuy.isFixed()) {
+        if (!groupBuy.isFinalized()) {
             throw new GroupBuyInvalidStateException(BEFORE_FIXED);
         }
 
@@ -86,9 +86,7 @@ public class EndGroupBuy {
                             groupBuy.getId(),
                             groupBuy.getUser().getId(),
                             participantIds,
-                            groupBuy.getTitle(),
-                            String.valueOf(groupBuy.getParticipantCount()),
-                            String.valueOf(groupBuy.getTotalAmount())
+                            groupBuy.getTitle()
                     );
             String payload = objectMapper.writeValueAsString(eventDto);
             kafkaEventPublisher.publish(GROUPBUY_STATUS_ENDED, String.valueOf(groupBuy.getId()), payload);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndPastPickupGroupBuys.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndPastPickupGroupBuys.java
@@ -1,20 +1,38 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusClosedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusEndedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEventMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.order.entity.Order;
+import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics.GROUPBUY_STATUS_ENDED;
+import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIALIZATION_FAIL;
+
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class EndPastPickupGroupBuys {
 
     private final GroupBuyRepository groupBuyRepository;
+    private final OrderRepository orderRepository;
+    private final KafkaEventPublisher kafkaEventPublisher;
+    private final GroupBuyEventMapper eventMapper;
+    private final ObjectMapper objectMapper;
 
     /// 공구 종료 (백그라운드 API)
     public void endPastPickupGroupBuys(LocalDateTime now) {
@@ -23,6 +41,29 @@ public class EndPastPickupGroupBuys {
 
         for (GroupBuy gb : toEnd) {
             gb.changePostStatus("ENDED");
+            try {
+                List<Order> orders = orderRepository.findAllByGroupBuyIdOrderByStatusCustom(gb.getId());
+
+                List<Long> participantIds = orders.stream()
+                        .map(order -> order.getUser().getId())
+                        .distinct()
+                        .toList();
+
+                GroupBuyStatusEndedEvent eventDto =
+                        eventMapper.toGroupBuyEndedEvent(
+                                gb.getId(),
+                                gb.getUser().getId(),
+                                participantIds,
+                                gb.getTitle(),
+                                String.valueOf(gb.getParticipantCount()),
+                                String.valueOf(gb.getTotalAmount())
+                        );
+                String payload = objectMapper.writeValueAsString(eventDto);
+                kafkaEventPublisher.publish(GROUPBUY_STATUS_ENDED, String.valueOf(gb.getId()), payload);
+            } catch (JsonProcessingException e) {
+                log.error("❌ Failed to serialize GroupBuyStatusEndedEvent: groupBuyId={}", gb.getId(), e);
+                throw new RuntimeException(SERIALIZATION_FAIL, e);
+            }
         }
         groupBuyRepository.saveAll(toEnd);
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndPastPickupGroupBuys.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndPastPickupGroupBuys.java
@@ -54,9 +54,7 @@ public class EndPastPickupGroupBuys {
                                 gb.getId(),
                                 gb.getUser().getId(),
                                 participantIds,
-                                gb.getTitle(),
-                                String.valueOf(gb.getParticipantCount()),
-                                String.valueOf(gb.getTotalAmount())
+                                gb.getTitle()
                         );
                 String payload = objectMapper.writeValueAsString(eventDto);
                 kafkaEventPublisher.publish(GROUPBUY_STATUS_ENDED, String.valueOf(gb.getId()), payload);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/controller/NotificationCommandController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/controller/NotificationCommandController.java
@@ -1,0 +1,31 @@
+package com.moogsan.moongsan_backend.domain.notification.controller;
+
+import com.moogsan.moongsan_backend.domain.WrapperResponse;
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationReadStatus;
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationResponse;
+import com.moogsan.moongsan_backend.domain.notification.dto.PagedResponse;
+import com.moogsan.moongsan_backend.domain.notification.service.NotificationMarkAsRead;
+import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationCommandController {
+
+    private final NotificationMarkAsRead notificationMarkAsRead;
+
+    @PatchMapping("/{notificationId}")
+    public ResponseEntity<WrapperResponse<PagedResponse<NotificationResponse>>> getPastNotifications(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long notificationId,
+            @RequestBody NotificationReadStatus request) {
+
+        notificationMarkAsRead.execute(userDetails.getUser().getId(), notificationId, request);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/controller/NotificationListController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/controller/NotificationListController.java
@@ -1,0 +1,43 @@
+package com.moogsan.moongsan_backend.domain.notification.controller;
+
+import com.moogsan.moongsan_backend.domain.WrapperResponse;
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationResponse;
+import com.moogsan.moongsan_backend.domain.notification.dto.PagedResponse;
+import com.moogsan.moongsan_backend.domain.notification.service.GetPastNotifications;
+import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
+import com.moogsan.moongsan_backend.global.exception.specific.UnauthenticatedAccessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.moogsan.moongsan_backend.domain.notification.message.ResponseMessage.GET_PAST_NOTIFICATION_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationListController {
+
+    private final GetPastNotifications getPastNotifications;
+
+    @GetMapping("/latest")
+    public ResponseEntity<WrapperResponse<PagedResponse<NotificationResponse>>> getPastNotifications(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false, defaultValue = "10") int size
+    ) {
+        if (userDetails == null) throw new UnauthenticatedAccessException("로그인이 필요합니다.");
+
+        PagedResponse<NotificationResponse> response = getPastNotifications
+                .getPastNotifications(userDetails.getUser().getId(), cursorId, size);
+
+        return ResponseEntity.ok(
+                WrapperResponse.<PagedResponse<NotificationResponse>>builder()
+                        .message(GET_PAST_NOTIFICATION_SUCCESS)
+                        .data(response)
+                        .build());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,21 @@
+package com.moogsan.moongsan_backend.domain.notification.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Builder
+@Getter
+public class NotificationResponse {
+
+    private Long id;
+    private String title;
+    private String body;
+    private String type;
+    private Map<String, Object> payload;
+    private LocalDateTime createdAt;
+    private boolean read;
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
@@ -10,7 +10,7 @@ public enum NotificationType {
     ORDER_PENDING(
             KafkaTopics.ORDER_STATUS_PENDING,
             "주문이 들어왔어요!",
-            "{buyerName}님이 {qty}개를 주문했습니다."
+            "{buyerName}님이 {qty}개를 주문했어요. 입금 확인 후 주문을 확정해주세요!"
     ),
 
     ORDER_CONFIRMED(
@@ -43,13 +43,20 @@ public enum NotificationType {
                     "■ 총 주문 수량 : {totalQty}개\n\n"
     ),
 
+    GROUPBUY_STATUS_FINALIZED(
+            KafkaTopics.GROUPBUY_STATUS_FINALIZED,
+            "공구가 확정되었어요!",
+            "{groupBuyTitle}: 모든 주문이 확인되어 공구가 확정되었습니다.\n" +
+                    "■ 확정 참여 인원 : {participantCount}명\n" +
+                    "■ 총 주문 수량 : {totalQty}개\n\n" +
+                    "함께 뭉쳐주셔서 감사합니다!"
+    ),
+
     GROUPBUY_STATUS_ENDED(
             KafkaTopics.GROUPBUY_STATUS_ENDED,
             "공구가 종료됐어요!",
             "{groupBuyTitle}: 공구가 최종 종료되었습니다. {extraMessage}\n" +
-                    "■ 최종 참여 인원 : {participantCount}명\n" +
-                    "■ 총 주문 수량 : {totalQty}개\n\n" +
-                    "공구는 만족스러우셨나요? 다음 공구에도 힘을 보태 주세요!"
+                    "공구는 만족스러우셨나요? 다음 공구에서도 뭉티기가 되어 주세요!"
     ),
 
     GROUPBUY_DUE_APPROACHING(

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
@@ -52,6 +52,26 @@ public enum NotificationType {
                     "공구는 만족스러우셨나요? 다음 공구에도 힘을 보태 주세요!"
     ),
 
+    GROUPBUY_DUE_APPROACHING(
+            KafkaTopics.GROUPBUY_DUE_APPROACHING,
+            "마감 D-1! 내일 자정에 종료됩니다 🕛",
+            "{groupBuyTitle}: 모집 마감이 하루 남았어요.{extraMessage}\n" +
+                    "■ 현재 참여 인원 : {participantCount}명\n" +
+                    "■ 남은 주문 수량 : {LeftQty}개\n\n" +
+                    "필요하다면 오늘 안에 수량을 조정하시거나\n" +
+                    "친구에게 소식을 살짝 전해 보세요 😉"
+    ),
+
+    GROUPBUY_PICKUP_APPROACHING(
+            KafkaTopics.GROUPBUY_PICKUP_APPROACHING,
+            "픽업 D-1! 내일 수령을 준비해주세요 📦",
+            "{groupBuyTitle}: 상품 수령일이 내일입니다.{extraMessage}\n" +
+                    "■ 참여 인원 : {participantCount}명\n" +
+                    "■ 총 주문 수량 : {totalQty}개\n\n" +
+                    "수령 장소·시간을 다시 한 번 확인하시고,\n" +
+                    "문의 사항은 채팅방에 남겨주세요. 감사합니다!"
+    ),
+
     GROUPBUY_PICKUP_UPDATED(
             KafkaTopics.GROUPBUY_PICKUP_UPDATED,
             "픽업 일정이 변경되었어요!",

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/entity/NotificationType.java
@@ -1,0 +1,80 @@
+package com.moogsan.moongsan_backend.domain.notification.entity;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics;
+import lombok.Getter;
+
+@Getter
+public enum NotificationType {
+
+    // ───────── 주문 상태 ─────────
+    ORDER_PENDING(
+            KafkaTopics.ORDER_STATUS_PENDING,
+            "주문이 들어왔어요!",
+            "{buyerName}님이 {qty}개를 주문했습니다."
+    ),
+
+    ORDER_CONFIRMED(
+            KafkaTopics.ORDER_STATUS_CONFIRMED,
+            "주문이 확정됐어요!",
+            "{groupBuyTitle}: {buyerName}님의 주문이 확정됐습니다."
+    ),
+
+    ORDER_CANCELED(
+            KafkaTopics.ORDER_STATUS_CANCELED,
+            "주문이 취소됐어요!",
+            "{buyerName}님의 주문이 취소되었습니다.\n" +
+                    "■ 환불 계좌  : {buyerBank} {buyerAccount}\n" +
+                    "■ 환불 금액  : {price}원\n\n" +
+                    "영업일 1일 이내로 환불을 진행해 주세요."
+    ),
+
+    ORDER_REFUNDED(
+            KafkaTopics.ORDER_STATUS_REFUNDED,
+            "환불이 완료됐어요!",
+            "{groupBuyTitle}: {buyerName}님의 주문에 대한 환불이 완료됐습니다."
+    ),
+
+    // ──────── 공동구매 상태 ────────
+    GROUPBUY_STATUS_CLOSED(
+            KafkaTopics.GROUPBUY_STATUS_CLOSED,
+            "공구 참여자 모집이 마감됐어요!",
+            "{groupBuyTitle}: 모집이 마감됐습니다!\n" +
+                    "■ 총 참여 인원 : {participantCount}명\n" +
+                    "■ 총 주문 수량 : {totalQty}개\n\n"
+    ),
+
+    GROUPBUY_STATUS_ENDED(
+            KafkaTopics.GROUPBUY_STATUS_ENDED,
+            "공구가 종료됐어요!",
+            "{groupBuyTitle}: 공구가 최종 종료되었습니다. {extraMessage}\n" +
+                    "■ 최종 참여 인원 : {participantCount}명\n" +
+                    "■ 총 주문 수량 : {totalQty}개\n\n" +
+                    "공구는 만족스러우셨나요? 다음 공구에도 힘을 보태 주세요!"
+    ),
+
+    GROUPBUY_PICKUP_UPDATED(
+            KafkaTopics.GROUPBUY_PICKUP_UPDATED,
+            "픽업 일정이 변경되었어요!",
+            "새 픽업일: {pickupDate}, 변경 사유: {dateModificationReason}"
+    );
+
+    // ───────── 필드 ─────────
+    private final String topic;          // 실제 Kafka 토픽명
+    private final String titleTemplate;  // 기본 제목
+    private final String bodyTemplate;   // 기본 본문
+
+    // ───────── 생성자 ─────────
+    NotificationType(String topic, String title, String body) {
+        this.topic         = topic;
+        this.titleTemplate = title;
+        this.bodyTemplate  = body;
+    }
+
+    /** 토픽명 → enum 역매핑 (컨슈머에서 사용) */
+    public static NotificationType fromTopic(String topic) {
+        for (NotificationType t : values()) {
+            if (t.topic.equals(topic)) return t;
+        }
+        throw new IllegalArgumentException("Unknown topic: " + topic);
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/mapper/NotificationMapper.java
@@ -1,0 +1,19 @@
+package com.moogsan.moongsan_backend.domain.notification.mapper;
+
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationResponse;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+
+public class NotificationMapper {
+
+    public static NotificationResponse toNotificationReponse(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .title(notification.getTitle())
+                .body(notification.getBody())
+                .type(notification.getNotificationType().toString())
+                .payload(notification.getData())
+                .createdAt(notification.getCreatedAt())
+                .read(notification.getRead())
+                .build();
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GetPastNotifications.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GetPastNotifications.java
@@ -1,0 +1,49 @@
+package com.moogsan.moongsan_backend.domain.notification.service;
+
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationResponse;
+import com.moogsan.moongsan_backend.domain.notification.dto.PagedResponse;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.mapper.NotificationMapper;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GetPastNotifications {
+
+    private final NotificationRepository notificationRepository;
+
+    public PagedResponse<NotificationResponse> getPastNotifications(Long userId, Long cursorId, int size) {
+
+        Pageable page = PageRequest.of(0, size + 1);
+
+        List<Notification> raw = (cursorId == null)
+                ? notificationRepository.findByReceiverIdOrderByIdDesc(userId, page)
+                : notificationRepository.findByReceiverIdAndIdLessThanOrderByIdDesc(userId, cursorId, page);
+
+        boolean hasNext = raw.size() > size;
+
+        if (hasNext) raw = raw.subList(0, size);
+
+        List<NotificationResponse> items = raw.stream()
+                .map(NotificationMapper::toNotificationReponse)
+                .toList();
+
+        Long nextCursor = hasNext ? raw.getLast().getId() : null;
+
+        return PagedResponse.<NotificationResponse>builder()
+                .items(items)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyFinalizedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyFinalizedNotiUseCase.java
@@ -1,4 +1,87 @@
 package com.moogsan.moongsan_backend.domain.notification.service.GroupBuy;
 
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusClosedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusFinalizedEvent;
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.factory.NotificationFactory;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationPayload;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class SendGroupBuyFinalizedNotiUseCase {
+    private final SseEmitterRepository emitterRepository;
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationFactory notificationFactory;
+    private final NotificationRepository notificationRepository;
+
+    public void handleGroupBuyFinalized(GroupBuyStatusFinalizedEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_STATUS_FINALIZED);
+        String body = templateRegistry.body(NotificationType.GROUPBUY_STATUS_FINALIZED)
+                .replace("{groupBuyTitle}", event.getGroupBuyTitle())
+                .replace("{participantCount}", String.valueOf(event.getParticipantCount()))
+                .replace("{totalQty}", String.valueOf(event.getTotalQty()));
+
+        NotificationPayload payload = new NotificationPayload(title, body, event);
+
+        Notification hostNoti = notificationFactory.create(
+                NotificationType.GROUPBUY_STATUS_FINALIZED,
+                hostId,
+                event,
+                Map.of(
+                        "groupBuyTitle", event.getGroupBuyTitle(),
+                        "participantCount", event.getParticipantCount(),
+                        "totalQty", String.valueOf(event.getTotalQty())
+                )
+        );
+
+        List<Notification> participantNotis = event.getParticipantIds().stream()
+                .filter(id -> !id.equals(hostId))
+                .map(id -> notificationFactory.create(
+                        NotificationType.GROUPBUY_STATUS_FINALIZED,
+                        id,
+                        event,
+                        Map.of(
+                                "groupBuyTitle", event.getGroupBuyTitle(),
+                                "participantCount", event.getParticipantCount(),
+                                "totalQty", String.valueOf(event.getTotalQty())
+                        )
+                ))
+                .toList();
+
+        notificationRepository.saveAll(Stream.concat(
+                Stream.of(hostNoti),
+                participantNotis.stream()
+        ).toList());
+
+        emitterRepository.send(hostId.toString(),
+                NotificationType.GROUPBUY_STATUS_FINALIZED.name(),
+                payload);
+
+        participantNotis.forEach(noti ->
+                emitterRepository.send(noti.getReceiverId().toString(),
+                        NotificationType.GROUPBUY_STATUS_FINALIZED.name(), payload));
+
+        log.debug("✅ 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyFinalizedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/GroupBuy/SendGroupBuyFinalizedNotiUseCase.java
@@ -1,0 +1,4 @@
+package com.moogsan.moongsan_backend.domain.notification.service.GroupBuy;
+
+public class SendGroupBuyFinalizedNotiUseCase {
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/publisher/NotificationPublisher.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/publisher/NotificationPublisher.java
@@ -1,0 +1,69 @@
+package com.moogsan.moongsan_backend.domain.notification.service.publisher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.domain.notification.dto.NotificationResponse;
+import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationPublisher {
+    private final NotificationRepository notificationRepository;
+    private final SseEmitterRepository emitterRepository;
+    private final ObjectMapper objectMapper;
+
+    public void publish(Long userId,
+                        NotificationType type,
+                        String title,
+                        String body,
+                        Object rawPayload) {
+        try {
+            // rawPayload → Map 변환
+            Map<String, Object> dataMap = objectMapper.convertValue(
+                    rawPayload,
+                    new TypeReference<Map<String, Object>>() {}
+            );
+
+            // 1) 엔티티 빌드 & 저장
+            Notification entity = Notification.builder()
+                    .receiverId(userId)
+                    .notificationType(type)
+                    .title(title)
+                    .body(body)
+                    .data(dataMap)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+
+            notificationRepository.save(entity);
+
+            // 2) DTO 변환
+            NotificationResponse dto = NotificationResponse.builder()
+                    .id(entity.getId())
+                    .type(entity.getNotificationType().name())
+                    .title(entity.getTitle())
+                    .body(entity.getBody())
+                    .payload(entity.getData())
+                    .createdAt(entity.getCreatedAt())
+                    .read(entity.getRead())
+                    .build();
+
+            // 3) SSE 전송
+            emitterRepository.send(
+                    userId.toString(),
+                    entity.getNotificationType().name(),
+                    dto
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Notification publish failed", e);
+        }
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendGroupBuyClosedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendGroupBuyClosedNotiUseCase.java
@@ -1,0 +1,63 @@
+package com.moogsan.moongsan_backend.domain.notification.service.useCase.GroupBuy;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusClosedEvent;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.service.publisher.NotificationPublisher;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendGroupBuyClosedNotiUseCase {
+
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationPublisher notificationPublisher;
+
+    public void handleGroupBuyClosed(GroupBuyStatusClosedEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_STATUS_CLOSED);
+        String body = templateRegistry.body(NotificationType.GROUPBUY_STATUS_CLOSED)
+                .replace("{groupBuyTitle}", event.getGroupBuyTitle())
+                .replace("{participantCount}", String.valueOf(event.getParticipantCount()))
+                .replace("{totalQty}", String.valueOf(event.getTotalQty()));
+
+        // host에게 알림 발행
+        notificationPublisher.publish(
+                hostId,
+                NotificationType.GROUPBUY_STATUS_CLOSED,
+                title,
+                body,
+                event
+        );
+
+        // 참가자들에게 알림 발행 (host 제외)
+        event.getParticipantIds().stream()
+                .filter(id -> !id.equals(hostId))
+                .forEach(participantId ->
+                        notificationPublisher.publish(
+                                participantId,
+                                NotificationType.GROUPBUY_STATUS_CLOSED,
+                                title,
+                                body,
+                                event
+                        )
+                );
+
+        log.debug("✅ 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendGroupBuyDueApproachingNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendGroupBuyDueApproachingNotiUseCase.java
@@ -1,0 +1,66 @@
+package com.moogsan.moongsan_backend.domain.notification.service.useCase.GroupBuy;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyDueApproachingEvent;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.service.publisher.NotificationPublisher;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendGroupBuyDueApproachingNotiUseCase {
+
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationPublisher notificationPublisher;
+
+    public void handleGroupBuyDueApproaching(GroupBuyDueApproachingEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_DUE_APPROACHING);
+        String hostBody = templateRegistry.body(NotificationType.GROUPBUY_DUE_APPROACHING)
+                .replace("{groupBuyTitle}", event.getGroupBuyTitle())
+                .replace("{participantCount}", String.valueOf(event.getParticipantCount()))
+                .replace("{totalQty}", String.valueOf(event.getLeftQty()))
+                .replace("{extraMessage}", "채팅방에 확인 메세지를 보내주세요!");
+
+        String partiBody = templateRegistry.body(NotificationType.GROUPBUY_DUE_APPROACHING)
+                .replace("{groupBuyTitle}", event.getGroupBuyTitle())
+                .replace("{participantCount}", String.valueOf(event.getParticipantCount()))
+                .replace("{totalQty}", String.valueOf(event.getLeftQty()))
+                .replace("{extraMessage}", "주최자의 메세지를 확인해주세요!");
+
+        // host에게 알림 발행
+        notificationPublisher.publish(
+                hostId,
+                NotificationType.GROUPBUY_DUE_APPROACHING,
+                title,
+                hostBody,
+                event
+        );
+
+        // 참가자들에게 알림 발행 (host 제외)
+        event.getParticipantIds().stream()
+                .filter(id -> !id.equals(hostId))
+                .forEach(participantId ->
+                        notificationPublisher.publish(
+                                participantId,
+                                NotificationType.GROUPBUY_DUE_APPROACHING,
+                                title,
+                                partiBody,
+                                event
+                        )
+                );
+
+        log.debug("✅ 공구 종료 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendGroupBuyEndedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendGroupBuyEndedNotiUseCase.java
@@ -1,0 +1,62 @@
+package com.moogsan.moongsan_backend.domain.notification.service.useCase.GroupBuy;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusEndedEvent;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.service.publisher.NotificationPublisher;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendGroupBuyEndedNotiUseCase {
+
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationPublisher notificationPublisher;
+
+    public void handleGroupBuyEnded(GroupBuyStatusEndedEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_STATUS_ENDED);
+        String hostBody = templateRegistry.body(NotificationType.GROUPBUY_STATUS_ENDED)
+                .replace("{groupBuyTitle}", event.getGroupBuyTitle())
+                .replace("{extraMessage}", "다음 공구에서 만나요!");
+
+        String partiBody = templateRegistry.body(NotificationType.GROUPBUY_STATUS_ENDED)
+                .replace("{groupBuyTitle}", event.getGroupBuyTitle())
+                .replace("{extraMessage}", "참여해 주셔서 감사합니다! 🎉");
+
+        // host에게 알림 발행
+        notificationPublisher.publish(
+                hostId,
+                NotificationType.GROUPBUY_STATUS_ENDED,
+                title,
+                hostBody,
+                event
+        );
+
+        // 참가자들에게 알림 발행 (host 제외)
+        event.getParticipantIds().stream()
+                .filter(id -> !id.equals(hostId))
+                .forEach(participantId ->
+                        notificationPublisher.publish(
+                                participantId,
+                                NotificationType.GROUPBUY_STATUS_ENDED,
+                                title,
+                                partiBody,
+                                event
+                        )
+                );
+
+        log.debug("✅ 공구 종료 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendGroupBuyFinalizedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendGroupBuyFinalizedNotiUseCase.java
@@ -1,4 +1,4 @@
-package com.moogsan.moongsan_backend.domain.notification.service.GroupBuy;
+package com.moogsan.moongsan_backend.domain.notification.service.useCase.GroupBuy;
 
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusClosedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusFinalizedEvent;
@@ -7,6 +7,7 @@ import com.moogsan.moongsan_backend.domain.notification.entity.Notification;
 import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
 import com.moogsan.moongsan_backend.domain.notification.factory.NotificationFactory;
 import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import com.moogsan.moongsan_backend.domain.notification.service.publisher.NotificationPublisher;
 import com.moogsan.moongsan_backend.domain.notification.template.NotificationPayload;
 import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class SendGroupBuyFinalizedNotiUseCase {
     private final NotificationTemplateRegistry templateRegistry;
     private final NotificationFactory notificationFactory;
     private final NotificationRepository notificationRepository;
+    private final NotificationPublisher notificationPublisher;
 
     public void handleGroupBuyFinalized(GroupBuyStatusFinalizedEvent event) {
 
@@ -37,50 +39,37 @@ public class SendGroupBuyFinalizedNotiUseCase {
         }
 
         String title = templateRegistry.title(NotificationType.GROUPBUY_STATUS_FINALIZED);
-        String body = templateRegistry.body(NotificationType.GROUPBUY_STATUS_FINALIZED)
+        String hostBody = templateRegistry.body(NotificationType.GROUPBUY_STATUS_FINALIZED)
                 .replace("{groupBuyTitle}", event.getGroupBuyTitle())
                 .replace("{participantCount}", String.valueOf(event.getParticipantCount()))
                 .replace("{totalQty}", String.valueOf(event.getTotalQty()));
 
-        NotificationPayload payload = new NotificationPayload(title, body, event);
+        String partiBody = templateRegistry.body(NotificationType.GROUPBUY_STATUS_FINALIZED)
+                .replace("{groupBuyTitle}", event.getGroupBuyTitle())
+                .replace("{participantCount}", String.valueOf(event.getParticipantCount()))
+                .replace("{totalQty}", String.valueOf(event.getTotalQty()));
 
-        Notification hostNoti = notificationFactory.create(
-                NotificationType.GROUPBUY_STATUS_FINALIZED,
+        // host에게 알림 발행
+        notificationPublisher.publish(
                 hostId,
-                event,
-                Map.of(
-                        "groupBuyTitle", event.getGroupBuyTitle(),
-                        "participantCount", event.getParticipantCount(),
-                        "totalQty", String.valueOf(event.getTotalQty())
-                )
+                NotificationType.GROUPBUY_STATUS_FINALIZED,
+                title,
+                hostBody,
+                event
         );
 
-        List<Notification> participantNotis = event.getParticipantIds().stream()
+        // 참가자들에게 알림 발행 (host 제외)
+        event.getParticipantIds().stream()
                 .filter(id -> !id.equals(hostId))
-                .map(id -> notificationFactory.create(
-                        NotificationType.GROUPBUY_STATUS_FINALIZED,
-                        id,
-                        event,
-                        Map.of(
-                                "groupBuyTitle", event.getGroupBuyTitle(),
-                                "participantCount", event.getParticipantCount(),
-                                "totalQty", String.valueOf(event.getTotalQty())
+                .forEach(participantId ->
+                        notificationPublisher.publish(
+                                participantId,
+                                NotificationType.GROUPBUY_STATUS_FINALIZED,
+                                title,
+                                partiBody,
+                                event
                         )
-                ))
-                .toList();
-
-        notificationRepository.saveAll(Stream.concat(
-                Stream.of(hostNoti),
-                participantNotis.stream()
-        ).toList());
-
-        emitterRepository.send(hostId.toString(),
-                NotificationType.GROUPBUY_STATUS_FINALIZED.name(),
-                payload);
-
-        participantNotis.forEach(noti ->
-                emitterRepository.send(noti.getReceiverId().toString(),
-                        NotificationType.GROUPBUY_STATUS_FINALIZED.name(), payload));
+                );
 
         log.debug("✅ 알림 전송 완료: groupId={}", event.getGroupBuyId());
     }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendGroupBuyPickupApproachingNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendGroupBuyPickupApproachingNotiUseCase.java
@@ -1,0 +1,66 @@
+package com.moogsan.moongsan_backend.domain.notification.service.useCase.GroupBuy;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyPickupApproachingEvent;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.service.publisher.NotificationPublisher;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendGroupBuyPickupApproachingNotiUseCase {
+
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationPublisher notificationPublisher;
+
+    public void handleGroupBuyPickupApproaching(GroupBuyPickupApproachingEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_PICKUP_APPROACHING);
+        String hostBody = templateRegistry.body(NotificationType.GROUPBUY_PICKUP_APPROACHING)
+                .replace("{groupBuyTitle}", event.getGroupBuyTitle())
+                .replace("{participantCount}", String.valueOf(event.getParticipantCount()))
+                .replace("{totalQty}", String.valueOf(event.getTotalQty()))
+                .replace("{extraMessage}", "채팅방에 확인 메세지를 보내주세요!");
+
+        String partiBody = templateRegistry.body(NotificationType.GROUPBUY_PICKUP_APPROACHING)
+                .replace("{groupBuyTitle}", event.getGroupBuyTitle())
+                .replace("{participantCount}", String.valueOf(event.getParticipantCount()))
+                .replace("{totalQty}", String.valueOf(event.getTotalQty()))
+                .replace("{extraMessage}", "주최자의 메세지를 확인해주세요!");
+
+        // host에게 알림 발행
+        notificationPublisher.publish(
+                hostId,
+                NotificationType.GROUPBUY_PICKUP_APPROACHING,
+                title,
+                hostBody,
+                event
+        );
+
+        // 참가자들에게 알림 발행 (host 제외)
+        event.getParticipantIds().stream()
+                .filter(id -> !id.equals(hostId))
+                .forEach(participantId ->
+                        notificationPublisher.publish(
+                                participantId,
+                                NotificationType.GROUPBUY_PICKUP_APPROACHING,
+                                title,
+                                partiBody,
+                                event
+                        )
+                );
+
+        log.debug("✅ 공구 종료 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendPickupChangedNotiUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/GroupBuy/SendPickupChangedNotiUseCase.java
@@ -1,0 +1,44 @@
+package com.moogsan.moongsan_backend.domain.notification.service.useCase.GroupBuy;
+
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyPickupUpdatedEvent;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.service.publisher.NotificationPublisher;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendPickupChangedNotiUseCase {
+
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationPublisher notificationPublisher;
+
+    public void handleGroupBuyPickupChanged(GroupBuyPickupUpdatedEvent event) {
+
+        String title = templateRegistry.title(NotificationType.GROUPBUY_PICKUP_UPDATED);
+
+        String partiBody = templateRegistry.body(NotificationType.GROUPBUY_PICKUP_UPDATED)
+                .replace("{pickupDate}", event.getPickupDate())
+                .replace("{dateModificationReason}", event.getDateModificationReason());
+
+
+        // 참가자들에게 알림 발행 (host 제외)
+        event.getParticipantIds()
+                .forEach(participantId ->
+                        notificationPublisher.publish(
+                                participantId,
+                                NotificationType.GROUPBUY_PICKUP_UPDATED,
+                                title,
+                                partiBody,
+                                event
+                        )
+                );
+
+        log.debug("✅ 알림 전송 완료: groupId={}", event.getGroupBuyId());
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/Order/SendOrderNotificationUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/notification/service/useCase/Order/SendOrderNotificationUseCase.java
@@ -1,0 +1,131 @@
+package com.moogsan.moongsan_backend.domain.notification.service.useCase.Order;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderCanceledEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderConfirmedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderPendingEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderRefundedEvent;
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.domain.notification.entity.NotificationType;
+import com.moogsan.moongsan_backend.domain.notification.factory.NotificationFactory;
+import com.moogsan.moongsan_backend.domain.notification.repository.NotificationRepository;
+import com.moogsan.moongsan_backend.domain.notification.service.publisher.NotificationPublisher;
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendOrderNotificationUseCase {
+
+    private final SseEmitterRepository emitterRepository;
+    private final NotificationTemplateRegistry templateRegistry;
+    private final NotificationFactory notificationFactory;
+    private final NotificationRepository notificationRepository;
+    private final NotificationPublisher notificationPublisher;
+    private final ObjectMapper objectMapper;
+
+    public void handleOrderPending(OrderPendingEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.ORDER_PENDING);
+        String body = templateRegistry.body(NotificationType.ORDER_PENDING)
+                        .replace("{buyerName}", event.getBuyerName())
+                        .replace("{qty}", String.valueOf(event.getQuantity()));
+
+        notificationPublisher.publish(
+                hostId,
+                NotificationType.ORDER_PENDING,
+                title,
+                body,
+                event
+        );
+
+        log.debug("✅ 알림 전송 완료: hostId={}, orderId={}", hostId, event.getOrderId());
+    }
+
+    public void handleOrderConfirmed(OrderConfirmedEvent event) {
+
+        Long participantId = event.getParticipantId();
+        if (participantId == null) {
+            log.warn("participantId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.ORDER_CONFIRMED);
+        String body = templateRegistry.body(NotificationType.ORDER_CONFIRMED)
+                .replace("{groupBuyTitle}", event.getGroupBuyName())
+                .replace("{buyerName}", event.getBuyerName());
+
+        notificationPublisher.publish(
+                participantId,
+                NotificationType.ORDER_CONFIRMED,
+                title,
+                body,
+                event
+        );
+
+        log.debug("✅ 알림 전송 완료: hostId={}, orderId={}", participantId, event.getOrderId());
+    }
+
+    public void handleOrderCanceled(OrderCanceledEvent event) {
+
+        Long hostId = event.getHostId();
+        if (hostId == null) {
+            log.warn("hostId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.ORDER_CANCELED);
+        String body = templateRegistry.body(NotificationType.ORDER_CANCELED)
+                .replace("{buyerName}", event.getBuyerName())
+                .replace("{buyerBank}", event.getBuyerBank())
+                .replace("{buyerAccount}", event.getBuyerAccount())
+                .replace("{price}", String.valueOf(event.getPrice()));
+
+        notificationPublisher.publish(
+                hostId,
+                NotificationType.ORDER_CANCELED,
+                title,
+                body,
+                event
+        );
+
+        log.debug("✅ 알림 전송 완료: hostId={}, orderId={}", hostId, event.getOrderId());
+    }
+
+    public void handleOrderRefunded(OrderRefundedEvent event) {
+
+        Long participantId = event.getParticipantId();
+        if (participantId == null) {
+            log.warn("participantId 가 없음, event={}", event);
+            return;
+        }
+
+        String title = templateRegistry.title(NotificationType.ORDER_REFUNDED);
+        String body = templateRegistry.body(NotificationType.ORDER_REFUNDED)
+                .replace("{groupBuyTitle}", event.getGroupBuyName())
+                .replace("{buyerName}", event.getBuyerName());
+
+        notificationPublisher.publish(
+                participantId,
+                NotificationType.ORDER_REFUNDED,
+                title,
+                body,
+                event
+        );
+
+        log.debug("✅ 알림 전송 완료: hostId={}, orderId={}", participantId, event.getOrderId());
+    }
+
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderCreateService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderCreateService.java
@@ -1,6 +1,15 @@
 package com.moogsan.moongsan_backend.domain.order.service;
 
-import com.moogsan.moongsan_backend.domain.chatting.Facade.command.ChattingCommandFacade;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyPickupUpdatedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusClosedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusEndedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderPendingEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEventMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.OrderEventMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
+import com.moogsan.moongsan_backend.domain.chatting.participant.Facade.command.ChattingCommandFacade;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.policy.DueSoonPolicy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
@@ -11,12 +20,23 @@ import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import com.moogsan.moongsan_backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.RLock;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import com.moogsan.moongsan_backend.global.exception.base.BusinessException;
 import com.moogsan.moongsan_backend.global.exception.code.ErrorCode;
 import java.util.List;
 
+import static com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics.*;
+import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIALIZATION_FAIL;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderCreateService {
@@ -26,29 +46,44 @@ public class OrderCreateService {
     private final OrderRepository orderRepository;
     private final DueSoonPolicy dueSoonPolicy;
     private final ChattingCommandFacade chattingCommandFacade;
+    private final KafkaEventPublisher kafkaEventPublisher;
+    private final OrderEventMapper orderEventMapper;
+    private final GroupBuyEventMapper groupBuyEventMapper;
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RedissonClient redissonClient;
 
     // 주문 생성 서비스
     @Transactional
     public OrderCreateResponse createOrder(OrderCreateRequest request, Long userId) {
+        // 유저, 공동구매 정보 조회 - 404 반환
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "유저 정보를 찾을 수 없습니다."));
 
         GroupBuy groupBuy = groupBuyRepository.findById(request.getPostId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "공동구매 정보를 찾을 수 없습니다."));
 
-        // 공동구매 글의 상태가 열려있어야지만 주문 가능
+        // 공동구매 게시 상태 조회 - 400 반환
         if (!"OPEN".equals(groupBuy.getPostStatus())) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "현재 주문이 불가능한 상태입니다.");
         }
 
-        // 동일 postId, userId로 CANCELED, REFUNDED 주문이 3건 이상이면 차단
+        // 동일 공동구매 주문 횟수 제한 - 409 반환
         int canceledCount = orderRepository.countByUserIdAndGroupBuyIdAndStatusIn(user.getId(), groupBuy.getId(),
                 List.of("CANCELED", "REFUNDED"));
         if (canceledCount > 3) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST, "주문을 3회 이상 취소하였습니다.");
+            throw new BusinessException(ErrorCode.DUPLICATE_REQUEST, "주문을 3회 이상 취소하였습니다.");
         }
 
-        // 해당 공구 내 CANCELED, REFUNDED 상태가 아닌 주문 존재
+        // 환불중인 주문 존재 - 409 반환
+        boolean existsCanceled = orderRepository.existsByUserIdAndGroupBuyIdAndStatusIn(
+                user.getId(), groupBuy.getId(), List.of("CANCELED"));
+
+        if (existsCanceled) {
+            throw new BusinessException(ErrorCode.DUPLICATE_REQUEST, "환불중인 주문이 존재합니다.");
+        }
+
+        // 참여중인 주문 존재 - 409 반환
         boolean exists = orderRepository.existsByUserIdAndGroupBuyIdAndStatusNotIn(
                 user.getId(), groupBuy.getId(), List.of("CANCELED", "REFUNDED"));
 
@@ -56,14 +91,9 @@ public class OrderCreateService {
             throw new BusinessException(ErrorCode.DUPLICATE_REQUEST, "이미 공동구매에 참여하였습니다.");
         }
 
-        // 입력 수량이 해당 공구의 주문 단위의 배수가 아님
+        // 주문 수량이 해당 공동구매 주문 단위의 배수가 아님
         if (request.getQuantity() % groupBuy.getUnitAmount() != 0) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "수량은 주문 단위의 배수여야 합니다.");
-        }
-
-        // 입력 수량이 해당 공구의 남은 수량을 초과
-        if (request.getQuantity() > groupBuy.getLeftAmount()) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST, "남은 수량을 초과하여 주문할 수 없습니다.");
         }
 
         String orderName = request.getName() != null ? request.getName() : user.getName();
@@ -76,17 +106,113 @@ public class OrderCreateService {
                 .name(orderName)
                 .build();
 
+        // 1. Redis 키 정의
+        String stockKey = "order:groupbuy:stock:" + request.getPostId();
+        String orderCheckKey = "order:user:" + userId + ":groupbuy:" + request.getPostId();
+        String lockKey = "order:lock:groupbuy:" + request.getPostId();
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            boolean locked = lock.tryLock(3, 2, TimeUnit.SECONDS);
+            if (!locked) {
+                throw new BusinessException(ErrorCode.TOO_MANY_REQUESTS, "잠시 후 다시 시도해주세요.");
+            }
+
+            // 2. Redis 중복 주문 방지
+            Boolean isNew = redisTemplate.opsForValue().setIfAbsent(orderCheckKey, "1", Duration.ofMinutes(10));
+            if (Boolean.FALSE.equals(isNew)) {
+                throw new BusinessException(ErrorCode.DUPLICATE_REQUEST, "이미 공동구매에 참여하였습니다.");
+            }
+
+            // 3. Lua Script로 재고 감소
+            DefaultRedisScript<Long> redisScript = new DefaultRedisScript<>();
+            redisScript.setScriptText(
+                    "local stock = redis.call('get', KEYS[1]);" +
+                            "if (stock and tonumber(stock) >= tonumber(ARGV[1])) then " +
+                            " return redis.call('decrby', KEYS[1], ARGV[1]); " +
+                            "else return -1; end"
+            );
+            redisScript.setResultType(Long.class);
+
+            Long redisResult = redisTemplate.execute(
+                    redisScript,
+                    List.of(stockKey),
+                    String.valueOf(request.getQuantity())
+            );
+
+            if (redisResult == null || redisResult < 0) {
+                throw new BusinessException(ErrorCode.BAD_REQUEST, "남은 수량을 초과하여 주문할 수 없습니다.");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "락 획득 중 오류가 발생했습니다.");
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+
+
         groupBuy.decreaseLeftAmount(request.getQuantity());
         groupBuy.increaseParticipantCount();
         groupBuy.updateDueSoonStatus(dueSoonPolicy);
 
-        if (groupBuy.getLeftAmount() == 0) {
-            groupBuy.changePostStatus("CLOSED");
-        }
-
-        groupBuyRepository.save(groupBuy);
         orderRepository.save(order);
         chattingCommandFacade.joinChatRoom(user, groupBuy.getId());
+
+        if (groupBuy.getLeftAmount() == 0) {
+            groupBuy.changePostStatus("CLOSED");
+
+            List<Order> orders = orderRepository.findAllByGroupBuyIdOrderByStatusCustom(groupBuy.getId());
+
+            List<Long> participantIds = orders.stream()
+                    .map(o -> o.getUser().getId())
+                    .distinct()
+                    .toList();
+
+            try {
+                GroupBuyStatusClosedEvent eventDto =
+                        groupBuyEventMapper.toGroupBuyClosedEvent(
+                                groupBuy.getId(),
+                                groupBuy.getUser().getId(),
+                                participantIds,
+                                groupBuy.getTitle(),
+                                String.valueOf(groupBuy.getParticipantCount()),
+                                String.valueOf(groupBuy.getTotalAmount())
+                        );
+                String payload = objectMapper.writeValueAsString(eventDto);
+                kafkaEventPublisher.publish(GROUPBUY_STATUS_CLOSED, String.valueOf(groupBuy.getId()), payload);
+            } catch (JsonProcessingException e) {
+                log.error("❌ Failed to serialize GroupBuyStatusClosedEvent: groupBuyId={}", groupBuy.getId(), e);
+                throw new RuntimeException(SERIALIZATION_FAIL, e);
+            } catch (Exception e) {
+                // Redis 롤백 처리
+                redisTemplate.opsForValue().increment(stockKey, request.getQuantity());
+                redisTemplate.delete(orderCheckKey);
+                throw e;
+            }
+
+            groupBuyRepository.save(groupBuy);
+            groupBuyRepository.flush();
+
+        }
+
+        try {
+            OrderPendingEvent eventDto =
+                    orderEventMapper.toPendingEvent(
+                            order.getId(),
+                            groupBuy.getId(),
+                            groupBuy.getUser().getId(),
+                            order.getUser().getNickname(),
+                            order.getQuantity()
+                    );
+            log.info("▶ orderPendingEvent DTO = {}", eventDto);
+            String payload = objectMapper.writeValueAsString(eventDto);
+            kafkaEventPublisher.publish(ORDER_STATUS_PENDING, String.valueOf(order.getId()), payload);
+        } catch (JsonProcessingException e) {
+            log.error("❌ Failed to serialize OrderPendingEvent: orderId={}", order.getId(), e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
 
         return OrderCreateResponse.builder()
                 .orderId(order.getId())


### PR DESCRIPTION
## 🔎 작업 개요
- SSE 이벤트와 REST 기반 과거 알림 조회 API에서 사용하는 알림 포맷을 완전히 일치시키기 위해  
  공통 `NotificationPublisher`를 적용하고, 기존에 분산되어 있던 저장·전송 코드를 제거했습니다.

## 🛠️ 주요 변경 사항
- `NotificationPublisher` 컴포넌트 추가  
- `SendOrderNotificationUseCase`, `SendGroupBuy*NotiUseCase` 등에서  
  - 기존 `NotificationFactory` + `notificationRepository.save` + `emitterRepository.send` 호출 제거  
  - 단일 `notificationPublisher.publish(...)` 호출로 대체  
- `Notification` 엔터티 및 `NotificationResponse` DTO 스펙에 맞춰 SSE 전송 로직 개선  
- 불필요해진 `SseEmitterRepository.send`, `notificationFactory` 의존성 제거

## ✅ 검증 방법
1. Kafka 이벤트 발생 시 SSE 클라이언트가 `NotificationResponse` 형태의 JSON을 수신하는지 확인  
2. `GET /api/notifications` 호출 시 동일한 `NotificationResponse` 배열이 반환되는지 확인  
3. 주문·공구 알림 시나리오(신규 주문, 주문 확정, 공구 마감·확정 등)별로 정상 동작 점검

## 🔍 머지 전 확인사항
- [x] 모든 UseCase에서 `NotificationPublisher.publish` 호출로 대체되었는지  
- [x] 클라이언트 SSE 및 REST 응답 파싱 로직이 변경 없이 정상 동작하는지  
- [x] 제거된 코드(`NotificationFactory`, 직접 `save`/`send` 호출) 잔여 여부 점검

## ➕ 이슈 링크
- #284 
