### PR TITLE
feat(group-buy): 챗봇 SSE 스트리밍 프록시 구현

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/dto/ChatBotRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/dto/ChatBotRequest.java
@@ -1,0 +1,11 @@
+package com.moogsan.moongsan_backend.groupbuy.domain.dto;
+
+import lombok.Builder;
+
+@Builder
+public class ChatBotRequest {
+    private String message;
+    private String sessionId;
+    private Long userId;
+    private String userName;
+}

--- a/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/dto/ChatSseResponse.java
+++ b/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/dto/ChatSseResponse.java
@@ -1,0 +1,8 @@
+package com.moogsan.moongsan_backend.groupbuy.domain.dto;
+
+public record ChatSseResponse (
+        String type,       // "processing" | "ai_response" | "completion"
+        String content,    // 본문
+        String agent,      // "chat" | "search" | "create"
+        String timestamp
+){}

--- a/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/message/ValidationMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/message/ValidationMessage.java
@@ -21,4 +21,5 @@ public class ValidationMessage {
     public static final String INVALID_IMAGE = "tmp/로 시작하는 이미지를 1장 이상, 5장 이하로 등록해주세요.";
     public static final String INVALID_UPDATE_IMAGE = "tmp/ 혹은 group-buys/로 시작하는 이미지를 1장 이상, 5장 이하로 등록해주세요.";
     public static final String BLANK_DATEMODIFICATION_REASON = "픽업 일자가 변경된 경우 사유를 2자 이상, 85자 이하로 작성해야 합니다.";
+    public static final String MESSAGE_SIZE = "메세지를 1자 이상 1000자 이하로 입력해주세요.";
 }

--- a/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/service/AiClient.java
+++ b/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/service/AiClient.java
@@ -1,6 +1,11 @@
 // 1) AiClient.java
 package com.moogsan.moongsan_backend.groupbuy.domain.service;
 
+import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import com.moogsan.moongsan_backend.global.infrastructure.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.groupbuy.domain.dto.ChatBotRequest;
+import com.moogsan.moongsan_backend.groupbuy.presentation.dto.command.request.ChatMessageRequest;
 import com.moogsan.moongsan_backend.groupbuy.presentation.dto.command.request.DescriptionGenerationRequest;
 import com.moogsan.moongsan_backend.groupbuy.presentation.dto.command.response.ApiResponse;
 import com.moogsan.moongsan_backend.groupbuy.presentation.dto.command.response.DescriptionDto;
@@ -10,9 +15,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.time.Instant;
 
 @Slf4j
 @Component
@@ -63,5 +73,32 @@ public class AiClient {
                         return Mono.error(new IllegalStateException("AI 서비스가 데이터를 반환하지 않았습니다."));
                     }
                 });
