### PR TITLE
fix(group-buy) & feat(sse): 주문 조회 status 기준 수정 및 만료된 heartbeat emitter 제거 로직 추가

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/global/infrastructure/sse/SseEmitterService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/infrastructure/sse/SseEmitterService.java
@@ -55,6 +55,7 @@ public class SseEmitterService {
                 emitter.send(SseEmitter.event().name(eventName).data(data));
             } catch (Exception ex) {
                 log.warn("⚠️ SSE send 실패, 제거 → key={}, emitter={}", key, emitter, ex);
+                remove(key, emitter);
                 emitter.completeWithError(ex);
             }
         }
@@ -69,6 +70,7 @@ public class SseEmitterService {
                 emitter.send(data);
             } catch (Exception ex) {
                 log.warn("⚠️ SSE send 실패, 제거 → key={}, emitter={}", key, emitter, ex);
+                remove(key, emitter);
                 emitter.completeWithError(ex);
             }
         }

--- a/src/main/java/com/moogsan/moongsan_backend/global/infrastructure/sse/SseEmitterService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/infrastructure/sse/SseEmitterService.java
@@ -85,7 +85,9 @@ public class SseEmitterService {
             try {
                 emitter.send(SseEmitter.event().name("heartbeat").data("ping"));
             } catch (Exception e) {
-                emitter.completeWithError(e);
+                emitter.complete();
+                remove(key, emitter);
+                log.debug("💀 heartbeat용 emitter 제거 → key={}, emitter={}", key, emitter);
             }
         }));
     }

--- a/src/main/java/com/moogsan/moongsan_backend/groupbuy/application/service/query/GetGroupBuyHostAccountInfo.java
+++ b/src/main/java/com/moogsan/moongsan_backend/groupbuy/application/service/query/GetGroupBuyHostAccountInfo.java
@@ -13,6 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @Transactional(readOnly=true)
@@ -34,8 +36,11 @@ public class GetGroupBuyHostAccountInfo {
         }
 
         // 해당 공구의 주문 테이블에 해당 유저의 주문이 존재하는지 조회 -> 아니면 404
-        Order order = orderRepository.findByUserIdAndGroupBuyIdAndStatusNot(userId, groupBuy.getId(), "CANCELED")
-                .orElseThrow(GroupBuyNotParticipantException::new);
+        boolean exists = orderRepository.existsByUserIdAndGroupBuyIdAndStatusIn(userId, postId, List.of("PENDING", "CONFIRMED"));
+
+        if (!exists) {
+            throw new GroupBuyNotParticipantException();
+        }
 
         return groupBuyQueryMapper.toHostAccount(groupBuy);
     }


### PR DESCRIPTION
## 🔎 작업 개요
- **주문 조회 개선**  
  `group-buy` 관련 API에서 주문 테이블을 `PENDING`, `CONFIRMED` 상태만 조회하도록 수정  
- **만료된 SSE emitter 제거**  
  `SseEmitterService#heartbeat` 스케줄러에서 send 실패 또는 타임아웃된 emitter를 자동으로 제거하는 로직 추가  

## 🛠️ 주요 변경 사항
- **fix(group-buy)**  
  - 주최자 정보 조회용 주문 조회 쿼리에 `WHERE status IN ('PENDING','CONFIRMED')` 조건 추가 (commit `0b6bbdd`)
- **feat(sse)**  
  - `heartbeat()` 내에서 `.send()` 예외 발생 시 해당 emitter를 `remove(key, emitter)` 하는 로직 추가 (commit `6ed20f0`)

## ✅ 검증 방법
1. **주문 조회 API**  
   - 특정 공동구매 조회 시 반환된 주문 리스트에 `PENDING` 또는 `CONFIRMED` 상태만 포함되는지 확인  
   - 그 외 상태(`CANCELED`, `COMPLETED` 등) 주문은 제외되는지 검증  
2. **SSE heartbeat 동작**  
   - 클라이언트가 SSE 구독 후 일정 시간(heartbeat 간격) 대기  
   - 정상 연결된 emitter에는 `heartbeat` 이벤트가 전송되는지 확인  
   - 의도적으로 타임아웃되거나 에러를 발생시킨 emitter가 로그(`만료된 emitter 제거`)와 함께 제거되는지 확인  

## 🔍 머지 전 확인사항
- [ ] 주문 조회 쿼리 변경으로 인한 다른 API 영향 범위 검토  
- [ ] heartbeat 간격(`sse.heartbeat-interval-ms`) 설정이 적절한지 재확인  
- [ ] emitter 제거 시 클라이언트 측 이벤트 스트림 연결 종료 처리 상태 확인  
