### PR TITLE
feat(sse): 하트비트를 표준 SSE 메시지로 변경

### DIFF
--- a/src/main/java/com/moogsan/moongsan_backend/global/infrastructure/sse/SseEmitterService.java
+++ b/src/main/java/com/moogsan/moongsan_backend/global/infrastructure/sse/SseEmitterService.java
@@ -96,7 +96,7 @@ public class SseEmitterService {
                 try {
                     emitter.send(SseEmitter.event()
                             .name("heartbeat")
-                            .comment("ping"));
+                            .data("{\"type\":\"HEARTBEAT\"}"));
                     log.debug("💓 SSE heartbeat sent → key={}, emitter={}", key, emitter);
                 } catch (IOException | IllegalStateException e) {
                     log.debug("💀 heartbeat용 emitter 제거 → key={}, emitter={}", key, emitter);


### PR DESCRIPTION
## 🔎 작업 개요
- 기존 `comment("ping")` 방식의 하트비트를 `event: heartbeat` + `data: {"type":"HEARTBEAT"}` 형태의 표준 SSE 메시지로 변경

## 🛠️ 주요 변경 사항
- `SseEmitterService.heartbeat()`에서 SSE 이벤트 이름과 데이터 payload를 함께 전송하도록 수정
- Polyfill 및 클라이언트 라이브러리에서 연결 재시도 없이 안정적으로 유지되도록 보장

## ✅ 검증 방법
- DevTools Network 탭에서 `event: heartbeat` 와 `data: {"type":"HEARTBEAT"}` 수신 여부 확인
- Polyfill 사용 환경에서 자동 재연결 시도가 발생하지 않는지 확인
