### PR TITLE
feat(notification): 주문 도메인 알림에 outbox 적용 및 주최자 알림 개선

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/outbox/publisher/OutboxEventPublisher.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/outbox/publisher/OutboxEventPublisher.java
@@ -1,0 +1,13 @@
+package com.moogsan.moongsan_backend.adapters.kafka.producer.outbox.publisher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public interface OutboxEventPublisher {
+    <T> void publish(
+            String aggregateType,      // ex. "ORDER"
+            String aggregateId,        // ex. orderId.toString()
+            String topic,              // ex. KafkaTopics.ORDER_STATUS_CONFIRMED
+            String key,                // ex. orderId.toString()
+            T payload                  // event DTO
+    ) throws JsonProcessingException;
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/outbox/publisher/OutboxEventPublisherImpl.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/outbox/publisher/OutboxEventPublisherImpl.java
@@ -1,0 +1,45 @@
+package com.moogsan.moongsan_backend.adapters.kafka.producer.outbox.publisher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.outbox.OutboxEventEntity;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.outbox.OutboxEventRepository;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.outbox.OutboxEventStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxEventPublisherImpl implements OutboxEventPublisher {
+    private final OutboxEventRepository outboxRepo;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional  // 반드시 도메인 트랜잭션 안에서 호출되어야 함
+    public <T> void publish(String aggregateType,
+                            String aggregateId,
+                            String topic,
+                            String key,
+                            T payload) throws JsonProcessingException {
+        String json = objectMapper.writeValueAsString(payload);
+
+        OutboxEventEntity ev = OutboxEventEntity.builder()
+                .eventId(UUID.randomUUID().toString())
+                .aggregateType(aggregateType)
+                .aggregateId(aggregateId)
+                .kafkaTopic(topic)
+                .kafkaPartitionKey(key)
+                .payload(json)
+                .headers("{}")
+                .status(OutboxEventStatus.PENDING)
+                .nextRetryAt(LocalDateTime.now())
+                .build();
+
+        outboxRepo.save(ev);
+    }
+}
+

--- a/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderCreateService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderCreateService.java
@@ -163,7 +163,7 @@ public class OrderCreateService {
         // 7. Pending 이벤트
         try {
             OrderPendingEvent pendingEvt = orderEventMapper.toPendingEvent(
-                    order.getGroupBuy().getUser().getId(), groupBuy.getId(), userId,
+                    order.getId(), groupBuy.getId(), groupBuy.getUser().getId(),
                     order.getUser().getNickname(), order.getQuantity()
             );
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderCreateService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderCreateService.java
@@ -6,6 +6,7 @@ import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuyStatusCl
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.OrderPendingEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEventMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.OrderEventMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.outbox.publisher.OutboxEventPublisher;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.domain.chatting.participant.Facade.command.ChattingCommandFacade;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
@@ -53,6 +54,7 @@ public class OrderCreateService {
     private final ObjectMapper objectMapper;
     private final RedisTemplate<String, String> redisTemplate;
     private final RedissonClient redissonClient;
+    private final OutboxEventPublisher outboxEventPublisher;
 
     @Transactional
     public OrderCreateResponse createOrder(OrderCreateRequest request, Long userId) {
@@ -161,18 +163,22 @@ public class OrderCreateService {
         // 7. Pending 이벤트
         try {
             OrderPendingEvent pendingEvt = orderEventMapper.toPendingEvent(
-                    order.getUser().getId(), groupBuy.getId(), userId,
+                    order.getGroupBuy().getUser().getId(), groupBuy.getId(), userId,
                     order.getUser().getNickname(), order.getQuantity()
             );
-            kafkaEventPublisher.publish(
+
+            outboxEventPublisher.publish(
+                    "Order",
+                    String.valueOf(order.getId()),
                     ORDER_STATUS_PENDING,
                     String.valueOf(order.getId()),
-                    objectMapper.writeValueAsString(pendingEvt)
+                    pendingEvt
             );
+
         } catch (JsonProcessingException e) {
             redisTemplate.opsForValue().increment(stockKey, request.getQuantity());
             redisTemplate.delete(orderCheckKey);
-            log.error("❌ PendingEvent serialization failed", e);
+            log.error("❌ PendingEvent outbox 저장 실패 ", e);
             throw new BusinessException(
                     ErrorCode.INTERNAL_SERVER_ERROR,
                     SERIALIZATION_FAIL


### PR DESCRIPTION
## 🔎 작업 개요
- 주문 생성·상태 변경 이벤트 발행을 기존 동기 Kafka 전송 방식에서 **outbox 패턴**으로 전환  
- `OrderCreateService`에서 주문 생성 시 발송되던 알림이 **구매자가 아닌 공구 주최자(host)** 에게 정상 전달되도록 수정

## 🛠️ 주요 변경 사항
- **OutboxEventPublisher** 도입  
  - `KafkaEventPublisher.publish(...)` → `OutboxEventPublisher.publish(...)` 호출로 대체  
  - `OutboxEventPublisherImpl` 구현체 등록  
- `OrderCreateService#createOrder`  
  - Pending 이벤트 발행 로직(7번) → Outbox 저장 코드로 교체  
  - `OrderPendingEvent` 생성 시 `hostId` 파라미터 순서 수정  
- 스프링 빈 설정  
  - `OutboxEventPublisher` 빈 주입  
  - 더 이상 직접 KafkaTemplate 호출하지 않도록 DI 정리  

## ✅ 검증 방법
1. **주문 생성** 시  
   - `outbox_event` 테이블에 `PENDING` 상태의 이벤트 레코드가 쌓이는지 확인  
2. **OutboxWorker** 동작 후  
   - `order.status.pending` 토픽에 JSON 페이로드 전송  
   - 페이로드에 올바른 `hostId`(공구 주최자 ID)가 포함되는지 확인  
3. **알림 수신**  
   - `OrderNotificationListener` → `SendOrderNotificationUseCase` 경로로  
   - 주최자 SSE 클라이언트가 주문 생성 알림을 정상 수신하는지 검증  

## 🔍 머지 전 확인사항
- [x] Outbox 테이블 스키마 및 스케줄러(`OutboxWorker`) 정상 동작 여부  
- [x] `OrderPendingEvent` JSON 구조(`hostId`, `orderId`, `groupBuyId` 등) 검증  
- [x] Redis 롤백(재고/잠금) 시 Outbox 트랜잭션 일관성 보장 확인  
- [ ] 기존 `KafkaEventPublisher` 의존성 제거 및 코드 잔여 여부 점검  

## ➕ 이슈 링크
- #217 
