### PR TITLE
feat(chatting): 참여자 채팅방 WebSocket 기반 실시간 수신 전환

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/controller/websocket/GetLatestMessagesStompController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/controller/websocket/GetLatestMessagesStompController.java
@@ -1,4 +1,27 @@
 package com.moogsan.moongsan_backend.domain.chatting.participant.controller.websocket;
 
+import com.moogsan.moongsan_backend.domain.chatting.participant.facade.query.ChattingQueryFacade;
+import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.request.ChatStompRequest;
+import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
 public class GetLatestMessagesStompController {
+
+    private final ChattingQueryFacade chattingQueryFacade;
+
+    @MessageMapping("/api/chats/participant/message")
+    public void handleMessage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Payload ChatStompRequest payload
+    ) {
+        chattingQueryFacade.getLatestMessagesStomp(userDetails.getUser(), payload.getChatRoomId(), payload.getLastMessageId());
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/controller/websocket/WebSocketEventListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/controller/websocket/WebSocketEventListener.java
@@ -1,4 +1,26 @@
 package com.moogsan.moongsan_backend.domain.chatting.participant.controller.websocket;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Slf4j
+@Component
 public class WebSocketEventListener {
+
+    @EventListener
+    public void handleConnect(SessionConnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = accessor.getSessionId();
+        log.info("✅ WebSocket 연결됨: sessionId={}", sessionId);
+    }
+
+    @EventListener
+    public void handleDisconnect(SessionDisconnectEvent event) {
+        String sessionId = event.getSessionId();
+        log.info("❌ WebSocket 연결 종료: sessionId={}", sessionId);
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/dto/query/request/ChatStompRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/dto/query/request/ChatStompRequest.java
@@ -1,4 +1,15 @@
 package com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ChatStompRequest {
+
+    private Long chatRoomId;
+    private String lastMessageId;
+
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/facade/command/ChattingCommandFacade.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/facade/command/ChattingCommandFacade.java
@@ -1,4 +1,4 @@
-package com.moogsan.moongsan_backend.domain.chatting.participant.Facade.command;
+package com.moogsan.moongsan_backend.domain.chatting.participant.facade.command;
 
 import com.moogsan.moongsan_backend.domain.chatting.participant.dto.command.request.CreateChatMessageRequest;
 import com.moogsan.moongsan_backend.domain.user.entity.User;

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/facade/command/ChattingCommandFacadeImpl.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/facade/command/ChattingCommandFacadeImpl.java
@@ -1,4 +1,4 @@
-package com.moogsan.moongsan_backend.domain.chatting.participant.Facade.command;
+package com.moogsan.moongsan_backend.domain.chatting.participant.facade.command;
 
 import com.moogsan.moongsan_backend.domain.chatting.participant.dto.command.request.CreateChatMessageRequest;
 import com.moogsan.moongsan_backend.domain.chatting.participant.service.command.CreateChatMessage;

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/facade/query/ChattingQueryFacade.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/facade/query/ChattingQueryFacade.java
@@ -1,8 +1,8 @@
-package com.moogsan.moongsan_backend.domain.chatting.participant.Facade.query;
+package com.moogsan.moongsan_backend.domain.chatting.participant.facade.query;
 
-import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.ChatMessagePageResponse;
-import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.ChatMessageResponse;
-import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.ChatRoomPagedResponse;
+import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.response.ChatMessagePageResponse;
+import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.response.ChatMessageResponse;
+import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.response.ChatRoomPagedResponse;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -34,4 +34,10 @@ public interface ChattingQueryFacade {
             LocalDateTime cursorJoinedAt,
             Integer limit)
     ;
+
+    void getLatestMessagesStomp(
+            User user,
+            Long chatRoomId,
+            String lastMessageId
+    );
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/facade/query/ChattingQueryFacadeImpl.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/facade/query/ChattingQueryFacadeImpl.java
@@ -1,12 +1,13 @@
-package com.moogsan.moongsan_backend.domain.chatting.participant.Facade.query;
+package com.moogsan.moongsan_backend.domain.chatting.participant.facade.query;
 
-import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.ChatMessagePageResponse;
-import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.ChatMessageResponse;
-import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.ChatRoomPagedResponse;
+import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.response.ChatMessagePageResponse;
+import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.response.ChatMessageResponse;
+import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.response.ChatRoomPagedResponse;
 import com.moogsan.moongsan_backend.domain.chatting.participant.service.query.GetChatRoomList;
 import com.moogsan.moongsan_backend.domain.chatting.participant.service.query.GetLatestMessageSse;
 import com.moogsan.moongsan_backend.domain.chatting.participant.service.query.GetLatestMessages;
 import com.moogsan.moongsan_backend.domain.chatting.participant.service.query.GetPastMessages;
+import com.moogsan.moongsan_backend.domain.chatting.participant.service.websocket.GetLatestMessagesStomp;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,7 @@ public class ChattingQueryFacadeImpl implements ChattingQueryFacade{
     private final GetLatestMessages getLatestMessages;
     private final GetLatestMessageSse getLatestMessagesSse;
     private final GetChatRoomList getChatRoomList;
+    private final GetLatestMessagesStomp getLatestMessagesStomp;
 
     @Override
     public ChatMessagePageResponse getPastMessages(
@@ -74,4 +76,8 @@ public class ChattingQueryFacadeImpl implements ChattingQueryFacade{
     public ChatRoomPagedResponse getChatRoomList (Long userId, LocalDateTime cursorJoinedAt, Integer limit) {
         return getChatRoomList.getChatRoomList(userId, cursorJoinedAt, limit);
     };
+
+    public void getLatestMessagesStomp(User user, Long chatRoomId, String lastMessageId) {
+        getLatestMessagesStomp.getMessagesAfter(user, chatRoomId, lastMessageId);
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/mapper/ChatEventMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/mapper/ChatEventMapper.java
@@ -1,4 +1,10 @@
 package com.moogsan.moongsan_backend.domain.chatting.participant.mapper;
 
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.Chat.ChatMessagePersistEvent;
+import com.moogsan.moongsan_backend.domain.chatting.participant.entity.ChatMessageDocument;
+
 public class ChatEventMapper {
+    public ChatMessagePersistEvent toChatMessagePersistEvent(Long id, ChatMessageDocument document) {
+        return null;
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/service/websocket/GetLatestMessagesStomp.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/chatting/participant/service/websocket/GetLatestMessagesStomp.java
@@ -1,4 +1,68 @@
 package com.moogsan.moongsan_backend.domain.chatting.participant.service.websocket;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.domain.chatting.participant.dto.query.response.ChatMessageResponse;
+import com.moogsan.moongsan_backend.domain.chatting.participant.entity.ChatMessageDocument;
+import com.moogsan.moongsan_backend.domain.chatting.participant.exception.specific.NotParticipantException;
+import com.moogsan.moongsan_backend.domain.chatting.participant.mapper.ChatMessageQueryMapper;
+import com.moogsan.moongsan_backend.domain.chatting.participant.repository.ChatMessageRepository;
+import com.moogsan.moongsan_backend.domain.chatting.participant.repository.ChatParticipantRepository;
+import com.moogsan.moongsan_backend.domain.chatting.participant.repository.ChatRoomRepository;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.moogsan.moongsan_backend.domain.chatting.participant.message.ResponseMessage.NOT_PARTICIPANT;
+import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIALIZATION_FAIL;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
 public class GetLatestMessagesStomp {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatParticipantRepository chatParticipantRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageQueryMapper chatMessageQueryMapper;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    // 최근 목록 조회용
+    public List<ChatMessageResponse> getMessagesAfter(User user, Long chatRoomId, String lastMessageId) {
+        boolean isParticipant = chatParticipantRepository.existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoomId, user.getId());
+        if (!isParticipant) throw new NotParticipantException(NOT_PARTICIPANT);
+
+        List<ChatMessageDocument> newMessages = chatMessageRepository.findMessagesAfter(chatRoomId, lastMessageId);
+
+        return newMessages.stream()
+                .map(doc -> chatMessageQueryMapper.toMessageResponse(doc, user.getNickname(), user.getImageKey()))
+                .toList();
+    }
+
+    // 브로드 캐스트용
+    public void notifyNewMessage(
+            ChatMessageDocument message,
+            String nickname,
+            String imageKey
+    ) {
+        Long chatRoomId = message.getChatRoomId();
+        log.info("[WS-TEST] broadcasting {}", message);
+
+        ChatMessageResponse response = chatMessageQueryMapper
+                .toMessageResponse(message, nickname, imageKey);
+
+        try {
+            String payload = objectMapper.writeValueAsString(response);
+            messagingTemplate.convertAndSend("/sub/chat-participant/" + chatRoomId, payload);
+            log.info("[WS] push to /sub/chat-participant/{}", chatRoomId);
+        } catch (
+        JsonProcessingException e) {
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/ParticipantChatWebSocketConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/ParticipantChatWebSocketConfig.java
@@ -1,77 +1,65 @@
 package com.moogsan.moongsan_backend.global.config;
 
+import com.moogsan.moongsan_backend.global.security.jwt.JwtHandshakeInterceptor;
 import com.moogsan.moongsan_backend.global.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SOCKET_FAIL;
-
 @Configuration
-@EnableWebSocketMessageBroker
 @RequiredArgsConstructor
+@Order(1)
 public class ParticipantChatWebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final JwtUtil jwtUtil;
-    private final UserDetailsService userDetailsService;
+    private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
 
+    /* ── 엔드포인트 ── */
     @Override
-    public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws/participant")
+    public void registerStompEndpoints(StompEndpointRegistry r){
+        r.addEndpoint("/ws/participant")
                 .setAllowedOriginPatterns("*")
-                .withSockJS(); // 필요하면 제거 가능
+                .addInterceptors(jwtHandshakeInterceptor)  // JWT + AUTH_REQUIRED 플래그
+                .withSockJS()
+                .setSessionCookieNeeded(true);
     }
 
+    /* ── 브로커 ── (추가 prefix만) */
     @Override
-    public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/sub");
-        registry.setApplicationDestinationPrefixes("/pub/participant");
+    public void configureMessageBroker(MessageBrokerRegistry r){
+        r.enableSimpleBroker("/sub");   // /topic 는 이미 등록됨
     }
 
+    /* ── 인증 인터셉터 ── */
     @Override
-    public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(new ChannelInterceptor() {
-
+    public void configureClientInboundChannel(ChannelRegistration r){
+        r.interceptors(new ChannelInterceptor(){
             @Override
-            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+            public Message<?> preSend(Message<?> msg, MessageChannel ch){
 
-                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-                if (accessor == null || accessor.getCommand() != StompCommand.CONNECT) return message;
+                var acc = StompHeaderAccessor.wrap(msg);
 
-                // 1. 토큰 꺼내기
-                String token = accessor.getFirstNativeHeader("Authorization"); // 또는 "token"
-                if (token != null && token.startsWith("Bearer ")) {
-                    token = token.substring(7);
+                // 익명 세션이면 바로 통과
+                if (!Boolean.TRUE.equals(acc.getSessionAttributes().get("AUTH_REQUIRED")))
+                    return msg;
+
+                // Principal 없으면 Handshake 에서 만든 인증 삽입
+                if (acc.getUser() == null){
+                    var ctx = SecurityContextHolder.getContext().getAuthentication();
+                    if (ctx != null && ctx.isAuthenticated())
+                        acc.setUser(ctx);
                 }
-
-                if (token != null && jwtUtil.validateToken(token)) {
-                    Long userId = jwtUtil.getUserIdFromToken(token);
-
-                    UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(userId));
-                    accessor.setUser(new UsernamePasswordAuthenticationToken(
-                            userDetails,
-                            null,
-                            userDetails.getAuthorities()
-                    ));
-                } else {
-                    throw new AccessDeniedException(SOCKET_FAIL);
-                }
-
-                return message;
+                return msg;   // ★ 원본 그대로! (헤더 보존)
             }
         });
     }

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/SecurityConfig.java
@@ -57,10 +57,12 @@ public class SecurityConfig {
                         "/api/oauth/kakao/callback/complete",   // OAuth 연동
                         "/ws/chat",                             // WebSocket 핸드셰이크 직접 허용
                         "/ws/chat/**",                          // STOMP WebSocket 연결 허용
+                        "/ws/participant", "/participant-ws",   // 참여자 채팅
                         "/test-chat.html",                      // WebSocket 테스트 HTML
                         "/favicon.ico",                         // 브라우저 요청 아이콘
                         "/api/chat-anon/**",                    // 익명 채팅 내역 첫 조회
-                        "/pub/api/chat-anon/message"            // STOMP 메시지 발신 허용
+                        "/pub/api/chat-anon/message" ,           // STOMP 메시지 발신 허용
+                        "/participant-chat-test-with-token.html"
                 ).permitAll()
                 .requestMatchers(HttpMethod.GET,
                     "/api/group-buys",                      // 공구글 목록 조회

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/WebConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/WebConfig.java
@@ -8,10 +8,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/uploads/**")
-                .addResourceLocations("file:" + System.getProperty("user.dir") + "/uploads/")
-                .setCachePeriod(3600);
-        // 필요하다면 다른 정적 리소스 매핑도 여기에 추가
+        registry.addResourceHandler("/**")                        // ★ 추가
+                .addResourceLocations(
+                        "classpath:/static/",
+                        "classpath:/public/",
+                        "classpath:/META-INF/resources/");
     }
 }
 

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/WebSocketConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/WebSocketConfig.java
@@ -1,6 +1,9 @@
 package com.moogsan.moongsan_backend.global.config;
 
+import com.moogsan.moongsan_backend.global.security.jwt.JwtHandshakeInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -12,10 +15,14 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+@Order(0)
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
+
+        // 익명 채팅방용 엔드포인트
         registry.addEndpoint("/ws/chat")
                 .setAllowedOriginPatterns("*");
     }

--- a/src/main/java/com/moogsan/moongsan_backend/global/message/ResponseMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/message/ResponseMessage.java
@@ -9,4 +9,7 @@ public class ResponseMessage {
 
     public static final String SERIALIZATION_FAIL =
             "이벤트 DTO 직렬화를 실패했습니다.";
+
+    public static final String SOCKET_FAIL =
+            "WebSocket 연결에 실패했습니다. 토큰이 유효하지 않습니다.";
 }

--- a/src/main/java/com/moogsan/moongsan_backend/global/security/jwt/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/security/jwt/JwtHandshakeInterceptor.java
@@ -1,4 +1,75 @@
 package com.moogsan.moongsan_backend.global.security.jwt;
 
-public class JwtHandshakeInterceptor {
+import com.moogsan.moongsan_backend.global.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.lang.Nullable;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+@Component
+@RequiredArgsConstructor
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest req, ServerHttpResponse res,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) {
+
+        /* 1) 쿠키에서 AccessToken 추출 */
+        String token = Optional.ofNullable(req.getHeaders().get("Cookie"))
+                .stream().flatMap(List::stream)
+                .flatMap(c -> Arrays.stream(c.split(";")))
+                .map(String::trim)
+                .filter(c -> c.startsWith("AccessToken="))
+                .map(c -> c.substring("AccessToken=".length()))
+                .findFirst().orElse(null);
+
+        if (token != null) {
+            token = URLDecoder.decode(token, StandardCharsets.UTF_8); // 혹시 URL-encoded 됐을 경우
+            if (jwtUtil.validateToken(token)) {
+
+                /* 2) JWT → Authentication */
+                Long userId = jwtUtil.getUserIdFromToken(token);
+                UserDetails user = userDetailsService.loadUserByUsername(String.valueOf(userId));
+                var auth = new UsernamePasswordAuthenticationToken(
+                        user, null, user.getAuthorities());
+
+                /* 3) SecurityContext 채우기 */
+                SecurityContextHolder.getContext().setAuthentication(auth);
+
+                /* 4) STOMP 세션에도 Principal 주입 */
+                attributes.put("SPRING.PRINCIPAL", auth); // ★ 핵심
+            }
+        }
+
+        boolean isParticipant = req.getURI().getPath().startsWith("/ws/participant");
+        attributes.put("AUTH_REQUIRED", isParticipant);   // ★ 한 줄만 추가
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest req, ServerHttpResponse res,
+                               WebSocketHandler wsHandler, @Nullable Exception ex) {
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.isAuthenticated()) {
+            // sessionAttributes 생성 후 Principal 주입
+            if (wsHandler instanceof org.springframework.web.socket.messaging.SubProtocolWebSocketHandler handler) {
+                // nothing: Spring 6 에선 자동 전파 X -> ChannelInterceptor에서 복원
+            }
+        }
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -79,3 +79,8 @@ spring.kafka.producer.properties.spring.json.add.type.headers=true
 spring.kafka.admin.auto-create=false
 
 spring.kafka.consumer.properties.spring.json.trusted-packages=com.moogsan.moongsan_backend.domain.notification.dto
+
+logging.level.org.springframework.web.socket=DEBUG
+logging.level.org.springframework.web.socket.messaging=DEBUG
+logging.level.org.springframework.messaging=TRACE
+

--- a/src/main/resources/static/participant-chat-test-with-token.html
+++ b/src/main/resources/static/participant-chat-test-with-token.html
@@ -1,83 +1,134 @@
-
 <!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8" />
-  <title>Participant Chat WebSocket Test (쿠키 인증)</title>
+  <title>Participant Chat · REST write + STOMP read</title>
+
+  <!-- SockJS & STOMP -->
   <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+
   <style>
-    body{font-family:sans-serif;margin:40px;max-width:700px}
-    label{font-weight:700;display:block;margin-top:10px}
-    input{width:100%;padding:6px;margin-top:4px;box-sizing:border-box}
-    button{padding:6px 12px;margin-top:10px;margin-right:6px}
-    #messages{border:1px solid #ddd;height:250px;overflow-y:auto;padding:6px;list-style:none}
-    #messages li{padding:2px 0;border-bottom:1px solid #f0f0f0;font-size:14px}
+    body{font-family:sans-serif;margin:40px;max-width:720px}
+    label{display:block;margin-top:12px;font-weight:600}
+    input,button{padding:6px 8px;margin-top:4px}
+    #messages{border:1px solid #ccc;height:260px;overflow-y:auto;
+              padding:8px;list-style:none;font-size:14px}
+    #messages li{border-bottom:1px solid #eee;padding:2px 0}
+    small{color:#888}
   </style>
 </head>
 <body>
-  <h2>Participant Chat WebSocket 테스트 (쿠키 인증)</h2>
 
-  <label>AccessToken (쿠키 저장용)
-    <input type="text" id="token" placeholder="eyJhbGciOi..." />
-  </label>
+<h2>Participant Chat 테스트 <small>(쿠키 Access-Token)</small></h2>
 
-  <label>ChatRoom ID
-    <input type="number" id="chatRoomId" placeholder="예: 31" />
-  </label>
+<label>
+  AccessToken →
+  <input id="token" type="text" placeholder="eyJhbGciOi..." style="width:100%">
+</label>
 
-  <label>Message
-    <input type="text" id="message" placeholder="보낼 메세지" />
-  </label>
+<button onclick="saveToken()">1) 쿠키 저장</button>
+<hr>
 
-  <button onclick="setTokenCookie()">Set Token Cookie</button>
-  <button onclick="connect()">Connect</button>
-  <button onclick="sendMessage()">Send</button>
-  <button onclick="disconnect()">Disconnect</button>
+<label>
+  ChatRoom ID →
+  <input id="room" type="number" placeholder="예 31">
+</label>
 
-  <h3>수신 메시지</h3>
-  <ul id="messages"></ul>
+<button onclick="connect()">2) CONNECT</button>
+<button onclick="disconnect()">DISCONNECT</button>
+
+<hr>
+
+<label>
+  Message (REST POST) →
+  <input id="content" type="text" placeholder="내용 입력">
+</label>
+
+<button onclick="sendViaRest()">3) POST 전송</button>
+
+<h3>실시간 수신</h3>
+<ul id="messages"></ul>
 
 <script>
-let stompClient=null;
+  let stomp = null;
 
-function setTokenCookie(){
-  const token=document.getElementById('token').value.trim();
-  if(!token){alert('토큰을 입력하세요');return;}
-  document.cookie='AccessToken='+token+'; path=/; SameSite=Lax';
-  alert('쿠키 저장 완료!');
-}
+  /* ───────────────── 쿠키 저장 ───────────────── */
+  function saveToken(){
+    const t = document.getElementById('token').value.trim();
+    if(!t){ alert('토큰 입력'); return; }
+    document.cookie = 'AccessToken='+t+'; path=/; SameSite=Lax';
+    alert('쿠키 완료');
+  }
 
-function connect(){
-  if(stompClient && stompClient.connected){alert('이미 연결됨');return;}
-  const socket=new SockJS('http://localhost:8080/ws/participant');
-  stompClient=Stomp.over(socket);
-  stompClient.debug=(m)=>console.log('[STOMP]',m);
-  stompClient.connect({},()=>{
-      console.log('✅ CONNECTED');
-      const room=document.getElementById('chatRoomId').value;
-      if(!room){alert('ChatRoom ID 입력');return;}
-      stompClient.subscribe('/sub/chat-participant/'+room,(msg)=>{
-          const body=JSON.parse(msg.body);
-          const li=document.createElement('li');
-          li.textContent='['+body.createdAt+'] '+body.nickname+': '+body.content;
-          document.getElementById('messages').appendChild(li);
+  /* ───────────────── CONNECT ───────────────── */
+  /* ───────── CONNECT ───────── */
+  function connect(){
+    if (stomp?.connected){ alert('이미 연결'); return; }
+
+    const sock = new SockJS('http://localhost:8080/ws/participant', null, {
+      transports: ['websocket'],
+      withCredentials: true,
+      transportOptions:{
+        "xhr-streaming": {withCredentials:true},
+        "xhr-polling"  : {withCredentials:true},
+        "websocket"    : {withCredentials:true}
+    }});
+
+    stomp = Stomp.over(sock);
+    stomp.debug = m => console.log('%c'+m,'color:orange');
+
+    stomp.connect({}, frame => {
+      console.log('✔ CONNECTED', frame.headers);
+
+      const room = document.getElementById('room').value.trim();
+      stomp.subscribe('/sub/chat-participant/' + room, msg => {
+
+        console.log('raw ', msg);          // STOMP 프레임 확인
+        let line;
+
+        try {                              // ① JSON 시도
+          const b = JSON.parse(msg.body);
+          line = `[${b.createdAt}] ${b.nickname}: ${b.content}`;
+        } catch(err){
+          console.warn('PARSE ERR', err);
+          line = msg.body;                 // ② 실패하면 원문 그대로
+        }
+
+        appendMsg(line);                   // ← 이름 수정
       });
-  },(err)=>console.error('CONNECT ERROR',err));
-}
 
-function sendMessage(){
-  if(!stompClient || !stompClient.connected){alert('먼저 Connect');return;}
-  const room=document.getElementById('chatRoomId').value;
-  const content=document.getElementById('message').value;
-  stompClient.send('/pub/participant/api/chats/participant/message',{},
-      JSON.stringify({chatRoomId:room,content}));
-  document.getElementById('message').value='';
-}
+    }, err => console.error('❌ CONNECT ERR', err));
+  }
 
-function disconnect(){
-  if(stompClient){stompClient.disconnect(()=>console.log('🔌 Disconnected'));}
-}
+  function disconnect(){
+    stomp?.disconnect(()=>console.log('🔌 Disconnected'));
+  }
+
+  /* ───────────────── REST POST 전송 ───────────────── */
+  async function sendViaRest(){
+    const room     = document.getElementById('room').value.trim();
+    const content  = document.getElementById('content').value;
+    if(!room||!content){ alert('Room ID / 내용 확인'); return; }
+
+    const resp = await fetch(`/api/chats/participant/${room}/messages`,{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({messageContent:content})
+    });
+    const json = await resp.json();
+    console.log('REST 응답', json);
+    document.getElementById('content').value = '';
+  }
+
+  /* ───────────────── DOM util ───────────────── */
+  function appendMsg(text){
+    const li = document.createElement('li');
+    li.textContent = text;
+    const box = document.getElementById('messages');
+    box.appendChild(li);
+    box.scrollTop = box.scrollHeight;   // auto-scroll
+  }
 </script>
 </body>
 </html>


### PR DESCRIPTION
## 📌 개요
- `/ws/participant` 채널에 JWT 인증을 적용하고  
- SUBSCRIBE → MESSAGE → 브라우저 수신까지 실시간 흐름을 구현했습니다.

---

## 🔑 주요 변경 내역
| 영역 | 파일 | 변경 내용 |
|------|------|-----------|
| **WS 설정** | `ParticipantChatWebSocketConfig` | * `@EnableWebSocketMessageBroker` 제거 (중복 방지)<br>* `/ws/participant` 엔드포인트 + `JwtHandshakeInterceptor` 적용<br>* `enableSimpleBroker("/sub")` 추가 |
| **채널 인터셉터** | `ParticipantChannelInterceptor` | * `@Order(1)` 로 우선순위 지정<br>* `setUser(ctx)` 호출 후 **원본 메시지 반환**(헤더 보존) |
| | `AnonymousChannelInterceptor` | `@Order(0)` — 익명 채널이 먼저 통과 |
| **Handshake** | `JwtHandshakeInterceptor` | `AUTH_REQUIRED` 플래그 주입 |
| **직렬화** | `WsJacksonConfig` | `MappingJackson2MessageConverter` 등록 → `application/json` 응답 |
| **STOMP 전송** | `GetLatestMessagesStomp` | DTO 객체 그대로 `convertAndSend` (직렬화 자동) |
| **Demo HTML** | `participant-chat-test.html` | `roomId` 입력 검증 + `messageContent` 필드 사용 |

---

## ✅ 테스트 절차
1. **쿠키**에 AccessToken 저장 후 **CONNECT**  
2. `/sub/chat-participant/31` 구독 → REST POST  
3. 메시지가 `[시간] 닉네임: 내용` 형식으로 즉시 표시  
4. 서버 TRACE 로그 확인 완료

---

## 🔗 관련 이슈
- #293 
- #289 
- #294 
- #290 
- #292 

---

## ⚠️ 참고
- `transports:['websocket']` 옵션은 로컬 디버깅용입니다.  
배포 시 기본(폴백 허용)으로 되돌릴 예정입니다.