### PR TITLE
fix(users): cookieSecure 환경변수 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     environment:
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/config/
       SPRING_PROFILES_ACTIVE: docker
+      CUSTOM_COOKIE_SECURE: "false"
 
   # ------- Zookeeper 3대 -------
   zookeeper-1:

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/KakaoOAuthService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/KakaoOAuthService.java
@@ -1,4 +1,5 @@
 package com.moogsan.moongsan_backend.domain.user.service;
+import org.springframework.beans.factory.annotation.Value;
 
 import com.moogsan.moongsan_backend.domain.user.exception.base.UserException;
 import com.moogsan.moongsan_backend.domain.user.exception.code.UserErrorCode;
@@ -35,6 +36,9 @@ public class KakaoOAuthService {
     private final OAuthRepository oauthRepository;
     private final JwtUtil jwtUtil;
     private final TokenRepository refreshTokenRepository;
+
+    @Value("${custom.cookie.secure:true}")
+    private boolean cookieSecure;
 
     @Transactional
     public Object kakaoLogin(String code, String redirectUri, HttpServletResponse response) {
@@ -104,7 +108,7 @@ public class KakaoOAuthService {
         // 엑세스 토큰 설정 (ResponseCookie 사용)
         ResponseCookie accessTokenCookie = ResponseCookie.from("AccessToken", accessToken)
                 .httpOnly(true)
-                .secure(true)
+                .secure(cookieSecure)
                 .path("/")
                 .sameSite("None")
                 .maxAge(Duration.ofMillis(accessTokenExpireAt))
@@ -114,7 +118,7 @@ public class KakaoOAuthService {
         // 리프레시 토큰 설정 (ResponseCookie 사용)
         ResponseCookie refreshTokenCookie = ResponseCookie.from("RefreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(true)
+                .secure(cookieSecure)
                 .path("/")
                 .sameSite("None")
                 .maxAge(Duration.ofMillis(refreshTokenExpireMillis))

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/LoginService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/LoginService.java
@@ -17,6 +17,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.beans.factory.annotation.Value;
+
 import java.time.Duration;
 import java.time.LocalDateTime;
 
@@ -28,6 +30,9 @@ public class LoginService {
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final TokenRepository refreshTokenRepository;
+
+    @Value("${custom.cookie.secure:true}")
+    private boolean cookieSecure;
 
     @Transactional
     public LoginResponse login(LoginRequest request, HttpServletResponse response) {
@@ -80,7 +85,7 @@ public class LoginService {
             // 엑세스 토큰 설정 (ResponseCookie 사용)
             ResponseCookie accessTokenCookie = ResponseCookie.from("AccessToken", accessToken)
                     .httpOnly(true)
-                    .secure(true)
+                    .secure(cookieSecure)
                     .path("/")
                     .sameSite("None")
                     .maxAge(Duration.ofMillis(accessTokenExpireAt))
@@ -90,7 +95,7 @@ public class LoginService {
             // 리프레시 토큰 설정 (ResponseCookie 사용)
             ResponseCookie refreshTokenCookie = ResponseCookie.from("RefreshToken", refreshToken)
                     .httpOnly(true)
-                    .secure(true)
+                    .secure(cookieSecure)
                     .path("/")
                     .sameSite("None")
                     .maxAge(Duration.ofMillis(refreshTokenExpireMillis))

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/LogoutService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/LogoutService.java
@@ -12,12 +12,16 @@ import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class LogoutService {
+
+    @Value("${custom.cookie.secure:true}")
+    private boolean cookieSecure;
 
     private final UserRepository userRepository;
     private final TokenRepository refreshTokenRepository;
@@ -38,7 +42,7 @@ public class LogoutService {
             // 엑세스 토큰 삭제 (ResponseCookie 사용)
             ResponseCookie accessTokenCookie = ResponseCookie.from("AccessToken", "")
                     .httpOnly(true)
-                    .secure(true)
+                    .secure(cookieSecure)
                     .path("/")
                     .maxAge(Duration.ZERO)
                     .sameSite("None")
@@ -48,7 +52,7 @@ public class LogoutService {
             // 리프레시 토큰 삭제 (ResponseCookie 사용)
             ResponseCookie refreshTokenCookie = ResponseCookie.from("RefreshToken", "")
                     .httpOnly(true)
-                    .secure(true)
+                    .secure(cookieSecure)
                     .path("/")
                     .maxAge(Duration.ZERO)
                     .sameSite("None")

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/SignUpService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/SignUpService.java
@@ -20,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
+import org.springframework.beans.factory.annotation.Value;
+
 @Service
 @RequiredArgsConstructor
 public class SignUpService {
@@ -28,6 +30,9 @@ public class SignUpService {
     private final TokenRepository tokenRepository;
     private final PasswordEncoder passwordEncoder; // 비밀번호 암호화기
     private final JwtUtil jwtUtil;
+
+    @Value("${custom.cookie.secure:true}")
+    private boolean cookieSecure;
 
     @Transactional
     public LoginResponse signUp(SignUpRequest request, HttpServletResponse response) {
@@ -59,7 +64,7 @@ public class SignUpService {
             // 액세스 토큰 설정 (ResponseCookie 사용)
             ResponseCookie accessTokenCookie = ResponseCookie.from("AccessToken", accessToken)
                     .httpOnly(true)
-                    .secure(true)
+                    .secure(cookieSecure)
                     .path("/")
                     .sameSite("None")
                     .maxAge(Duration.ofMillis(accessTokenExpireAt))
@@ -69,7 +74,7 @@ public class SignUpService {
             // 리프레시 토큰 설정 (ResponseCookie 사용)
             ResponseCookie refreshTokenCookie = ResponseCookie.from("RefreshToken", refreshToken)
                     .httpOnly(true)
-                    .secure(true)
+                    .secure(cookieSecure)
                     .path("/")
                     .sameSite("None")
                     .maxAge(Duration.ofMillis(jwtUtil.getRefreshTokenExpireMillis()))

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/TokenRefreshService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/TokenRefreshService.java
@@ -15,10 +15,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
 
 @Service
 @RequiredArgsConstructor
 public class TokenRefreshService {
+
+    @Value("${custom.cookie.secure:true}")
+    private boolean cookieSecure;
 
     private final JwtUtil jwtUtil;
     private final TokenRepository tokenRepository;
@@ -52,7 +56,7 @@ public class TokenRefreshService {
         // 쿠키에 새 AccessToken 설정 (ResponseCookie 사용)
         ResponseCookie accessTokenCookie = ResponseCookie.from("AccessToken", newAccessToken)
                 .httpOnly(true)
-                .secure(true)
+                .secure(cookieSecure)
                 .path("/")
                 .sameSite("None")
                 .maxAge(Duration.ofMillis(accessTokenExpireAt))

--- a/src/main/java/com/moogsan/moongsan_backend/domain/user/service/WithdrawService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/domain/user/service/WithdrawService.java
@@ -15,10 +15,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import java.time.Duration;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 
 @Service
 @RequiredArgsConstructor
 public class WithdrawService {
+
+    @Value("${custom.cookie.secure:true}")
+    private boolean cookieSecure;
 
     private final UserRepository userRepository;
     private final TokenRepository tokenRepository;
@@ -45,7 +49,7 @@ public class WithdrawService {
         // 액세스 토큰 삭제 (ResponseCookie 사용)
         ResponseCookie accessTokenCookie = ResponseCookie.from("AccessToken", "")
                 .httpOnly(true)
-                .secure(true)
+                .secure(cookieSecure)
                 .path("/")
                 .maxAge(Duration.ZERO)
                 .sameSite("None")
@@ -55,7 +59,7 @@ public class WithdrawService {
         // 리프레시 토큰 삭제 (ResponseCookie 사용)
         ResponseCookie refreshTokenCookie = ResponseCookie.from("RefreshToken", "")
                 .httpOnly(true)
-                .secure(true)
+                .secure(cookieSecure)
                 .path("/")
                 .maxAge(Duration.ZERO)
                 .sameSite("None")

--- a/src/main/java/com/moogsan/moongsan_backend/global/config/WebSocketConfig.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/config/WebSocketConfig.java
@@ -1,6 +1,5 @@
 package com.moogsan.moongsan_backend.global.config;
 
-import com.moogsan.moongsan_backend.global.security.jwt.JwtHandshakeInterceptor;
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -13,9 +12,6 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
-import org.springframework.context.event.EventListener;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
-import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 import lombok.extern.slf4j.Slf4j;
 
 @Configuration
@@ -52,23 +48,5 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 return message;
             }
         });
-    }
-
-    @Override
-    public void configureClientOutboundChannel(ChannelRegistration registration) {
-        registration.interceptors(new ChannelInterceptor() {
-            @Override
-            public void postSend(Message<?> message, MessageChannel channel, boolean sent) {
-                System.out.println("📤 [Broker] 클라이언트로 전송된 메시지: " + message);
-            }
-        });
-    }
-
-    @EventListener
-    public void handleSubscribe(SessionSubscribeEvent event) {
-        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
-        String sessionId = accessor.getSessionId();
-        String destination = accessor.getDestination();
-        log.info("📡 WebSocket 구독됨: sessionId={}, destination={}", sessionId, destination);
     }
 }


### PR DESCRIPTION
## fix(users): cookieSecure 환경변수 추가

## 🔎 작업 개요
프론트 요청으로 인한 쿠키 secure설정을 환경변수로 false로 대체할 수 있도록 수정

## 🛠️ 주요 변경 사항
- 기존 쿠키 설정의 .secure()부분을 환경변수로 대체, 기본값은 true
- docker-compose 내 CUSTOM_COOKIE_SECURE: "false"를 추가시 false로 변경

## ✅ 검증 방법
- 도커 실행 확인 완료

## 🔍 머지 전 확인사항  
- [ ] 테스트 통과 여부

## ➕ 이슈 링크