+    }
+
+    /**  챗봇 스트리밍 **/
+    public Flux<String> streamChat(User user, ChatMessageRequest req, String sessionId) {
+        log.info("[AiClient] chat endpoint = {}/chat/stream", aiBaseUrl);
+
+        ChatBotRequest chatBotRequest = ChatBotRequest.builder()
+                .message(req.getMessage())
+                .sessionId(req.getSessionId())
+                .userId(user.getId())
+                .userName(user.getName())
+                .build();
+
+        return webClient.post()
+                .uri(aiBaseUrl + "/chat/stream")
+                .cookie("AccessToken", sessionId)
+                .accept(MediaType.TEXT_EVENT_STREAM)                 // SSE 구독
+                .bodyValue(chatBotRequest)
+                .retrieve()
+                .bodyToFlux(String.class)                             // SSE 라인 단위 Flux
+                .doOnError(e -> log.error("[AiClient] streamChat error", e))
+                .onErrorResume(e -> Flux.just(
+                        // 에러를 직접 JSON 문자열로 감싸 보낼 수도 있고
+                        "{\"type\":\"error\",\"content\":\"챗봇 오류 발생: "
+                                + e.getMessage() + "\",\"agent\":\"chat\",\"timestamp\":\""
+                                + Instant.now().toString() + "\"}"
+                ));
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/service/ChatBotService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/service/ChatBotService.java
@@ -22,7 +22,7 @@ public class ChatBotService {
     public Mono<Void> streamChatForUser(User user,
                                                    ChatMessageRequest request,
                                                    String sessionId) {
-        String key = "chat-bot:" + user.getId();
+        String key = "chat:" + user.getId();
 
         // 1) processing 이벤트
         ChatSseResponse processingEvt = new ChatSseResponse(

--- a/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/service/ChatBotService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/groupbuy/domain/service/ChatBotService.java
@@ -1,0 +1,47 @@
+package com.moogsan.moongsan_backend.groupbuy.domain.service;
+
+import com.moogsan.moongsan_backend.domain.user.entity.User;
+import com.moogsan.moongsan_backend.global.infrastructure.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.groupbuy.domain.dto.ChatSseResponse;
+import com.moogsan.moongsan_backend.groupbuy.presentation.dto.command.request.ChatMessageRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ChatBotService {
+    private final AiClient aiClient;
+    private final SseEmitterRepository sseEmitterRepository;
+
+    public Mono<Void> streamChatForUser(User user,
+                                                   ChatMessageRequest request,
+                                                   String sessionId) {
+        String key = "chat-bot:" + user.getId();
+
+        // 1) processing 이벤트
+        ChatSseResponse processingEvt = new ChatSseResponse(
+                "processing",
+                "분석 중...",
+                "chat",
+                Instant.now().atOffset(ZoneOffset.UTC).toString()
+        );
+        sseEmitterRepository.send(key, processingEvt);
+
+        return aiClient.streamChat(user, request, sessionId)
+                .doOnNext(chunk -> sseEmitterRepository.send(key, chunk))
+                .then(Mono.fromRunnable(() ->
+                        sseEmitterRepository.send(key, Map.of(
+                                "type",      "completion",
+                                "content",   "응답 완료",
+                                "agent",     "chat",
+                                "timestamp", Instant.now().atOffset(ZoneOffset.UTC).toString()
+                        ))
+                ));
+    }
+}

--- a/src/main/java/com/moogsan/moongsan_backend/groupbuy/presentation/controller/command/ChatBotController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/groupbuy/presentation/controller/command/ChatBotController.java
@@ -1,0 +1,52 @@
+package com.moogsan.moongsan_backend.groupbuy.presentation.controller.command;
+
+import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
+import com.moogsan.moongsan_backend.global.infrastructure.sse.SseEmitterRepository;
+import com.moogsan.moongsan_backend.groupbuy.domain.dto.ChatSseResponse;
+import com.moogsan.moongsan_backend.groupbuy.domain.service.AiClient;
+import com.moogsan.moongsan_backend.groupbuy.domain.service.ChatBotService;
+import com.moogsan.moongsan_backend.groupbuy.presentation.dto.command.request.ChatMessageRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import static com.moogsan.moongsan_backend.global.util.CookieUtils.extractCookie;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat-bot")
+public class ChatBotController {
+
+    private final SseEmitterRepository sseEmitterRepository;
+    private final ChatBotService chatBotService;
+
+    @GetMapping(value = "/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        String key = "chat:" + userDetails.getUser().getId();
+        return sseEmitterRepository.add(String.valueOf(key));
+    }
+
+    @PostMapping("/message")
+    public Mono<Void> sendMessage(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                  @RequestBody ChatMessageRequest request,
+                                  HttpServletRequest servletRequest) {
+        String sessionId = extractCookie(servletRequest, "AccessToken");
+        return chatBotService.streamChatForUser(
+                        userDetails.getUser(),
+                        request,
+                        sessionId
+                )
+                .then();
+    }
+
+}

--- a/src/main/java/com/moogsan/moongsan_backend/groupbuy/presentation/dto/command/request/ChatMessageRequest.java
+++ b/src/main/java/com/moogsan/moongsan_backend/groupbuy/presentation/dto/command/request/ChatMessageRequest.java
@@ -1,0 +1,20 @@
+package com.moogsan.moongsan_backend.groupbuy.presentation.dto.command.request;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import static com.moogsan.moongsan_backend.groupbuy.domain.message.ValidationMessage.MESSAGE_SIZE;
+
+@Getter
+public class ChatMessageRequest {
+
+    @NotNull(message = MESSAGE_SIZE)
+    @NotBlank(message = MESSAGE_SIZE)
+    @Size(min = 1, max = 1000, message = MESSAGE_SIZE)
+    private String message;
+
+    private String sessionId;
+}

--- a/src/main/java/com/moogsan/moongsan_backend/notification/presentation/controller/NotificationSseController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/notification/presentation/controller/NotificationSseController.java
@@ -2,13 +2,14 @@ package com.moogsan.moongsan_backend.notification.presentation.controller;
 
 import com.moogsan.moongsan_backend.global.infrastructure.sse.SseEmitterRepository;
 import com.moogsan.moongsan_backend.domain.user.entity.CustomUserDetails;
+import com.moogsan.moongsan_backend.groupbuy.domain.service.AiClient;
+import com.moogsan.moongsan_backend.groupbuy.presentation.dto.command.request.ChatMessageRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Mono;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,7 +22,8 @@ public class NotificationSseController {
     public SseEmitter subscribe(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return sseEmitterRepository.add(String.valueOf(userDetails.getUser().getId()));
+        String key = "notification:" + userDetails.getUser().getId();
+        return sseEmitterRepository.add(String.valueOf(key));
     }
 
 }


### PR DESCRIPTION
## 🔎 작업 개요
- 외부 AI 서비스의 SSE 채팅 스트림을 중계하는 **프록시 로직**을 구현했습니다.

---

## 🛠️ 주요 변경 사항
- **AiClient**  
  - `public Flux<String> streamChat(User, ChatMessageRequest, String)` 메서드 추가  
    - `bodyToFlux(String.class)` 으로 AI SSE 라인 단위 수신  
    - `onErrorResume` 으로 오류 시에도 JSON 형태로 이벤트 스트림 유지  
- **ChatBotService**  
  - `public Mono<Void> streamChatForUser(...)` 메서드 구현  
    1. `processing` 이벤트 즉시 푸시  
    2. `aiClient.streamChat(...)` 반환 Flux를 `doOnNext`로 그대로 `SseEmitterRepository.send()`  
    3. 스트림 완료 후 `completion` 이벤트 푸시  
- **ChatBotController**  
  - `GET /api/chat-bot/sse` → `SseEmitter` 구독 엔드포인트  
  - `POST /api/chat-bot/message` → `ChatMessageRequest` 수신 후 `streamChatForUser` 호출  
- **인증·쿠키**  
  - `CookieUtils.extractCookie(servletRequest, "AccessToken")`로 AI 토큰 추출  
  - `SseEmitterRepository` 키: `"chat-bot:{userId}"`  

---

## ✅ 검증 방법
1. 로컬에 프론트, ai가 존재하지 않아 dev 환경에서 연결 검증 예정

---

## 🔍 머지 전 확인사항
- **동시성**: 동일 사용자 다중 탭 구독 시 `SseEmitterRepository` 브로드캐스트 동작 검증  
- **타임아웃 설정**: `SseEmitter` 기본 타임아웃(30초) 비활성화 여부 확인  
- **에러 핸들링**: AI 호출 실패 시 클라이언트에 `"type":"error"` 이벤트 정상 전달  
- **리소스 정리**: 구독 해제, 클라이언트 강제 해제 시 `SseEmitterRepository`에서 제거 로직 검증  
