### PR TITLE
fix(notification): SSE 키 prefix 상수화 및 add/send 키 일치 보장

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/global/infrastructure/kafka/publisher/NotificationPublisher.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/infrastructure/kafka/publisher/NotificationPublisher.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDateTime;
 import java.util.Map;
 
+import static com.moogsan.moongsan_backend.notification.domain.constant.NotificationConstants.NOTI_SSE_PREFIX;
+
 @Component
 @RequiredArgsConstructor
 public class NotificationPublisher {
@@ -57,7 +59,7 @@ public class NotificationPublisher {
 
             // 3) SSE 전송
             emitterRepository.send(
-                    userId.toString(),
+                    NOTI_SSE_PREFIX + userId,
                     entity.getNotificationType().name(),
                     dto
             );

--- a/src/main/java/com/moogsan/moongsan_backend/global/infrastructure/sse/SseEmitterService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/infrastructure/sse/SseEmitterService.java
@@ -24,15 +24,27 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SseEmitterService {
 
     private final Map<String, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+    private static final long DEFAULT_TIMEOUT = 1000_000L; // 45초
 
     /** 신규 연결 등록 */
     public SseEmitter add(String key) {
-        SseEmitter emitter = new SseEmitter(0L);
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
         emitters
                 .computeIfAbsent(key, k -> Collections.synchronizedList(new ArrayList<>()))
                 .add(emitter);
+
+        // 콜백 등록
         emitter.onCompletion(() -> remove(key, emitter));
-        emitter.onTimeout   (() -> { emitter.complete(); remove(key, emitter); });
+        emitter.onTimeout(() -> {
+            log.debug("⏱ SSE timeout, remove emitter → key={}, emitter={}", key, emitter);
+            emitter.complete();
+            remove(key, emitter);
+        });
+        emitter.onError(e -> {
+            log.debug("⚠️ SSE error, remove emitter → key={}, emitter={}", key, emitter, e);
+            emitter.completeWithError(e);
+            remove(key, emitter);
+        });
 
         try {
             log.debug("➕ SSE 구독 등록 → key={}, totalEmitters={}", key, emitters.get(key).size());
@@ -40,6 +52,7 @@ public class SseEmitterService {
                     .name("connect")
                     .data("SSE 연결 성공"));
         } catch (IOException e) {
+            log.warn("Failed to send connect event, remove emitter → key={}, emitter={}", key, emitter, e);
             remove(key, emitter);
         }
 
@@ -49,48 +62,48 @@ public class SseEmitterService {
     /** 대상 키에 연결된 모든 emitter 에 이벤트 전송 */
     public <T> void send(String key, String eventName, T data) {
         List<SseEmitter> list = emitters.getOrDefault(key, Collections.emptyList());
+        log.debug("📡 SSE Broadcast 시작 → key={}, emitters={}", key, list.size());
         for (SseEmitter emitter : list) {
             try {
-                log.debug("📡 SSE Broadcast 준비 → key={}, emitters={}", key, list.size());
-                emitter.send(SseEmitter.event().name(eventName).data(data));
-            } catch (Exception ex) {
+                emitter.send(SseEmitter.event()
+                        .name(eventName)
+                        .data(data));
+                log.debug("✅ SSE send 성공 → key={}, emitter={}", key, emitter);
+            } catch (IOException | IllegalStateException ex) {
                 log.warn("⚠️ SSE send 실패, 제거 → key={}, emitter={}", key, emitter, ex);
                 remove(key, emitter);
-                emitter.completeWithError(ex);
             }
         }
     }
 
     public <T> void send(String key, T data) {
-        List<SseEmitter> list = emitters.getOrDefault(key, Collections.emptyList());
-        for (SseEmitter emitter : list) {
-            try {
-                // event 이름 없이 data 만 전송
-                log.debug("📡 SSE Broadcast 준비 → key={}, emitters={}", key, list.size());
-                emitter.send(data);
-            } catch (Exception ex) {
-                log.warn("⚠️ SSE send 실패, 제거 → key={}, emitter={}", key, emitter, ex);
-                remove(key, emitter);
-                emitter.completeWithError(ex);
-            }
-        }
+        send(key, null, data);
     }
 
     private void remove(String key, SseEmitter emitter) {
         List<SseEmitter> list = emitters.get(key);
         if (list != null) list.remove(emitter);
+        log.debug("➖ SSE emitter removed → key={}, remaining={}", key, list != null ? list.size() : 0);
     }
 
+    /**
+     * 15초마다 heartbeat 전송
+     */
     @Scheduled(fixedRateString = "${sse.heartbeat-interval-ms:15000}")
     public void heartbeat() {
-        emitters.forEach((key, list) -> list.forEach(emitter -> {
-            try {
-                emitter.send(SseEmitter.event().name("heartbeat").data("ping"));
-            } catch (Exception e) {
-                emitter.complete();
-                remove(key, emitter);
-                log.debug("💀 heartbeat용 emitter 제거 → key={}, emitter={}", key, emitter);
+        emitters.forEach((key, list) -> {
+            for (SseEmitter emitter : new ArrayList<>(list)) {
+                try {
+                    emitter.send(SseEmitter.event()
+                            .name("heartbeat")
+                            .comment("ping"));
+                    log.debug("💓 SSE heartbeat sent → key={}, emitter={}", key, emitter);
+                } catch (IOException | IllegalStateException e) {
+                    log.debug("💀 heartbeat용 emitter 제거 → key={}, emitter={}", key, emitter);
+                    emitter.complete();
+                    remove(key, emitter);
+                }
             }
-        }));
+        });
     }
 }

--- a/src/main/java/com/moogsan/moongsan_backend/notification/domain/constant/NotificationConstants.java
+++ b/src/main/java/com/moogsan/moongsan_backend/notification/domain/constant/NotificationConstants.java
@@ -1,0 +1,7 @@
+package com.moogsan.moongsan_backend.notification.domain.constant;
+
+public final class NotificationConstants {
+    private NotificationConstants() {}
+
+    public static final String NOTI_SSE_PREFIX = "notification:";
+}

--- a/src/main/java/com/moogsan/moongsan_backend/notification/presentation/controller/NotificationSseController.java
+++ b/src/main/java/com/moogsan/moongsan_backend/notification/presentation/controller/NotificationSseController.java
@@ -8,6 +8,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import static com.moogsan.moongsan_backend.notification.domain.constant.NotificationConstants.NOTI_SSE_PREFIX;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notifications")
@@ -19,7 +21,7 @@ public class NotificationSseController {
     public SseEmitter subscribe(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        String key = "notification:" + userDetails.getUser().getId();
+        String key = NOTI_SSE_PREFIX + userDetails.getUser().getId();
         return sseEmitterService.add(String.valueOf(key));
     }
 


### PR DESCRIPTION
## 🔎 작업 개요
- `NotificationConstants.NOTI_SSE_PREFIX` 상수 도입으로 SSE key prefix를 중앙화  
- `SseEmitterService.add()` 와 `send()` 호출 시 동일한 키(`notification:{userId}`)를 사용하도록 수정하여 key mismatch 문제 해결  

## 🛠️ 주요 변경 사항
- `NotificationConstants`에 `NOTI_SSE_PREFIX = "notification:"` 상수 추가 (commit `20f7f31`)  
- `NotificationPublisher.publish()`에서  
  - 잘못 사용되던 `NOTI_SSE_PREFIX + entity.getId()` → `NOTI_SSE_PREFIX + userId`로 수정  
  - 불필요하게 호출하던 `userId()` 메서드 참조 제거, 파라미터 변수 `userId` 직접 사용  
- 기존 하드코딩된 key 문자열들을 모두 상수로 교체  

## ✅ 검증 방법
1. **SSE 구독**  
   - 클라이언트에서 `/api/notifications/sse` 호출 후  
   - 로그에 `➕ SSE 구독 등록 → key=notification:{userId}, totalEmitters=1` 확인  
2. **알림 발행**  
   - Notification 발행 API 호출 시  
   - 로그에 `📡 SSE Broadcast 시작 → key=notification:{userId}, emitters=1` 및  
     `✅ SSE send 성공 → key=notification:{userId}` 출력 확인  
3. **클라이언트 수신**  
   - 브라우저 또는 `curl -N` 로 `event:<NOTIFICATION_TYPE>` 이벤트가 정상적으로 전달되는지 검증  

## 🔍 머지 전 확인사항
- [ ] `NOTI_SSE_PREFIX` 값(`"notification:"`)이 서비스 전반에서 일관되게 사용되는지  
- [ ] `publish()` 호출부 외 다른 곳에서 key를 하드코딩하지 않았는지 스캔  
- [ ] 기존 Kafka 발행—리스너—SSE 로직에 영향 없이 정상 동작하는지   
