### PR TITLE
refactor(participantChat): 참여자 채팅 서비스 코드 리팩토링

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/notification/application/service/NotificationMarkAsRead.java
+++ b/src/main/java/com/moogsan/moongsan_backend/notification/application/service/NotificationMarkAsRead.java
@@ -17,7 +17,7 @@ public class NotificationMarkAsRead {
 
     private final NotificationRepository notificationRepository;
 
-    public void execute(Long userId, Long notificationId, NotificationReadStatus request) {
+    public void execute(Long notificationId, NotificationReadStatus request) {
 
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(NotiNotFoundException::new);

--- a/src/main/java/com/moogsan/moongsan_backend/notification/presentation/controller/NotificationCommandController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/notification/presentation/controller/NotificationCommandController.java
@@ -26,7 +26,7 @@ public class NotificationCommandController {
             @PathVariable Long notificationId,
             @RequestBody NotificationReadStatus request) {
 
-        notificationMarkAsRead.execute(userDetails.getUser().getId(), notificationId, request);
+        notificationMarkAsRead.execute(notificationId, request);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/command/CreateChatMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/command/CreateChatMessage.java
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.Duration;
 
-import static com.moogsan.moongsan_backend.participantchat.domain.constant.ParticipantChatConstants.CASHE_REDIS_KET;
+import static com.moogsan.moongsan_backend.participantchat.domain.constant.ParticipantChatConstants.CASHE_REDIS_KEY;
 import static com.moogsan.moongsan_backend.participantchat.domain.message.ResponseMessage.DELETED_CHAT_ROOM;
 import static com.moogsan.moongsan_backend.groupbuy.domain.message.ResponseMessage.NOT_PARTICIPANT;
 import static com.moogsan.moongsan_backend.global.util.ObjectIdScoreUtil.toScore;
@@ -99,7 +99,7 @@ public class CreateChatMessage {
     }
 
     private void cacheMessage(Long chatRoomId, ChatMessageDocument document) {
-        String redisKey = CASHE_REDIS_KET + chatRoomId;
+        String redisKey = CASHE_REDIS_KEY + chatRoomId;
 
         try {
             String json = objectMapper.writeValueAsString(document);

--- a/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/command/CreateChatMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/command/CreateChatMessage.java
@@ -56,7 +56,7 @@ public class CreateChatMessage {
         ChatRoom chatRoom = fetchAndValidate(chatRoomId);
 
         // 참여자인지 조회 -> 아니면 403
-        ChatParticipant participant = validateUser(chatRoomId, currentUser.getId());
+        ChatParticipant participant = validateUser(currentUser.getId(), chatRoomId);
 
         // 메세지 순번 생성 (커서 기반 페이징용)
         Long nextSeq = messageSequenceGenerator.getNextMessageSeq(chatRoomId);

--- a/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/command/CreateChatMessage.java
+++ b/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/command/CreateChatMessage.java
@@ -2,9 +2,6 @@ package com.moogsan.moongsan_backend.participantchat.application.service.command
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.moogsan.moongsan_backend.participantchat.domain.event.ChatMessagePersistEvent;
-import com.moogsan.moongsan_backend.participantchat.domain.mapper.ChatEventMapper;
-import com.moogsan.moongsan_backend.global.infrastructure.kafka.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.participantchat.presentation.dto.command.request.CreateChatMessageRequest;
 import com.moogsan.moongsan_backend.participantchat.domain.entity.ChatMessageDocument;
 import com.moogsan.moongsan_backend.participantchat.domain.entity.ChatParticipant;
@@ -24,18 +21,15 @@ import com.moogsan.moongsan_backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.Duration;
 
-import static com.moogsan.moongsan_backend.global.infrastructure.kafka.KafkaTopics.CHAT_PART_MESSAGE_CREATED;
+import static com.moogsan.moongsan_backend.participantchat.domain.constant.ParticipantChatConstants.CASHE_REDIS_KET;
 import static com.moogsan.moongsan_backend.participantchat.domain.message.ResponseMessage.DELETED_CHAT_ROOM;
 import static com.moogsan.moongsan_backend.groupbuy.domain.message.ResponseMessage.NOT_PARTICIPANT;
-import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIALIZATION_FAIL;
 import static com.moogsan.moongsan_backend.global.util.ObjectIdScoreUtil.toScore;
 
 @Slf4j
@@ -53,54 +47,59 @@ public class CreateChatMessage {
     private final GetLatestMessageSse getLatestMessageSse;
     private final GetLatestMessagesStomp getLatestMessagesStomp;
     private final RedisTemplate<String, String> redisTemplate;
-    private final KafkaEventPublisher kafkaEventPublisher;
-    private final ChatEventMapper eventMapper;
     private final ObjectMapper objectMapper;
     private final Clock clock;
 
     public void createChatMessage(User currentUser, CreateChatMessageRequest request, Long chatRoomId) {
 
-        // 채팅방 조회 -> 없으면 404
-        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(ChatRoomNotFoundException::new);
-
-        // 채팅방이 삭제되지 않았는지 조회
-        if(chatRoom.getDeletedAt() != null) {
-            throw new ChatRoomInvalidStateException(DELETED_CHAT_ROOM);
-        }
+        // 채팅방 조회 및 유효성 검사
+        ChatRoom chatRoom = fetchAndValidate(chatRoomId);
 
         // 참여자인지 조회 -> 아니면 403
-        ChatParticipant participant = chatParticipantRepository
-                .findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoomId, currentUser.getId())
-                .orElseThrow(() -> new NotParticipantException(NOT_PARTICIPANT));
-
+        ChatParticipant participant = validateUser(chatRoomId, currentUser.getId());
 
         // 메세지 순번 생성 (커서 기반 페이징용)
         Long nextSeq = messageSequenceGenerator.getNextMessageSeq(chatRoomId);
 
-        // 메세지 작성
-        ChatMessageDocument document = chatMessageCommandMapper
-                .toMessageDocument(chatRoom, participant.getId(), request, nextSeq);
-        SecurityContext context = SecurityContextHolder.getContext();
+        // 메세지 작성 및 저장
+        ChatMessageDocument document = chatMessageCommandMapper.toMessageDocument(chatRoom, participant.getId(), request, nextSeq);
         chatMessageRepository.save(document);
 
+        /* SecurityContext context = SecurityContextHolder.getContext();
         // 롱 폴링
-        // getLatestMessages.notifyNewMessage(document, currentUser.getNickname(), currentUser.getImageKey(), context);
-
+        getLatestMessages.notifyNewMessage(document, currentUser.getNickname(), currentUser.getImageKey(), context);
         // sse
-        /*
-        getLatestMessageSse.notifyNewMessageSse(
-                document,
-                currentUser.getNickname(),
-                currentUser.getImageKey(),
-                context
-        );
-         */
+        getLatestMessageSse.notifyNewMessageSse(document,currentUser.getNickname(),currentUser.getImageKey(),context); */
 
         // socket
         getLatestMessagesStomp.notifyNewMessage(document, currentUser.getNickname(), currentUser.getImageKey());
 
-        String redisKey = "chatting:messages:" + chatRoomId;
+        // 메세지 캐싱
+        cacheMessage(chatRoomId, document);
+
+    }
+
+    private ChatRoom fetchAndValidate(Long chatRoomId) {
+        // 채팅방 조회 -> 없으면 404
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(ChatRoomNotFoundException::new);
+
+        // 채팅방 삭제 여부 조회 -> 409
+        if(chatRoom.getDeletedAt() != null) {
+            throw new ChatRoomInvalidStateException(DELETED_CHAT_ROOM);
+        }
+
+        return chatRoom;
+    }
+
+    private ChatParticipant validateUser(Long userId, Long chatRoomId) {
+        return chatParticipantRepository
+                .findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoomId, userId)
+                .orElseThrow(() -> new NotParticipantException(NOT_PARTICIPANT));
+    }
+
+    private void cacheMessage(Long chatRoomId, ChatMessageDocument document) {
+        String redisKey = CASHE_REDIS_KET + chatRoomId;
 
         try {
             String json = objectMapper.writeValueAsString(document);
@@ -111,16 +110,6 @@ public class CreateChatMessage {
             }
         } catch (JsonProcessingException e) {
             log.warn("❌ Redis 캐싱 실패 [chatRoomId={}]: {}", chatRoomId, e.getMessage());
-        }
-
-        try {
-            ChatMessagePersistEvent eventDto =
-                    eventMapper.toChatMessagePersistEvent(chatRoom.getId(), document.getId());
-            String payload = objectMapper.writeValueAsString(eventDto);
-            kafkaEventPublisher.publish(CHAT_PART_MESSAGE_CREATED, String.valueOf(document.getId()), payload);
-        } catch (JsonProcessingException e) {
-            log.error("❌ Failed to serialize ParticipantChatMessageCreatedEvent: documentId={}", document.getId(), e);
-            throw new RuntimeException(SERIALIZATION_FAIL, e);
         }
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/command/JoinChatRoom.java
+++ b/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/command/JoinChatRoom.java
@@ -32,24 +32,39 @@ public class JoinChatRoom {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatParticipantRepository chatParticipantRepository;
 
-    public void joinChatRoom(User currentUser,Long postId) {
+    public void joinChatRoom(User currentUser, Long postId) {
 
+        Long userId = currentUser.getId();
+
+        // 유효성 검증
+        GroupBuy groupBuy = fetchAndValidate(userId, postId);
+
+        // 채팅방 생성
+        ChatRoom chatRoom = fetchChatRoom(userId, groupBuy);
+
+        // 채팅방 참여
+        enrollParticipant(currentUser, chatRoom, groupBuy);
+    }
+
+    private GroupBuy fetchAndValidate(Long userId, Long postId) {
         // 해당 공구가 존재하는지 조회 -> 없으면 404
-        GroupBuy groupBuy = groupBuyRepository.findById(postId)
+        return groupBuyRepository.findById(postId)
                 .orElseThrow(GroupBuyNotFoundException::new);
+    }
 
-        Boolean isHost = groupBuy.getUser().getId().equals(currentUser.getId());
+    private ChatRoom fetchChatRoom(Long userId, GroupBuy groupBuy) {
+
+        boolean isHost = groupBuy.getUser().getId().equals(userId);
 
         if (!isHost) {
             // 해당 공구의 주문 테이블에 해당 유저의 주문이 존재하는지 조회 -> 아니면 404
-            Order order = orderRepository.findByUserIdAndGroupBuyIdAndStatusNotIn(currentUser.getId(), groupBuy.getId(),
+            Order order = orderRepository.findByUserIdAndGroupBuyIdAndStatusNotIn(userId, groupBuy.getId(),
                             List.of("CANCELED", "REFUNDED"))
                     .orElseThrow(() -> new OrderNotFoundException(ORDER_NOT_FOUND));
         }
 
-
         // 해당 공구의 참여자 채팅방이 존재하는지 조회
-        ChatRoom chatRoom = chatRoomRepository
+        return chatRoomRepository
                 .findByGroupBuy_IdAndType(groupBuy.getId(), "PARTICIPANT")
                 .orElseGet(() -> {
                     // 없으면 새로 생성 -> 동시 생성 방지 필요
@@ -59,10 +74,12 @@ public class JoinChatRoom {
                             .build();
                     return chatRoomRepository.save(newRoom);
                 });
+    }
 
+    private void enrollParticipant(User user, ChatRoom chatRoom, GroupBuy groupBuy) {
         // 이미 호스트가 참여중인지 확인 (만약 새로 생성되었으면 당연히 미참여 상태)
         boolean alreadyJoined = chatParticipantRepository
-                .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), currentUser.getId());
+                .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), user.getId());
 
         if (alreadyJoined) {
             throw new AlreadyJoinedException(ALREADEY_JOINED);
@@ -70,7 +87,7 @@ public class JoinChatRoom {
             // 호스트를 참여자로 등록
             ChatParticipant participant = ChatParticipant.builder()
                     .chatRoom(chatRoom)
-                    .user(currentUser)
+                    .user(user)
                     .joinedAt(LocalDateTime.now())
                     .build();
             chatParticipantRepository.save(participant);

--- a/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/query/GetChatRoomList.java
+++ b/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/query/GetChatRoomList.java
@@ -22,8 +22,39 @@ public class GetChatRoomList {
     private final ChatParticipantRepository chatParticipantRepository;
     private final ChatMessageQueryMapper chatMessageQueryMapper;
 
-    public ChatRoomPagedResponse getChatRoomList (Long userId, LocalDateTime cursorJoinedAt, Integer limit) {
+    public ChatRoomPagedResponse getChatRoomList (
+            Long userId, LocalDateTime cursorJoinedAt, Integer limit) {
 
+        // 참여자 조회
+        List<ChatParticipant> participants = fetchAndValidate(userId, cursorJoinedAt, limit);
+
+        // 더보기 여부 확인
+        boolean hasMore = participants.size() > limit;
+
+        // 실제 데이터 크기로 조정
+        List<ChatParticipant> paginatedParticipants = participants.size() > limit ? participants.subList(0, limit) : participants;
+
+        // 다음 커서 지정
+        LocalDateTime nextJoinedAt = null;
+        if (!paginatedParticipants.isEmpty()) {
+            ChatParticipant last = paginatedParticipants.getLast();
+            nextJoinedAt = last.getJoinedAt();
+        }
+
+        // 채팅방 매핑
+         List<ChatRoom> rooms = extractChatRoom(paginatedParticipants);
+
+        // DTO 매핑
+        List<ChatRoomResponse> results = chatMessageQueryMapper.toChatRoomList(rooms);
+
+        return ChatRoomPagedResponse.builder()
+                .chatRooms(results)
+                .nextCursorJoinedAt(nextJoinedAt)
+                .hasMore(hasMore)
+                .build();
+    }
+
+    private List<ChatParticipant> fetchAndValidate(Long userId, LocalDateTime cursorJoinedAt, Integer limit) {
         // 결과 조회 -> 없으면 빈 리스트 리턴
         Pageable page = PageRequest.of(0,
                 limit + 1,
@@ -38,28 +69,12 @@ public class GetChatRoomList {
             participants = chatParticipantRepository.findParticipantsAfter(userId, cursorJoinedAt, page);
         }
 
-        List<ChatParticipant> pageOf = participants.size() > limit
-                ? participants.subList(0, limit)
-                : participants;
+        return participants;
+    }
 
-        LocalDateTime nextJoinedAt = null;
-        if (!pageOf.isEmpty()) {
-            ChatParticipant last = pageOf.getLast();
-            nextJoinedAt = last.getJoinedAt();
-        }
-
-        boolean hasMore = participants.size() > limit;
-
-         List<ChatRoom> rooms = pageOf.stream()
+    private List<ChatRoom> extractChatRoom(List<ChatParticipant> paginatedParticipants) {
+        return paginatedParticipants.stream()
                 .map(ChatParticipant::getChatRoom)
                 .toList();
-
-        List<ChatRoomResponse> results = chatMessageQueryMapper.toChatRoomList(rooms);
-
-        return ChatRoomPagedResponse.builder()
-                .chatRooms(results)
-                .nextCursorJoinedAt(nextJoinedAt)
-                .hasMore(hasMore)
-                .build();
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/query/GetLatestMessages.java
+++ b/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/query/GetLatestMessages.java
@@ -80,7 +80,6 @@ public class GetLatestMessages {
         return dr;
     }
 
-
     public void notifyNewMessage(
             ChatMessageDocument newMessage,
             String nickname,

--- a/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/query/GetPastMessages.java
+++ b/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/query/GetPastMessages.java
@@ -26,11 +26,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.moogsan.moongsan_backend.global.util.ObjectIdScoreUtil.toScore;
+import static com.moogsan.moongsan_backend.participantchat.domain.constant.ParticipantChatConstants.CASHE_REDIS_KEY;
 
 @Slf4j
 @Service
@@ -52,25 +54,79 @@ public class GetPastMessages {
             String cursorId,
             boolean isPrev
     ) {
-        // 1) 권한 및 방 검증
+        // 유효성 검사
+        fetchAndValidate(chatRoomId, currentUser.getId());
+
+        // Redis 조회 (방향 분기)
+        String redisKey = CASHE_REDIS_KEY + chatRoomId;
+        Set<String> cachedMembers = fetchCachedMessageIds(redisKey, cursorId, isPrev);
+
+        // 캐시 메시지를 ID로 변환
+        List<String> idList = extractId(cachedMembers);
+        if (cursorId != null) idList.removeIf(id -> id.equals(cursorId));
+
+        // 부족한 메시지 MongoDB 조회
+        List<ChatMessageDocument> dbDocs = fetchMongoDB(idList, chatRoomId, cursorId, isPrev, redisKey);
+
+        // 5) ID 병합
+        Stream<ObjectId> fromCache = idList.stream().limit(PAGE_SIZE).map(ObjectId::new);
+        Stream<ObjectId> fromDb = dbDocs.stream().map(doc -> new ObjectId(doc.getId()));
+        List<ObjectId> finalIds = Stream.concat(fromCache, fromDb)
+                .distinct()
+                .limit(PAGE_SIZE)
+                .collect(Collectors.toList());
+
+        // 6) 최종 정렬 및 조회
+        Sort.Direction finalDirection = isPrev ? Sort.Direction.DESC : Sort.Direction.ASC;
+        Query finalQ = new Query(Criteria.where("_id").in(finalIds));
+        finalQ.with(Sort.by(finalDirection, "_id"));
+        List<ChatMessageDocument> finalPage = mongoTemplate.find(finalQ, ChatMessageDocument.class);
+
+        // 6-1) 정방향 응답을 위해 정렬 (오름차순으로 보내기)
+        if (isPrev) {
+            Collections.reverse(finalPage);
+        }
+
+        // 7) hasNext 계산
+        boolean hasNext = finalPage.size() == PAGE_SIZE && (!dbDocs.isEmpty() || cachedMembers.size() > PAGE_SIZE);
+
+        // 8) DTO 변환
+        List<ChatMessageResponse> responses = assemblePageResponse(finalPage);
+
+        // 다음 커서 지정
+        String beforeCursor = null;
+        if (!finalPage.isEmpty()) {
+            beforeCursor = isPrev ? finalPage.getFirst().getId() : finalPage.getLast().getId();
+        }
+
+        return ChatMessagePageResponse.builder()
+                .chatMessageResponses(responses)
+                .beforeCursorId(beforeCursor)
+                .hasBefore(hasNext)
+                .build();
+    }
+
+    private void fetchAndValidate(Long chatRoomId, Long userId) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(ChatRoomNotFoundException::new);
         boolean isParticipant = chatParticipantRepository
-                .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoomId, currentUser.getId());
+                .existsByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), userId);
         if (!isParticipant) throw new NotParticipantException("참여자만 메세지를 조회할 수 있습니다.");
+    }
 
-        String redisKey = "chatting:messages:" + chatRoomId;
+    private Set<String> fetchCachedMessageIds(String redisKey, String cursorId, boolean isPrev) {
         double cursorScore = cursorId != null
                 ? toScore(cursorId)
                 : (isPrev ? Double.MAX_VALUE : Double.MIN_VALUE);
 
-        // 2) Redis 조회 (방향 분기)
-        Set<String> cachedMembers = isPrev
+        // 방향 분기 Redis 조회
+        return isPrev
                 ? redisTemplate.opsForZSet().reverseRangeByScore(redisKey, cursorScore - 1, Double.NEGATIVE_INFINITY, 0, PAGE_SIZE + 1)
                 : redisTemplate.opsForZSet().rangeByScore(redisKey, cursorScore + 1, Double.MAX_VALUE, 0, PAGE_SIZE + 1);
+    }
 
-        // 3) 캐시 메시지를 ID로 변환
-        List<String> idList = cachedMembers.stream()
+    private List<String> extractId(Set<String> cachedMembers) {
+        return cachedMembers.stream()
                 .map(member -> {
                     member = member.trim();
                     if (member.startsWith("{")) {
@@ -87,11 +143,13 @@ public class GetPastMessages {
                 .filter(Objects::nonNull)
                 .filter(ObjectId::isValid)
                 .distinct()
-                .collect(Collectors.toList());
-        if (cursorId != null) idList.removeIf(id -> id.equals(cursorId));
+                .toList();
+    }
 
-        // 4) 부족한 메시지 MongoDB 조회
-        List<ChatMessageDocument> dbDocs = new ArrayList<>();
+    private List<ChatMessageDocument> fetchMongoDB(
+            List<String> idList, Long chatRoomId, String cursorId, boolean isPrev, String redisKey){
+
+        List<ChatMessageDocument> docs = new ArrayList<>();
         if (idList.size() < PAGE_SIZE) {
             int need = PAGE_SIZE - idList.size();
             Query q = new Query(Criteria.where("chatRoomId").is(chatRoomId));
@@ -115,60 +173,25 @@ public class GetPastMessages {
                 }
             });
 
-            dbDocs.addAll(toCache);
+            docs.addAll(toCache);
         }
+        return docs;
+    }
 
-        // 5) ID 병합
-        Stream<ObjectId> fromCache = idList.stream().limit(PAGE_SIZE).map(ObjectId::new);
-        Stream<ObjectId> fromDb = dbDocs.stream().map(doc -> new ObjectId(doc.getId()));
-        List<ObjectId> finalIds = Stream.concat(fromCache, fromDb)
-                .distinct()
-                .limit(PAGE_SIZE)
-                .collect(Collectors.toList());
-
-        // 6) 최종 정렬 및 조회
-        Sort.Direction finalDirection = isPrev ? Sort.Direction.DESC : Sort.Direction.ASC;
-        Query finalQ = new Query(Criteria.where("_id").in(finalIds));
-        finalQ.with(Sort.by(finalDirection, "_id"));
-        List<ChatMessageDocument> finalPage = mongoTemplate.find(finalQ, ChatMessageDocument.class);
-
-        // 6-1) 정방향 응답을 위해 정렬 (오름차순으로 보내기)
-        if (isPrev) {
-            Collections.reverse(finalPage);
-        }
-
-        // 7) hasNext 계산
-        boolean hasNext = finalPage.size() == PAGE_SIZE && (
-                !dbDocs.isEmpty() || cachedMembers.size() > PAGE_SIZE
-        );
-
-        // 8) DTO 변환
+    private List<ChatMessageResponse> assemblePageResponse(List<ChatMessageDocument> finalPage) {
         Set<Long> partIds = finalPage.stream()
                 .map(ChatMessageDocument::getChatParticipantId)
                 .collect(Collectors.toSet());
         Map<Long, ChatParticipant> parts = chatParticipantRepository.findAllById(partIds)
                 .stream().collect(Collectors.toMap(ChatParticipant::getId, p -> p));
-        List<ChatMessageResponse> responses = finalPage.stream().map(doc -> {
+
+        return finalPage.stream().map(doc -> {
             ChatParticipant p = parts.get(doc.getChatParticipantId());
             return chatMessageQueryMapper.toMessageResponse(
                     doc,
                     Optional.ofNullable(p).map(part -> part.getUser().getNickname()).orElse("Unknown"),
                     Optional.ofNullable(p).map(part -> part.getUser().getImageKey()).orElse(null)
             );
-        }).collect(Collectors.toList());
-
-        String beforeCursor = null;
-
-        if (!finalPage.isEmpty()) {
-            beforeCursor = isPrev
-                    ? finalPage.getFirst().getId()
-                    : finalPage.getLast().getId();
-        }
-
-        return ChatMessagePageResponse.builder()
-                .chatMessageResponses(responses)
-                .beforeCursorId(beforeCursor)
-                .hasBefore(hasNext)
-                .build();
+        }).toList();
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/websocket/GetLatestMessagesStomp.java
+++ b/src/main/java/com/moogsan/moongsan_backend/participantchat/application/service/websocket/GetLatestMessagesStomp.java
@@ -58,8 +58,12 @@ public class GetLatestMessagesStomp {
 
         try {
             String payload = objectMapper.writeValueAsString(response);
-            messagingTemplate.convertAndSend("/sub/chat-participant/" + chatRoomId, payload);
-            log.info("[WS] push to /sub/chat-participant/{}", chatRoomId);
+            Runnable broadcastTask = () -> {
+                messagingTemplate.convertAndSend("/sub/chat-participant/" + chatRoomId, payload);
+                log.info("[WS] push to /sub/chat-participant/{}", chatRoomId);
+            };
+
+            Thread.startVirtualThread(broadcastTask);
         } catch (
         JsonProcessingException e) {
             throw new RuntimeException(SERIALIZATION_FAIL, e);

--- a/src/main/java/com/moogsan/moongsan_backend/participantchat/domain/constant/ParticipantChatConstants.java
+++ b/src/main/java/com/moogsan/moongsan_backend/participantchat/domain/constant/ParticipantChatConstants.java
@@ -1,0 +1,7 @@
+package com.moogsan.moongsan_backend.participantchat.domain.constant;
+
+public class ParticipantChatConstants {
+    private ParticipantChatConstants() {}
+
+    public static final String CASHE_REDIS_KET = "chatting:messages:";
+}

--- a/src/main/java/com/moogsan/moongsan_backend/participantchat/domain/constant/ParticipantChatConstants.java
+++ b/src/main/java/com/moogsan/moongsan_backend/participantchat/domain/constant/ParticipantChatConstants.java
@@ -3,5 +3,5 @@ package com.moogsan.moongsan_backend.participantchat.domain.constant;
 public class ParticipantChatConstants {
     private ParticipantChatConstants() {}
 
-    public static final String CASHE_REDIS_KET = "chatting:messages:";
+    public static final String CASHE_REDIS_KEY = "chatting:messages:";
 }

--- a/src/main/java/com/moogsan/moongsan_backend/participantchat/domain/service/ParticipantChatEventService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/participantchat/domain/service/ParticipantChatEventService.java
@@ -1,0 +1,40 @@
+package com.moogsan.moongsan_backend.participantchat.domain.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moogsan.moongsan_backend.global.infrastructure.kafka.publisher.KafkaEventPublisher;
+import com.moogsan.moongsan_backend.groupbuy.domain.entity.GroupBuy;
+import com.moogsan.moongsan_backend.participantchat.domain.entity.ChatMessageDocument;
+import com.moogsan.moongsan_backend.participantchat.domain.entity.ChatRoom;
+import com.moogsan.moongsan_backend.participantchat.domain.event.ChatMessagePersistEvent;
+import com.moogsan.moongsan_backend.participantchat.domain.mapper.ChatEventMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.moogsan.moongsan_backend.global.infrastructure.kafka.KafkaTopics.CHAT_PART_MESSAGE_CREATED;
+import static com.moogsan.moongsan_backend.global.message.ResponseMessage.SERIALIZATION_FAIL;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ParticipantChatEventService {
+
+    private final KafkaEventPublisher kafkaEventPublisher;
+    private final ChatEventMapper eventMapper;
+    private final ObjectMapper objectMapper;
+
+    public void publishChatPersist(ChatRoom chatRoom, ChatMessageDocument document) {
+        try {
+            ChatMessagePersistEvent eventDto =
+                    eventMapper.toChatMessagePersistEvent(chatRoom.getId(), document.getId());
+            String payload = objectMapper.writeValueAsString(eventDto);
+            kafkaEventPublisher.publish(CHAT_PART_MESSAGE_CREATED, String.valueOf(document.getId()), payload);
+        } catch (JsonProcessingException e) {
+            log.error("❌ Failed to serialize ChatMessagePersistEvent: documentId={}", document.getId(), e);
+            throw new RuntimeException(SERIALIZATION_FAIL, e);
+        }
+    }
+}

--- a/src/test/java/com/moogsan/moongsan_backend/unit/chatting/participant/service/command/CreateChatMessageTest.java
+++ b/src/test/java/com/moogsan/moongsan_backend/unit/chatting/participant/service/command/CreateChatMessageTest.java
@@ -2,8 +2,6 @@ package com.moogsan.moongsan_backend.unit.chatting.participant.service.command;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.moogsan.moongsan_backend.participantchat.domain.mapper.ChatEventMapper;
-import com.moogsan.moongsan_backend.global.infrastructure.kafka.publisher.KafkaEventPublisher;
 import com.moogsan.moongsan_backend.participantchat.presentation.dto.command.request.CreateChatMessageRequest;
 import com.moogsan.moongsan_backend.participantchat.domain.entity.ChatMessageDocument;
 import com.moogsan.moongsan_backend.participantchat.domain.entity.ChatParticipant;
@@ -42,44 +40,18 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class CreateChatMessageTest {
 
-    @Mock
-    private ChatRoomRepository chatRoomRepository;
-
-    @Mock
-    private ChatParticipantRepository chatParticipantRepository;
-
-    @Mock
-    private ChatMessageRepository chatMessageRepository;
-
-    @Mock
-    private MessageSequenceGenerator messageSequenceGenerator;
-
-    @Mock
-    private ChatMessageCommandMapper chatMessageCommandMapper;
-
-    @Mock
-    private GetLatestMessages getLatestMessages;
-
-    @Mock
-    private GetLatestMessageSse getLatestMessageSse;
-
-    @Mock
-    private RedisTemplate<String, String> redisTemplate;
-
-    @Mock
-    private GetLatestMessagesStomp getLatestMessagesStomp;
-
-    @Mock
-    private KafkaEventPublisher kafkaEventPublisher;
-
-    @Mock
-    private ChatEventMapper eventMapper;
-
-    @Mock
-    private ObjectMapper objectMapper;
-
-    @Mock
-    private ZSetOperations<String, String> zSetOperations;
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private ChatParticipantRepository chatParticipantRepository;
+    @Mock private ChatMessageRepository chatMessageRepository;
+    @Mock private MessageSequenceGenerator messageSequenceGenerator;
+    @Mock private ChatMessageCommandMapper chatMessageCommandMapper;
+    @Mock private GetLatestMessages getLatestMessages;
+    @Mock private GetLatestMessageSse getLatestMessageSse;
+    @Mock private GetLatestMessagesStomp getLatestMessagesStomp;
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private ObjectMapper objectMapper;
+    @Mock private Clock clock;
+    @Mock private ZSetOperations<String, String> zSetOperations;
 
     private CreateChatMessage createChatMessage;
     private ChatRoom chatRoom;
@@ -119,8 +91,6 @@ public class CreateChatMessageTest {
                 getLatestMessageSse,
                 getLatestMessagesStomp,
                 redisTemplate,
-                kafkaEventPublisher,
-                eventMapper,
                 objectMapper,
                 fixedClock
         );
@@ -130,7 +100,7 @@ public class CreateChatMessageTest {
     @DisplayName("참여자 채팅방 메세지 작성 성공")
     void createChatMessage_success() throws JsonProcessingException{
         when(chatRoomRepository.findById(20L)).thenReturn(Optional.of(chatRoom));
-        when(chatParticipantRepository.findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId()))
+        when(chatParticipantRepository.findByChatRoom_IdAndUser_IdAndLeftAtIsNull(participantUser.getId(), chatRoom.getId()))
                 .thenReturn(Optional.ofNullable(chatParticipant));
         when(messageSequenceGenerator.getNextMessageSeq(chatRoom.getId())).thenReturn(2L);
         when(chatMessageCommandMapper.toMessageDocument(chatRoom, chatParticipant.getId(), request, 2L))
@@ -145,7 +115,7 @@ public class CreateChatMessageTest {
 
         verify(chatRoomRepository, times(1)).findById(20L);
         verify(chatParticipantRepository, times(1))
-                .findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+                .findByChatRoom_IdAndUser_IdAndLeftAtIsNull(participantUser.getId(), chatRoom.getId());
         verify(messageSequenceGenerator, times(1)).getNextMessageSeq(chatRoom.getId());
         verify(chatMessageCommandMapper, times(1)).toMessageDocument(chatRoom, chatParticipant.getId(), request, 2L);
         verify(redisTemplate.opsForZSet(), times(1)).add(anyString(), anyString(), anyDouble());
@@ -189,7 +159,7 @@ public class CreateChatMessageTest {
     @DisplayName("참여자 채팅방 메세지 작성 실패 - 참여자가 아님")
     void createChatMessage_fail_not_participant() {
         when(chatRoomRepository.findById(20L)).thenReturn(Optional.of(chatRoom));
-        when(chatParticipantRepository.findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId()))
+        when(chatParticipantRepository.findByChatRoom_IdAndUser_IdAndLeftAtIsNull(participantUser.getId(), chatRoom.getId()))
                 .thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> createChatMessage.createChatMessage(participantUser, request, 20L))
@@ -198,7 +168,7 @@ public class CreateChatMessageTest {
 
         verify(chatRoomRepository, times(1)).findById(20L);
         verify(chatParticipantRepository, times(1))
-                .findByChatRoom_IdAndUser_IdAndLeftAtIsNull(chatRoom.getId(), participantUser.getId());
+                .findByChatRoom_IdAndUser_IdAndLeftAtIsNull(participantUser.getId(), chatRoom.getId());
         verify(messageSequenceGenerator, never()).getNextMessageSeq(chatRoom.getId());
         verify(chatMessageCommandMapper, never()).toMessageDocument(chatRoom, chatParticipant.getId(), request, 2L);
     }


### PR DESCRIPTION
## 🔎 작업 개요
- `participantchat` 모듈의 핵심 서비스(`CreateChatMessage`, `JoinChatRoom`, `GetChatRoomList`, `GetPastMessages`, `GetLatestMessages`) 로직을 단계별 private 메서드로 분리  
- Kafka/SSE 알림 발행을 전담하는 `ParticipantChatEventService` 도입  
- 더 이상 사용되지 않는 `notification` 코드 삭제 및 관련 컨트롤러 파라미터 정리  
- Redis 키를 `ParticipantChatConstants.CACHE_REDIS_KEY`로 상수화

## 🛠️ 주요 변경 사항
1. **CreateChatMessageService**  
   - 채팅방 조회/검증 → `fetchAndValidate()`  
   - 참여자 검증 → `validateParticipant()`  
   - 메시지 생성→저장, Redis 캐시 → `cacheMessage()`  
   - Socket/SSE 발행 호출부 정리 → `getLatestMessagesStomp`, `ParticipantChatEventService.publishChatPersist()` 위임  

2. **JoinChatRoomService**  
   - 게시글/방 조회 검증 → `fetchAndValidate()`  
   - 실제 채팅방 조회·생성 → `fetchChatRoom()`  
   - 참여자 등록 → `enrollParticipant()`  

3. **GetChatRoomListService**  
   - 커서 기반 페이징 → `fetchAndValidate()`, `paginatedParticipants` 변수명 변경  
   - DTO 매핑 흐름 정리  

4. **GetPastMessagesService**  
   - 단계별 로직 메서드명 개선:  
     - `fetchAndValidate()`  
     - `fetchCachedMessageIds()`  
     - `extractValidIds()`  
     - `fetchMissingMessagesFromDb()`  
     - ID 병합·정렬 → `mergeAndLimitIds()`  
     - 응답 조립 → `assemblePageResponse()`  

5. **GetLatestMessagesService**  
   - 오래된 호출 주석 제거, 메서드 시그니처 정비  

6. **notification 정리**  
   - `NotificationMarkAsRead.execute()` 시그니처 변경 (userId 제거)  
   - `NotificationCommandController` 호출부 수정  
   - 불필요한 notification 클래스 및 의존성 삭제

## ✅ 검증 방법
- 기능별 API 시나리오 테스트 (단위·통합) 모두 성공  
  1. 메시지 작성 → 저장·캐시·알림 정상  
  2. 채팅방 참가/퇴장 → DB·캐시 반영  
  3. 채팅방 리스트 조회 → 페이징/필터 정상  
  4. 과거 메시지 조회 → 커서 이동 및 페이지네이션 정상  
  5. 알림 관련 API 호출 시 에러 없음  

## 🔍 머지 전 확인 사항
- 단계별 private 메서드 분리로 흐름이 명확해졌는지  
- `ParticipantChatEventService` 가 이벤트 발행을 전담하는지  
- 삭제된 notification 코드가 더 이상 호출되지 않는지  
- Redis 키 상수(`CACHE_REDIS_KEY`)가 일관되게 사용되는지  
- 모든 테스트를 통과하는지