### PR TITLE
feat(groupbuy): SSE 기반 상세 페이지 실시간 갱신 구현

### DIFF
--- a/infra/scripts/create-topics.sh
+++ b/infra/scripts/create-topics.sh
@@ -26,6 +26,9 @@ docker exec -it kafka-1 kafka-topics.sh --create --bootstrap-server ${BROKER} \
 
 # 공구 상태
 docker exec -it kafka-1 kafka-topics.sh --create --bootstrap-server ${BROKER} \
+  --partitions 2 --replication-factor 3 --topic groupbuy.detail.updated
+
+docker exec -it kafka-1 kafka-topics.sh --create --bootstrap-server ${BROKER} \
   --partitions 2 --replication-factor 3 --topic groupbuy.status.closed
 
 docker exec -it kafka-1 kafka-topics.sh --create --bootstrap-server ${BROKER} \

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/ConsumerGroups.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/ConsumerGroups.java
@@ -1,0 +1,9 @@
+package com.moogsan.moongsan_backend.adapters.kafka.consumer;
+
+public final class ConsumerGroups {
+    private ConsumerGroups() {}
+
+    public static final String NOTIFICATION = "notification-service";
+
+    public static final String REALTIME_GROUPBUY = "realtime-groupbuy-service";
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/listener/ChatNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/listener/ChatNotificationListener.java
@@ -1,0 +1,4 @@
+package com.moogsan.moongsan_backend.adapters.kafka.consumer.listener;
+
+public class ChatNotificationListener {
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/listener/GroupBuyNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/listener/GroupBuyNotificationListener.java
@@ -1,6 +1,7 @@
-package com.moogsan.moongsan_backend.adapters.kafka.listener;
+package com.moogsan.moongsan_backend.adapters.kafka.consumer.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.consumer.ConsumerGroups;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyPickupUpdatedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyStatusClosedEvent;

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/listener/GroupBuyRealtimeListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/listener/GroupBuyRealtimeListener.java
@@ -1,0 +1,35 @@
+package com.moogsan.moongsan_backend.adapters.kafka.consumer.listener;
+
+import com.moogsan.moongsan_backend.adapters.kafka.consumer.ConsumerGroups;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIALIZATION_FAIL;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GroupBuyRealtimeListener {
+
+    @KafkaListener(
+            topics = KafkaTopics.GROUPBUY_DETAIL_UPDATED,
+            groupId = ConsumerGroups.REALTIME_GROUPBUY
+    )
+    public void onGroupBuyUpdated(GroupBuyUpdatedEvent event,
+                                  Acknowledgment ack) {
+        try {
+
+            log.debug("groupBuy.detail.updated 수신: {}", event);
+            useCase.handleGroupBuyDetailUpdated(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("❌ GroupBuyUpdatedEvent 역직렬화 실패. raw", e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/listener/GroupBuyRealtimeListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/listener/GroupBuyRealtimeListener.java
@@ -3,6 +3,7 @@ package com.moogsan.moongsan_backend.adapters.kafka.consumer.listener;
 import com.moogsan.moongsan_backend.adapters.kafka.consumer.ConsumerGroups;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.useCase.BroadcastGroupBuyUpdatedEventUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -16,6 +17,8 @@ import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIAL
 @RequiredArgsConstructor
 public class GroupBuyRealtimeListener {
 
+    private final BroadcastGroupBuyUpdatedEventUseCase useCase;
+
     @KafkaListener(
             topics = KafkaTopics.GROUPBUY_DETAIL_UPDATED,
             groupId = ConsumerGroups.REALTIME_GROUPBUY
@@ -25,7 +28,7 @@ public class GroupBuyRealtimeListener {
         try {
 
             log.debug("groupBuy.detail.updated 수신: {}", event);
-            useCase.handleGroupBuyDetailUpdated(event);
+            useCase.handleGroupBuyUpdated(event);
             ack.acknowledge();
         } catch (Exception e) {
             log.error("❌ GroupBuyUpdatedEvent 역직렬화 실패. raw", e);

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/listener/OrderNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/consumer/listener/OrderNotificationListener.java
@@ -1,6 +1,7 @@
-package com.moogsan.moongsan_backend.adapters.kafka.listener;
+package com.moogsan.moongsan_backend.adapters.kafka.consumer.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.consumer.ConsumerGroups;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.KafkaTopics;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.Order.OrderCanceledEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.Order.OrderConfirmedEvent;

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/ChatNotificationListener.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/ChatNotificationListener.java
@@ -1,4 +1,0 @@
-package com.moogsan.moongsan_backend.adapters.kafka.listener;
-
-public class ChatNotificationListener {
-}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/ConsumerGroups.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/listener/ConsumerGroups.java
@@ -1,7 +1,0 @@
-package com.moogsan.moongsan_backend.adapters.kafka.listener;
-
-public final class ConsumerGroups {
-    private ConsumerGroups() {}
-
-    public static final String NOTIFICATION = "notification-service";
-}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/KafkaTopics.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/KafkaTopics.java
@@ -16,6 +16,7 @@ public interface KafkaTopics {
     String GROUPBUY_STATUS_CLOSED = "groupbuy.status.closed";
     String GROUPBUY_STATUS_FINALIZED = "groupbuy.status.finalized";
     String GROUPBUY_STATUS_ENDED = "groupbuy.status.ended";
+    String GROUPBUY_DETAIL_UPDATED = "groupbuy.detail.updated";
 
     // 주문 상태 관련 이벤트
     String ORDER_STATUS_PENDING = "order.status.pending";

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuy/GroupBuyUpdatedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuy/GroupBuyUpdatedEvent.java
@@ -1,0 +1,4 @@
+package com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy;
+
+public class GroupBuyUpdatedEvent {
+}

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuy/GroupBuyUpdatedEvent.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/dto/GroupBuy/GroupBuyUpdatedEvent.java
@@ -1,4 +1,19 @@
 package com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy;
 
-public class GroupBuyUpdatedEvent {
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.BaseEvent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * 토픽: groupbuy.detail.updated
+ * 설명: 공구 체결 알림용 이벤트
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class GroupBuyUpdatedEvent extends BaseEvent {
+    private Long groupBuyId;  // 공구 게시글 아이디
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/kafka/producer/mapper/GroupBuyEventMapper.java
@@ -99,4 +99,14 @@ public class GroupBuyEventMapper {
                 .occurredAt(Instant.now().toString())
                 .build();
     }
+
+    // 공동구매 상세 변경 이벤트
+    public GroupBuyUpdatedEvent toGroupBuyDetailUpdated(
+            Long groupBuyId
+    ) {
+        return GroupBuyUpdatedEvent.builder()
+                .groupBuyId(groupBuyId)
+                .occurredAt(Instant.now().toString())
+                .build();
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/adapters/sse/SseEmitterRepository.java
+++ b/src/main/java/com/moogsan/moongsan_backend/adapters/sse/SseEmitterRepository.java
@@ -44,6 +44,18 @@ public class SseEmitterRepository {
         }
     }
 
+    public <T> void send(String key, T data) {
+        List<SseEmitter> list = emitters.getOrDefault(key, Collections.emptyList());
+        for (SseEmitter emitter : list) {
+            try {
+                // event 이름 없이 data 만 전송
+                emitter.send(data);
+            } catch (Exception ex) {
+                emitter.completeWithError(ex);
+            }
+        }
+    }
+
     private void remove(String key, SseEmitter emitter) {
         List<SseEmitter> list = emitters.get(key);
         if (list != null) list.remove(emitter);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/sse/GroupBuySseController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/sse/GroupBuySseController.java
@@ -1,11 +1,35 @@
-package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService;
+package com.moogsan.moongsan_backend.domain.groupbuy.controller.sse;
 
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.GroupBuyRealtime;
+import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
+import com.moogsan.moongsan_backend.global.exception.specific.UnauthenticatedAccessException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/sse/group-buys")
+@RequestMapping("/api/group-buys")
 public class GroupBuySseController {
+
+    private final GroupBuyRealtime groupBuyRealtime;
+
+    @GetMapping(
+            value = "/{groupBuyId}/sse",
+            produces = MediaType.TEXT_EVENT_STREAM_VALUE
+    )
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long groupBuyId) {
+
+        if (userDetails == null) throw new UnauthenticatedAccessException("로그인이 필요합니다.");
+
+        return groupBuyRealtime.subscribe(groupBuyId);
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/sse/GroupBuySseController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/controller/sse/GroupBuySseController.java
@@ -1,0 +1,11 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/sse/group-buys")
+public class GroupBuySseController {
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CancelGroupBuyParticipant.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/CancelGroupBuyParticipant.java
@@ -1,8 +1,10 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService;
 
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.policy.DueSoonPolicy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +21,7 @@ import java.util.List;
 public class CancelGroupBuyParticipant {
 
     private final OrderRepository orderRepository;
-    private final GroupBuyRepository groupBuyRepository;
+    private final RealtimePublisher realtimePublisher;
     private final DueSoonPolicy dueSoonPolicy;
 
     /**
@@ -43,6 +45,12 @@ public class CancelGroupBuyParticipant {
 
             // 주문 상태 변경
             order.setStatus("CANCELED");
+
+            // 공구 상태 업데이트 이벤트 발행
+            GroupBuyUpdatedEvent event = GroupBuyUpdatedEvent.builder()
+                    .groupBuyId(order.getGroupBuy().getId())
+                    .build();
+            realtimePublisher.publish(event);
 
             // dueSoon 상태 업데이트
             groupBuy.updateDueSoonStatus(dueSoonPolicy);

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/ClosePastDueGroupBuys.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/ClosePastDueGroupBuys.java
@@ -3,10 +3,12 @@ package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandServ
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyStatusClosedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEventMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,7 @@ public class ClosePastDueGroupBuys {
     private final GroupBuyEventMapper eventMapper;
     private final ObjectMapper objectMapper;
     private final OrderRepository orderRepository;
+    private final RealtimePublisher realtimePublisher;
 
     ///  공구 모집 마감(백그라운드 API)
     public void closePastDueGroupBuys(LocalDateTime now) {
@@ -39,6 +42,12 @@ public class ClosePastDueGroupBuys {
 
         for (GroupBuy gb : expired) {
             gb.changePostStatus("CLOSED");
+
+            // 공구 상태 업데이트 이벤트 발행
+            GroupBuyUpdatedEvent event = GroupBuyUpdatedEvent.builder()
+                    .groupBuyId(gb.getId())
+                    .build();
+            realtimePublisher.publish(event);
 
             List<Order> orders = orderRepository.findAllByGroupBuyIdOrderByStatusCustom(gb.getId());
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/DeleteGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/DeleteGroupBuy.java
@@ -1,10 +1,12 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService;
 
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ public class DeleteGroupBuy {
 
     private final GroupBuyRepository groupBuyRepository;
     private final OrderRepository orderRepository;
+    private final RealtimePublisher realtimePublisher;
     private final Clock clock;
 
     /// 공구 게시글 삭제: 참여자가 아무도 없는, 주문 레코드가 없는 경우이므로 하드 삭제
@@ -51,6 +54,12 @@ public class DeleteGroupBuy {
 
         groupBuy.changePostStatus("DELETED");
         groupBuyRepository.save(groupBuy);
+
+        // 공구 상태 업데이트 이벤트 발행
+        GroupBuyUpdatedEvent event = GroupBuyUpdatedEvent.builder()
+                .groupBuyId(groupBuy.getId())
+                .build();
+        realtimePublisher.publish(event);
 
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndGroupBuy.java
@@ -3,6 +3,7 @@ package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandServ
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyStatusEndedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEventMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
@@ -10,6 +11,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyI
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
@@ -37,6 +39,7 @@ public class EndGroupBuy {
     private final KafkaEventPublisher kafkaEventPublisher;
     private final GroupBuyEventMapper eventMapper;
     private final ObjectMapper objectMapper;
+    private final RealtimePublisher realtimePublisher;
 
     /// 공구 게시글 공구 종료
     public void endGroupBuy(User currentUser, Long postId) {
@@ -70,6 +73,12 @@ public class EndGroupBuy {
         groupBuyRepository.save(groupBuy);
 
         // TODO V3에서는 참여자 채팅방 해제 카운트 시작(2주- CS 고려), 익명 채팅방 즉시 해제
+
+        // 공구 상태 업데이트 이벤트 발행
+        GroupBuyUpdatedEvent event = GroupBuyUpdatedEvent.builder()
+                .groupBuyId(groupBuy.getId())
+                .build();
+        realtimePublisher.publish(event);
 
         try {
             List<Order> orders = orderRepository.findAllByGroupBuyIdOrderByStatusCustom(groupBuy.getId());

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndPastPickupGroupBuys.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/EndPastPickupGroupBuys.java
@@ -3,10 +3,12 @@ package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandServ
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyStatusEndedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEventMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,7 @@ public class EndPastPickupGroupBuys {
     private final KafkaEventPublisher kafkaEventPublisher;
     private final GroupBuyEventMapper eventMapper;
     private final ObjectMapper objectMapper;
+    private RealtimePublisher realtimePublisher;
 
     /// 공구 종료 (백그라운드 API)
     public void endPastPickupGroupBuys(LocalDateTime now) {
@@ -39,6 +42,13 @@ public class EndPastPickupGroupBuys {
 
         for (GroupBuy gb : toEnd) {
             gb.changePostStatus("ENDED");
+
+            // 공구 상태 업데이트 이벤트 발행
+            GroupBuyUpdatedEvent event = GroupBuyUpdatedEvent.builder()
+                    .groupBuyId(gb.getId())
+                    .build();
+            realtimePublisher.publish(event);
+
             try {
                 List<Order> orders = orderRepository.findAllByGroupBuyIdOrderByStatusCustom(gb.getId());
 

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/LeaveGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/LeaveGroupBuy.java
@@ -2,6 +2,7 @@ package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandServ
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.Order.OrderCanceledEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.OrderEventMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
@@ -11,6 +12,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyI
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
 import com.moogsan.moongsan_backend.domain.groupbuy.policy.DueSoonPolicy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.exception.specific.OrderNotFoundException;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
@@ -39,6 +41,7 @@ public class LeaveGroupBuy {
     private final DueSoonPolicy dueSoonPolicy;
     private final ChattingCommandFacade chattingCommandFacade;
     private final KafkaEventPublisher kafkaEventPublisher;
+    private final RealtimePublisher realtimePublisher;
     private final OrderEventMapper eventMapper;
     private final ObjectMapper objectMapper;
     private final Clock clock;
@@ -80,6 +83,12 @@ public class LeaveGroupBuy {
         groupBuy.updateDueSoonStatus(dueSoonPolicy);
 
         orderRepository.save(order);
+
+        // 공구 상태 업데이트 이벤트 발행
+        GroupBuyUpdatedEvent event = GroupBuyUpdatedEvent.builder()
+                .groupBuyId(order.getGroupBuy().getId())
+                .build();
+        realtimePublisher.publish(event);
 
         int price = order.getPrice();
         int quantity = order.getQuantity();

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/UpdateGroupBuy.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuyCommandService/UpdateGroupBuy.java
@@ -3,6 +3,7 @@ package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandServ
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyPickupUpdatedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEventMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.domain.groupbuy.dto.command.request.UpdateGroupBuyRequest;
@@ -10,6 +11,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyInvalidStateException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotFoundException;
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.image.entity.Image;
 import com.moogsan.moongsan_backend.domain.image.mapper.ImageMapper;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
@@ -45,6 +47,7 @@ public class UpdateGroupBuy {
     private final GroupBuyEventMapper eventMapper;
     private final ObjectMapper objectMapper;
     private final KafkaEventPublisher kafkaEventPublisher;
+    private final RealtimePublisher realtimePublisher;
     private final Clock clock;
 
     /// 공구 게시글 수정
@@ -105,6 +108,12 @@ public class UpdateGroupBuy {
         imageMapper.mapImagesToGroupBuy(finalKeys, gb);
 
         groupBuyRepository.save(gb);
+
+        // 공구 상태 업데이트 이벤트 발행
+        GroupBuyUpdatedEvent event = GroupBuyUpdatedEvent.builder()
+                .groupBuyId(gb.getId())
+                .build();
+        realtimePublisher.publish(event);
 
         if (updateGroupBuyRequest.getDateModificationReason() != null) {
             List<Order> orders = orderRepository.findAllByGroupBuyIdOrderByStatusCustom(groupBuy.getId());

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/GroupBuyRealtime.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/GroupBuyRealtime.java
@@ -1,0 +1,4 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService;
+
+public class GroupBuyRealtime {
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/GroupBuyRealtime.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/GroupBuyRealtime.java
@@ -1,4 +1,21 @@
 package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService;
 
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class GroupBuyRealtime {
+
+    private final SseEmitterRepository emitterRepository;
+
+    public SseEmitter subscribe(Long groupBuyId) {
+        return emitterRepository.add(groupBuyId.toString());
+    }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/publisher/RealtimePublisher.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/publisher/RealtimePublisher.java
@@ -1,0 +1,34 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.service.publisher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
+import com.moogsan.moongsan_backend.adapters.sse.SseEmitterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RealtimePublisher {
+    private final SseEmitterRepository emitterRepository;
+    private final ObjectMapper objectMapper;
+
+    public void publish(GroupBuyUpdatedEvent event) {
+        try {
+            // 필요한 경우 디버그용 JSON 직렬화
+            String json = objectMapper.writeValueAsString(event);
+
+            emitterRepository.send(
+                    event.getGroupBuyId().toString(),
+                    event.getGroupBuyId().toString()
+            );
+
+            log.debug("📡 SSE Broadcast → {}", event.getGroupBuyId());
+
+        } catch (Exception e) {
+            throw new RuntimeException("Realtime publish failed", e);
+        }
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/publisher/RealtimePublisher.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/publisher/RealtimePublisher.java
@@ -1,4 +1,4 @@
-package com.moogsan.moongsan_backend.domain.groupbuy.service.publisher;
+package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/useCase/BroadcastGroupBuyUpdatedEventUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/useCase/BroadcastGroupBuyUpdatedEventUseCase.java
@@ -1,5 +1,7 @@
-package com.moogsan.moongsan_backend.domain.groupbuy.service.useCase;
+package com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.useCase;
 
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,5 +15,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class BroadcastGroupBuyUpdatedEventUseCase {
 
     private final NotificationTemplateRegistry templateRegistry;
-    private final
+    private final RealtimePublisher realtimePublisher;
+
+    public void handleGroupBuyUpdated(GroupBuyUpdatedEvent event) {
+        if (event == null || event.getGroupBuyId() == null) {
+            log.warn("⚠️  GroupBuyUpdatedEvent 잘못된 페이로드: {}", event);
+            return;
+        }
+
+        // 실시간 브로드캐스트 (Thin Event)로 처리함
+        realtimePublisher.publish(event);
+
+        log.debug("📡 GroupBuyUpdatedEvent 브로드캐스트 완료: groupBuyId={}", event.getGroupBuyId());
+    }
+
 }

--- a/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/useCase/BroadcastGroupBuyUpdatedEventUseCase.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/groupbuy/service/GroupBuySseService/useCase/BroadcastGroupBuyUpdatedEventUseCase.java
@@ -1,0 +1,17 @@
+package com.moogsan.moongsan_backend.domain.groupbuy.service.useCase;
+
+import com.moogsan.moongsan_backend.domain.notification.template.NotificationTemplateRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BroadcastGroupBuyUpdatedEventUseCase {
+
+    private final NotificationTemplateRegistry templateRegistry;
+    private final
+}

--- a/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderCreateService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/order/service/OrderCreateService.java
@@ -3,6 +3,7 @@ package com.moogsan.moongsan_backend.domain.order.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyStatusClosedEvent;
+import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.GroupBuy.GroupBuyUpdatedEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.dto.Order.OrderPendingEvent;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.GroupBuyEventMapper;
 import com.moogsan.moongsan_backend.adapters.kafka.producer.mapper.OrderEventMapper;
@@ -12,6 +13,7 @@ import com.moogsan.moongsan_backend.domain.chatting.participant.facade.command.C
 import com.moogsan.moongsan_backend.domain.groupbuy.entity.GroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.policy.DueSoonPolicy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.order.dto.request.OrderCreateRequest;
 import com.moogsan.moongsan_backend.domain.order.dto.response.OrderCreateResponse;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
@@ -54,6 +56,7 @@ public class OrderCreateService {
     private final ObjectMapper objectMapper;
     private final RedisTemplate<String, String> redisTemplate;
     private final RedissonClient redissonClient;
+    private final RealtimePublisher realtimePublisher;
     private final OutboxEventPublisher outboxEventPublisher;
 
     @Transactional
@@ -161,6 +164,12 @@ public class OrderCreateService {
         }
 
         // 7. Pending 이벤트
+
+        GroupBuyUpdatedEvent event = GroupBuyUpdatedEvent.builder()
+                .groupBuyId(groupBuy.getId())
+                .build();
+        realtimePublisher.publish(event);
+
         try {
             OrderPendingEvent pendingEvt = orderEventMapper.toPendingEvent(
                     order.getId(), groupBuy.getId(), groupBuy.getUser().getId(),

--- a/src/test/java/com/moogsan/moongsan_backend/MoongsanBackendApplicationTests.java
+++ b/src/test/java/com/moogsan/moongsan_backend/MoongsanBackendApplicationTests.java
@@ -1,12 +1,25 @@
 package com.moogsan.moongsan_backend;
 
+import com.moogsan.moongsan_backend.adapters.kafka.producer.outbox.OutboxWorker;
+import com.moogsan.moongsan_backend.domain.chatting.anonymous.service.KafkaConsumerService;
+import com.moogsan.moongsan_backend.support.fake.TestKafkaConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Import(TestKafkaConfiguration.class)
 class MoongsanBackendApplicationTests {
+
+	@MockBean
+	KafkaConsumerService kafkaConsumerService;
+
+	@MockBean
+	OutboxWorker outboxWorker;
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/moogsan/moongsan_backend/support/fake/TestKafkaConfiguration.java
+++ b/src/test/java/com/moogsan/moongsan_backend/support/fake/TestKafkaConfiguration.java
@@ -1,0 +1,33 @@
+package com.moogsan.moongsan_backend.support.fake;
+
+import com.moogsan.moongsan_backend.domain.chatting.anonymous.dto.ChatAnonDto;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import static org.mockito.Mockito.*;
+
+@TestConfiguration
+public class TestKafkaConfiguration {
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplateObject() {
+        return mock(KafkaTemplate.class);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplateString() {
+        return mock(KafkaTemplate.class);
+    }
+
+    @Bean
+    public KafkaTemplate<String, ChatAnonDto> kafkaTemplateChatAnon() {
+        return mock(KafkaTemplate.class);
+    }
+
+    @Bean(name = "simpleMessageListenerFactory")
+    public KafkaListenerContainerFactory<?> simpleMessageListenerFactory() {
+        return mock(ConcurrentKafkaListenerContainerFactory.class);
+    }
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/participant/service/command/CreateChatMessageTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/participant/service/command/CreateChatMessageTest.java
@@ -18,6 +18,7 @@ import com.moogsan.moongsan_backend.domain.chatting.participant.repository.ChatR
 import com.moogsan.moongsan_backend.domain.chatting.participant.service.command.CreateChatMessage;
 import com.moogsan.moongsan_backend.domain.chatting.participant.service.query.GetLatestMessageSse;
 import com.moogsan.moongsan_backend.domain.chatting.participant.service.query.GetLatestMessages;
+import com.moogsan.moongsan_backend.domain.chatting.participant.service.websocket.GetLatestMessagesStomp;
 import com.moogsan.moongsan_backend.domain.chatting.participant.util.MessageSequenceGenerator;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,6 +65,9 @@ public class CreateChatMessageTest {
 
     @Mock
     private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private GetLatestMessagesStomp getLatestMessagesStomp;
 
     @Mock
     private KafkaEventPublisher kafkaEventPublisher;
@@ -113,6 +117,7 @@ public class CreateChatMessageTest {
                 chatMessageCommandMapper,
                 getLatestMessages,
                 getLatestMessageSse,
+                getLatestMessagesStomp,
                 redisTemplate,
                 kafkaEventPublisher,
                 eventMapper,

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/CreateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/CreateGroupBuyTest.java
@@ -7,6 +7,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyI
 import com.moogsan.moongsan_backend.domain.groupbuy.mapper.GroupBuyCommandMapper;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.CreateGroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.image.mapper.ImageMapper;
 import com.moogsan.moongsan_backend.domain.image.service.S3Service;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
@@ -17,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -48,6 +51,12 @@ public class CreateGroupBuyTest {
     private ChattingCommandFacade chattingCommandFacade;
 
     @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    ValueOperations<String,String> valueOps;
+
+    @Mock
     private S3Service s3Service;
 
     private CreateGroupBuy createGroupBuy;
@@ -75,7 +84,8 @@ public class CreateGroupBuyTest {
                 chattingCommandFacade,
                 duplicateRequestPreventer,
                 s3Service,
-                fixedClock
+                fixedClock,
+                redisTemplate
         );
 
         request = CreateGroupBuyRequest.builder()
@@ -101,6 +111,7 @@ public class CreateGroupBuyTest {
     void createGroupBuy_success() {
         // given
         GroupBuy mockGb = mock(GroupBuy.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
         when(groupBuyCommandMapper.create(request, user)).thenReturn(mockGb);
         when(groupBuyRepository.save(mockGb)).thenReturn(mockGb);
         doReturn(42L).when(mockGb).getId();

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/DeleteGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/DeleteGroupBuyTest.java
@@ -6,6 +6,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyN
 import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyNotHostException;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.DeleteGroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.image.mapper.ImageMapper;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
@@ -40,6 +41,9 @@ public class DeleteGroupBuyTest {
     @Mock
     private OrderRepository orderRepository;
 
+    @Mock
+    private RealtimePublisher realtimePublisher;
+
     private DeleteGroupBuy deleteGroupBuy;
     private User hostUser;
     private GroupBuy before;
@@ -61,6 +65,7 @@ public class DeleteGroupBuyTest {
         deleteGroupBuy = new DeleteGroupBuy(
                 groupBuyRepository,
                 orderRepository,
+                realtimePublisher,
                 fixedClock
         );
     }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/EndGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/EndGroupBuyTest.java
@@ -10,6 +10,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyN
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.EndGroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.LeaveGroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +51,9 @@ public class EndGroupBuyTest {
     @Mock
     private ObjectMapper objectMapper;
 
+    @Mock
+    private RealtimePublisher realtimePublisher;
+
     private EndGroupBuy endGroupBuy;
     private User hostUser;
     private User participant;
@@ -76,7 +80,8 @@ public class EndGroupBuyTest {
                 fixedClock,
                 kafkaEventPublisher,
                 eventMapper,
-                objectMapper
+                objectMapper,
+                realtimePublisher
         );
     }
 
@@ -87,7 +92,7 @@ public class EndGroupBuyTest {
                 .thenReturn(Optional.of(before));
         when(before.getPostStatus())
                 .thenReturn("CLOSED");
-        when(before.isFixed())
+        when(before.isFinalized())
                 .thenReturn(true);
         when(before.getUser()).thenReturn(hostUser);
 
@@ -150,7 +155,7 @@ public class EndGroupBuyTest {
                 .thenReturn(Optional.of(before));
         when(before.getPostStatus())
                 .thenReturn("CLOSED");
-        when(before.isFixed())
+        when(before.isFinalized())
                 .thenReturn(false);
 
         assertThatThrownBy(() -> endGroupBuy.endGroupBuy(participant, 1L))
@@ -168,7 +173,7 @@ public class EndGroupBuyTest {
                 .thenReturn(Optional.of(before));
         when(before.getPostStatus())
                 .thenReturn("CLOSED");
-        when(before.isFixed())
+        when(before.isFinalized())
                 .thenReturn(true);
         when(before.getUser()).thenReturn(hostUser);
 

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/LeaveGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/LeaveGroupBuyTest.java
@@ -10,6 +10,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyN
 import com.moogsan.moongsan_backend.domain.groupbuy.policy.DueSoonPolicy;
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.LeaveGroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.order.entity.Order;
 import com.moogsan.moongsan_backend.domain.order.exception.specific.OrderNotFoundException;
 import com.moogsan.moongsan_backend.domain.order.repository.OrderRepository;
@@ -32,36 +33,41 @@ import static com.moogsan.moongsan_backend.domain.groupbuy.message.ResponseMessa
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class LeaveGroupBuyTest {
-    @Mock private GroupBuyRepository groupBuyRepository;
-    @Mock private OrderRepository orderRepository;
-    @Mock private DueSoonPolicy dueSoonPolicy;
-    @Mock private KafkaEventPublisher kafkaEventPublisher;
-    @Mock private OrderEventMapper eventMapper;
-    @Mock private ObjectMapper objectMapper;
+    @Mock private GroupBuyRepository    groupBuyRepository;
+    @Mock private OrderRepository       orderRepository;
+    @Mock private DueSoonPolicy         dueSoonPolicy;
+    @Mock private KafkaEventPublisher   kafkaEventPublisher;
+    @Mock private OrderEventMapper      eventMapper;
+    @Mock private ObjectMapper          objectMapper;
     @Mock private ChattingCommandFacade chattingCommandFacade;
+    @Mock private RealtimePublisher     realtimePublisher;
 
     private LeaveGroupBuy leaveGroupBuy;
-    private User participant;
-    private GroupBuy before;
-    private Order order;
-    private Clock fixedClock;
+    private User        participant;
+    private GroupBuy    before;
+    private Order       order;
+    private Clock       fixedClock;
     private LocalDateTime now;
 
     @BeforeEach
     void setup() {
         participant = User.builder().id(1L).build();
-        before = mock(GroupBuy.class);
-        order = mock(Order.class);
+        before = spy(GroupBuy.builder()
+                .id(20L)
+                .user(participant)
+                .build());
+        order = Order.builder().id(1L).user(participant).groupBuy(before).build();
+        // set mandatory fields to avoid NPEs
+        order.setQuantity(2);
+        order.setPrice(1000);
 
         fixedClock = Clock.fixed(
                 Instant.parse("2025-06-11T13:00:00Z"),
                 ZoneId.of("Asia/Seoul")
         );
-
         now = LocalDateTime.now(fixedClock);
 
         leaveGroupBuy = new LeaveGroupBuy(
@@ -70,6 +76,7 @@ public class LeaveGroupBuyTest {
                 dueSoonPolicy,
                 chattingCommandFacade,
                 kafkaEventPublisher,
+                realtimePublisher,
                 eventMapper,
                 objectMapper,
                 fixedClock
@@ -79,97 +86,90 @@ public class LeaveGroupBuyTest {
     @Test
     @DisplayName("공구 참여 취소 성공")
     void leaveGroupBuy_success() {
-        when(groupBuyRepository.findById(1L))
+        when(groupBuyRepository.findById(20L))
                 .thenReturn(Optional.of(before));
         when(before.getPostStatus()).thenReturn("OPEN");
-        when(before.getDueDate())
-                .thenReturn(now.plusDays(1));
-        when(before.getId()).thenReturn(20L);
-        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNotIn(1L, 20L,
-                List.of("CANCELED", "REFUNDED")))
+        when(before.getDueDate()).thenReturn(now.plusDays(1));
+        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNotIn(
+                1L, 20L, List.of("CANCELED", "REFUNDED")))
                 .thenReturn(Optional.of(order));
 
-        leaveGroupBuy.leaveGroupBuy(participant, 1L);
+        leaveGroupBuy.leaveGroupBuy(participant, 20L);
 
-        verify(groupBuyRepository, times(1)).findById(1L);
-        verify(orderRepository, times(1))
-                .findByUserIdAndGroupBuyIdAndStatusNotIn(1L, 20L, List.of("CANCELED", "REFUNDED"));
-        verify(orderRepository, times(1)).save(any(Order.class));
+        verify(groupBuyRepository).findById(20L);
+        verify(orderRepository).findByUserIdAndGroupBuyIdAndStatusNotIn(
+                1L, 20L, List.of("CANCELED", "REFUNDED")
+        );
+        verify(orderRepository).save(any(Order.class));
     }
 
     @Test
     @DisplayName("존재하지 않는 공구글 - 404 예외")
     void leaveGroupBuy_groupBuy_notFound() {
-        when(groupBuyRepository.findById(1L))
-                .thenReturn(Optional.empty());
-
         assertThatThrownBy(() -> leaveGroupBuy.leaveGroupBuy(participant, 1L))
                 .isInstanceOf(GroupBuyNotFoundException.class)
                 .hasMessageContaining(NOT_EXIST);
 
-        verify(groupBuyRepository, times(1)).findById(1L);
+        verify(groupBuyRepository).findById(1L);
         verify(orderRepository, never())
-                .findByUserIdAndGroupBuyIdAndStatusNotIn(1L, 20L, List.of("CANCELED", "REFUNDED"));
-        verify(orderRepository, never()).save(any(Order.class));
+                .findByUserIdAndGroupBuyIdAndStatusNotIn(anyLong(), anyLong(), anyList());
+        verify(orderRepository, never()).save(any());
     }
 
     @Test
     @DisplayName("공구글 status가 OPEN이 아님 - 409 예외")
     void leaveGroupBuy_postStatus_not_open() {
-        when(groupBuyRepository.findById(1L))
+        when(groupBuyRepository.findById(20L))
                 .thenReturn(Optional.of(before));
-        when(before.getPostStatus())
-                .thenReturn("ENDED");
+        when(before.getPostStatus()).thenReturn("CLOSED");
 
-        assertThatThrownBy(() -> leaveGroupBuy.leaveGroupBuy(participant, 1L))
+        assertThatThrownBy(() -> leaveGroupBuy.leaveGroupBuy(participant, 20L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
                 .hasMessageContaining(NOT_OPEN);
 
-        verify(groupBuyRepository, times(1)).findById(1L);
+        verify(groupBuyRepository).findById(20L);
         verify(orderRepository, never())
-                .findByUserIdAndGroupBuyIdAndStatusNotIn(1L, 20L, List.of("CANCELED", "REFUNDED"));
-        verify(orderRepository, never()).save(any(Order.class));
+                .findByUserIdAndGroupBuyIdAndStatusNotIn(anyLong(), anyLong(), anyList());
+        verify(orderRepository, never()).save(any());
     }
 
     @Test
     @DisplayName("dueDate가 현재보다 과거 - 409 예외")
     void leaveGroupBuy_dueDate_past() {
-        when(groupBuyRepository.findById(1L))
+        when(groupBuyRepository.findById(20L))
                 .thenReturn(Optional.of(before));
         when(before.getPostStatus()).thenReturn("OPEN");
-        when(before.getDueDate())
-                .thenReturn(now.minusDays(1));
+        when(before.getDueDate()).thenReturn(now.minusDays(1));
 
-        assertThatThrownBy(() -> leaveGroupBuy.leaveGroupBuy(participant, 1L))
+        assertThatThrownBy(() -> leaveGroupBuy.leaveGroupBuy(participant, 20L))
                 .isInstanceOf(GroupBuyInvalidStateException.class)
                 .hasMessageContaining(NOT_OPEN);
 
-        verify(groupBuyRepository, times(1)).findById(1L);
+        verify(groupBuyRepository).findById(20L);
         verify(orderRepository, never())
-                .findByUserIdAndGroupBuyIdAndStatusNotIn(1L, 20L, List.of("CANCELED", "REFUNDED"));
-        verify(orderRepository, never()).save(any(Order.class));
+                .findByUserIdAndGroupBuyIdAndStatusNotIn(anyLong(), anyLong(), anyList());
+        verify(orderRepository, never()).save(any());
     }
 
     @Test
     @DisplayName("존재하지 않는 주문 - 404 예외")
     void leaveGroupBuy_order_notFound() {
-        when(groupBuyRepository.findById(1L))
+        when(groupBuyRepository.findById(20L))
                 .thenReturn(Optional.of(before));
         when(before.getPostStatus()).thenReturn("OPEN");
-        when(before.getDueDate())
-                .thenReturn(LocalDateTime.now().plusDays(1));
-        when(before.getId()).thenReturn(20L);
-        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNotIn(1L, 20L,
-                List.of("CANCELED", "REFUNDED")))
-                .thenReturn(Optional.empty());
+        when(before.getDueDate()).thenReturn(now.plusDays(1));
+        when(orderRepository.findByUserIdAndGroupBuyIdAndStatusNotIn(
+                1L, 20L, List.of("CANCELED", "REFUNDED")
+        )).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> leaveGroupBuy.leaveGroupBuy(participant, 1L))
+        assertThatThrownBy(() -> leaveGroupBuy.leaveGroupBuy(participant, 20L))
                 .isInstanceOf(OrderNotFoundException.class)
                 .hasMessageContaining(NOT_EXIST_ORDER);
 
-        verify(groupBuyRepository, times(1)).findById(1L);
-        verify(orderRepository, times(1))
-                .findByUserIdAndGroupBuyIdAndStatusNotIn(1L, 20L, List.of("CANCELED", "REFUNDED"));
-        verify(orderRepository, never()).save(any(Order.class));
+        verify(groupBuyRepository).findById(20L);
+        verify(orderRepository).findByUserIdAndGroupBuyIdAndStatusNotIn(
+                1L, 20L, List.of("CANCELED", "REFUNDED")
+        );
+        verify(orderRepository, never()).save(any());
     }
 }

--- a/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/UpdateGroupBuyTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/groupbuy/service/command/UpdateGroupBuyTest.java
@@ -12,6 +12,7 @@ import com.moogsan.moongsan_backend.domain.groupbuy.exception.specific.GroupBuyN
 import com.moogsan.moongsan_backend.domain.groupbuy.repository.GroupBuyRepository;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.CreateGroupBuy;
 import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuyCommandService.UpdateGroupBuy;
+import com.moogsan.moongsan_backend.domain.groupbuy.service.GroupBuySseService.publisher.RealtimePublisher;
 import com.moogsan.moongsan_backend.domain.image.entity.Image;
 import com.moogsan.moongsan_backend.domain.image.mapper.ImageMapper;
 import com.moogsan.moongsan_backend.domain.image.service.S3Service;
@@ -59,6 +60,9 @@ class UpdateGroupBuyTest {
 
     @Mock
     private ObjectMapper objectMapper;
+
+    @Mock
+    private RealtimePublisher realtimePublisher;
 
     @Mock
     private Clock clock;
@@ -121,6 +125,7 @@ class UpdateGroupBuyTest {
                 eventMapper,
                 objectMapper,
                 kafkaEventPublisher,
+                realtimePublisher,
                 fixedClock
         );
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,16 +20,14 @@ spring:
       database: test_mongo
       uri: ${MONGO_DB_URI:mongodb://localhost:27017/test_mongo}
     redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+      host: localhost
+      port: 3333
   kafka:
     bootstrap-servers: dummy:9092
     listener:
       auto-startup: false
     consumer:
       group-id: test.test.test
-
-
 ai:
   service:
     base-url: http://localhost:18080  # 더미 주소


### PR DESCRIPTION
## 🔎 작업 개요
- 그룹구매 상세(트랜잭션) 페이지를 **SSE 스트림**으로 최신화하도록 전면 개선
- 공구 수정 시 Kafka → Listener → UseCase → SSE 브로드캐스트 체인 완성

## 🛠️ 주요 변경 사항
- **Kafka 토픽 추가**
  - `GROUPBUY_DETAIL_UPDATED` 상수 정의 (`KafkaTopics`)
- **DTO & Mapper**
  - `GroupBuyUpdatedEvent` → `groupBuyId`, `updatedAt` 필드 보강
  - `GroupBuyEventMapper`에 `toGroupBuyUpdatedEvent()` 변환 메서드 추가
- **Publisher & SSE 저장소**
  - `RealtimePublisher.publish(event)` → `SseEmitterRepository.send(key, data)` 호출
  - `SseEmitterRepository`에 2-인자 `send(key, data)` 오버로드 및 thread-safe 개선
- **서비스 & 유스케이스**
  - `UpdateGroupBuy` 저장 후 `GroupBuyUpdatedEvent` 발행 (Kafka + SSE)
  - `BroadcastGroupBuyUpdatedEventUseCase` → 이벤트 유효성 검증 후 실시간 전송
- **Kafka Listener**
  - `GroupBuyRealtimeListener` (groupId = `REALTIME_GROUPBUY`) 신설
  - 토픽 수신 → UseCase 위임
- **API 엔드포인트**
  - `GET /api/sse/group-buys/{groupBuyId}` (Controller 분리)
  - 인증 쿠키(`AccessToken`) 기반 SSE 스트림 연결

## ✅ 검증 방법
- **유닛/통합 테스트**
  - `./gradlew clean test` 전체 통과 확인
- **로컬 E2E** 테스트 완료

## 🔍 머지 전 확인사항
- CI(빌드·테스트) 전체 통과
- 운영 환경 application.yml 에 Kafka 토픽 자동 생성 허용 여부 확인
- Nginx/WebProxy에서 Connection: keep-alive 및 SSE 헤더 차단 없는지 점검
- API 명세서 작성 확인

## ➕ 이슈 링크
- #298 